### PR TITLE
Minor fixes for stability in the preview pipeline.

### DIFF
--- a/banzai/main.py
+++ b/banzai/main.py
@@ -12,6 +12,8 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import argparse
 import multiprocessing
 import os
+import traceback
+import sys
 
 from kombu import Connection, Queue, Exchange
 from kombu.mixins import ConsumerMixin
@@ -395,6 +397,11 @@ class PreviewModeListener(ConsumerMixin):
                                      extra=logging_tags)
                 except Exception as e:
                     logging_tags = {'tags': {'filename': os.path.basename(path)}}
-                    logger.error("Exception producing preview frame. {0}. {1}".format(e, path),
+                    exc_type, exc_value, exc_tb = sys.exc_info()
+                    traceback.format_exception(exc_type, exc_value, exc_tb)
+
+                    logger.error("Exception producing preview frame. {0}. {1}".format(traceback.form, path),
                                  extra=logging_tags)
+                    logger.error(traceback.format_exception(exc_type, exc_value, exc_tb), extra=logging_tags)
+
         message.ack()  # acknowledge to the sender we got this message (it can be popped)

--- a/banzai/qc/pointing.py
+++ b/banzai/qc/pointing.py
@@ -13,8 +13,8 @@ class PointingTest(Stage):
     """
 
     # Typical pointing is within 5" of requested pointing (decimal degrees).
-    WARNING_THRESHOLD = 5.0
-    SEVERE_THRESHOLD = 30.0
+    WARNING_THRESHOLD = 30.0
+    SEVERE_THRESHOLD = 300.0
 
     def __init__(self, pipeline_context):
         super(PointingTest, self).__init__(pipeline_context)


### PR DESCRIPTION
Include the stack trace in expecptions from the preview pipeline now. Also only produce preview images for schedulable telescopes now. Updated pointing offset thresholds to 30 arcseconds for warning and 300 arcseconds for error. Added a fix for writing NFS files that could be slow when fpacking files. We now write to temp directory first and then only write to /archive at the very end.