### PR TITLE
Fixed bug in sizes of circular photometry apertures

### DIFF
--- a/banzai/photometry.py
+++ b/banzai/photometry.py
@@ -87,7 +87,7 @@ class SourceDetector(Stage):
                 # Do circular aperture photometry for diameters of 1" to 6"
                 for diameter in [1, 2, 3, 4, 5, 6]:
                     flux, fluxerr, flag = sep.sum_circle(data, sources['x'], sources['y'],
-                                                         diameter / 2.0, gain=1.0, err=error)
+                                                         diameter / 2.0 / image.pixel_scale, gain=1.0, err=error)
                     sources['fluxaper{0}'.format(diameter)] = flux
                     sources['fluxerr{0}'.format(diameter)] = fluxerr
                     sources['flag'] |= flag

--- a/banzai/utils/image_utils.py
+++ b/banzai/utils/image_utils.py
@@ -10,7 +10,6 @@ from banzai import dbs
 from banzai import logs
 from banzai.utils import file_utils
 from banzai.utils import fits_utils
-from banzai.utils import image_utils
 from banzai.utils import date_utils
 from datetime import timedelta
 
@@ -87,7 +86,7 @@ def save_images(pipeline_context, images, master_calibration=False):
         image_filename = os.path.basename(image.filename)
         filepath = os.path.join(output_directory, image_filename)
         output_files.append(filepath)
-        image_utils.save_pipeline_metadata(image, pipeline_context)
+        save_pipeline_metadata(image, pipeline_context)
         image.writeto(filepath, pipeline_context.fpack)
         if pipeline_context.fpack:
             image_filename += '.fz'


### PR DESCRIPTION
Was doing pixel apertures when we should have been using arcseconds.