### PR TITLE
FFT Data Quality Test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ env:
         - ASTROPY_VERSION=stable
         - MAIN_CMD='python setup.py'
         - SETUP_CMD='test'
-        - PIP_DEPENDENCIES='astropy>=0.4 sqlalchemy logutils numpy cython mysqlclient lcogt_logging sep kombu requests mock pytest'
+        - PIP_DEPENDENCIES='astropy>=0.4 sqlalchemy logutils numpy cython mysqlclient lcogt_logging sep kombu requests mock pytest elasticsearch'
         - EVENT_TYPE='pull_request push'
 
         # For this package-template, we include examples of Cython modules,

--- a/.travis.yml
+++ b/.travis.yml
@@ -139,6 +139,7 @@ install:
 
     - git clone git://github.com/astropy/ci-helpers.git
     - source ci-helpers/travis/setup_conda_$TRAVIS_OS_NAME.sh
+    - if [[ $TRAVIS_OS_NAME == "osx" ]]; then brew update > /dev/null && brew install mariadb && mysql.server start; fi
 
     # As described above, using ci-helpers, you should be able to set up an
     # environment with dependencies installed using conda and pip, but in some

--- a/banzai/astrometry.py
+++ b/banzai/astrometry.py
@@ -60,7 +60,11 @@ class WCSSolver(Stage):
                                           scale_high=1.1*image.pixel_scale, wcs_name=wcs_name,
                                           catalog_name=catalog_name, nx=image.nx, ny=image.ny)
 
-                console_output = subprocess.check_output(shlex.split(command))
+                try:
+                    console_output = subprocess.check_output(shlex.split(command))
+                except subprocess.CalledProcessError:
+                    self.logger.error('Astrometry.net threw an error.', extra=logging_tags)
+
                 self.logger.debug(console_output, extra=logging_tags)
 
                 if os.path.exists(wcs_name):

--- a/banzai/main.py
+++ b/banzai/main.py
@@ -30,6 +30,7 @@ logger = logs.get_logger(__name__)
 
 ordered_stages = [qc.ThousandsTest,
                   qc.SaturationTest,
+                  qc.PatternNoiseDetector,
                   bias.OverscanSubtractor,
                   crosstalk.CrosstalkCorrector,
                   gain.GainNormalizer,
@@ -233,8 +234,8 @@ def reduce_night():
 
         # For each telescope at the given site
         for telescope in telescopes:
-            pipeline_context.raw_path = os.path.join(args.rawpath_root, args.site,
-                                                     telescope.instrument, args.dayobs, 'raw')
+            pipeline_context.raw_path = os.path.join(args.rawpath_root, args.site, telescope.instrument,
+                                                     args.dayobs, 'raw')
             try:
                 # Run the reductions on the given dayobs
                 make_master_bias(pipeline_context)

--- a/banzai/qc/__init__.py
+++ b/banzai/qc/__init__.py
@@ -1,5 +1,6 @@
 from banzai.qc.saturation import SaturationTest
 from banzai.qc.pointing import PointingTest
 from banzai.qc.sinistro_1000s import ThousandsTest
+from banzai.qc.pattern_noise import PatternNoiseDetector
 
-__all__ = ['SaturationTest', 'PointingTest', 'ThousandsTest']
+__all__ = ['SaturationTest', 'PointingTest', 'ThousandsTest', 'PatternNoiseDetector']

--- a/banzai/qc/pattern_noise.py
+++ b/banzai/qc/pattern_noise.py
@@ -1,0 +1,57 @@
+from banzai.stages import Stage
+from banzai.utils.stats import median_absolute_deviation
+from banzai.qc.utils import save_qc_results
+import numpy as np
+
+class PatternNoiseDetector(Stage):
+    # Signal to Noise threshold to raise an alert
+    snr_threshold = 15.0
+    # Number of pixels that need to be above the S/N threshold to raise an alert
+    pixel_threshold = 5
+
+    def __init__(self, pipeline_context):
+        super(PatternNoiseDetector, self).__init__(pipeline_context)
+
+    @property
+    def group_by_keywords(self):
+        return None
+
+    def do_stage(self, images):
+        for image in images:
+            # If the data is a cube, then run on each extension individually
+            if len(image.data.shape) > 2:
+                for data in image.data:
+                    pattern_noise_is_bad = check_for_pattern_noise(data, self.snr_threshold, self.pixel_threshold)
+            else:
+                pattern_noise_is_bad = check_for_pattern_noise(image.data, self.snr_threshold, self.pixel_threshold)
+
+            if pattern_noise_is_bad:
+                save_qc_results({'PatternNoise': True}, image)
+        return images
+
+
+def check_for_pattern_noise(data, snr_threshold, pixel_threshold):
+    """
+    Test for pattern noise in an image
+
+    Parameters
+    ----------
+    data : numpy array
+           Image data to test for pattern noise
+    snr_threshold : float
+                    Threshold for the Signal to Noise ratio in the power spectrum to be considered bad
+    pixel_threshold : int
+                      Number of pixels that have to be above the S/N threshold for an image to be considered bad
+
+    Returns
+    -------
+    is_bad : bool
+             Returns true if the image has pattern noise
+
+    """
+    power = np.median(np.abs(np.fft.rfft2(data)), axis=0)
+    snr = (power - np.median(power)) / median_absolute_deviation(power)
+    # Throw away the first several elements of the snr because they are usually high
+    # It is not clear exactly how many you should throw away, 15 seems to work
+    snr = snr[15:]
+    return (snr > snr_threshold).sum() >= pixel_threshold

--- a/banzai/qc/utils.py
+++ b/banzai/qc/utils.py
@@ -1,0 +1,26 @@
+import elasticsearch
+
+def save_qc_results(qc_results, image, es_url='http://elasticsearch.lco.gtn:9200'):
+    """
+    Save the Quality Control results to ElasticSearch
+
+    Parameters
+    ----------
+    qc_results : dict
+                 Dictionary of key value pairs to be saved to ElasticSearch
+    image : banzai.images.Image
+            Image that should be linked
+    es_url : str
+             URL of ElasticSearch database
+
+    Notes
+    -----
+    File name, site, instrument, and dayobs are always saved in the database.
+
+    """
+    results_to_save = {'site': image.site, 'instrument': image.instrument, 'dayobs': image.epoch}
+    for key, value in qc_results.items():
+        results_to_save[key] = value
+    es = elasticsearch.Elasticsearch(es_url)
+    filename = image.filename.replace('.fits', '').replace('.fz', '')
+    es.index(index='banzai_qc', id=filename, body={'doc': results_to_save, 'doc_as_upsert':True})

--- a/banzai/tests/test_pattern_noise_qc.py
+++ b/banzai/tests/test_pattern_noise_qc.py
@@ -1,0 +1,86 @@
+import numpy as np
+import mock
+
+from banzai.qc import pattern_noise
+
+from banzai.tests.utils import FakeImage, gaussian2d
+
+np.random.seed(200)
+
+
+def test_no_input_images():
+    detector = pattern_noise.PatternNoiseDetector(None)
+    images = detector.do_stage([])
+    assert len(images) == 0
+
+
+def test_group_by_keywords():
+    detector = pattern_noise.PatternNoiseDetector(None)
+    assert detector.group_by_keywords is None
+
+
+def test_pattern_noise_detects_noise_when_it_should():
+    data = 100.0 * np.sin(np.arange(1000000) / 0.1) + 1000 + np.random.normal(0.0, 10.0, size=1000000)
+    data = data.reshape(1000, 1000)
+    assert pattern_noise.check_for_pattern_noise(data, 10, 5)
+
+
+def test_pattern_noise_does_not_detect_white_noise():
+    data = 1000 + np.random.normal(0.0, 10.0, size=1000000)
+    data = data.reshape(1000, 1000)
+    assert pattern_noise.check_for_pattern_noise(data, 10, 5) == False
+
+
+def test_pattern_noise_does_not_detect_stars():
+    data = 1000 + np.random.normal(0.0, 10.0, size=1000000)
+    data = data.reshape(1000, 1000)
+    for i in range(5):
+        x = np.random.uniform(low=0.0, high=100)
+        y = np.random.uniform(low=0.0, high=100)
+        brightness = np.random.uniform(low=1000., high=5000.)
+        data += gaussian2d(data.shape, x, y, brightness, 3.5)
+    assert pattern_noise.check_for_pattern_noise(data, 10, 5) == False
+
+
+@mock.patch('banzai.qc.pattern_noise.save_qc_results')
+def test_pattern_noise_on_2d_image(mock_save_qc):
+    data = 100.0 * np.sin(np.arange(1e6) / 0.1) + 1000 + np.random.normal(0.0, 10.0, size=1e6)
+    data = data.reshape(1000, 1000)
+
+    image = FakeImage()
+    image.data = data
+
+    detector = pattern_noise.PatternNoiseDetector(None)
+    _ = detector.do_stage([image])
+
+    assert mock_save_qc.called
+
+
+@mock.patch('banzai.qc.pattern_noise.save_qc_results')
+def test_pattern_noise_on_3d_image(mock_save_qc):
+    data = 100.0 * np.sin(np.arange(1e6 * 4) / 0.1) + 1000 + np.random.normal(0.0, 10.0, size=1e6 * 4)
+    data = data.reshape(4, 1000, 1000)
+
+    image = FakeImage()
+    image.data = data
+
+    detector = pattern_noise.PatternNoiseDetector(None)
+    _ = detector.do_stage([image])
+
+    assert mock_save_qc.called
+
+
+
+@mock.patch('banzai.qc.pattern_noise.save_qc_results', return_value=None)
+def test_pattern_noise_in_only_one_quadrant(mock_save_qc):
+    data = np.random.normal(0.0, 10.0, size=1e6 * 4) + 1000
+    data = data.reshape(4, 1000, 1000)
+    data[3] += 100.0 * np.sin(np.arange(1e6) / 0.1).reshape(1000, 1000)
+
+    image = FakeImage()
+    image.data = data
+
+    detector = pattern_noise.PatternNoiseDetector(None)
+    _ = detector.do_stage([image])
+
+    assert mock_save_qc.called

--- a/banzai/tests/test_pattern_noise_qc.py
+++ b/banzai/tests/test_pattern_noise_qc.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
 import numpy as np
 import mock
 
@@ -20,7 +21,7 @@ def test_group_by_keywords():
 
 
 def test_pattern_noise_detects_noise_when_it_should():
-    data = 100.0 * np.sin(np.arange(1000000) / 0.1) + 1000 + np.random.normal(0.0, 10.0, size=1000000)
+    data = 100.0 * np.sin(np.arange(1000000) / 0.1) + 1000.0 + np.random.normal(0.0, 10.0, size=1000000)
     data = data.reshape(1000, 1000)
     assert pattern_noise.check_for_pattern_noise(data, 10, 5)
 
@@ -44,7 +45,7 @@ def test_pattern_noise_does_not_detect_stars():
 
 @mock.patch('banzai.qc.pattern_noise.save_qc_results')
 def test_pattern_noise_on_2d_image(mock_save_qc):
-    data = 100.0 * np.sin(np.arange(1e6) / 0.1) + 1000 + np.random.normal(0.0, 10.0, size=1e6)
+    data = 100.0 * np.sin(np.arange(1e6) / 0.1) + 1000.0 + np.random.normal(0.0, 10.0, size=1e6)
     data = data.reshape(1000, 1000)
 
     image = FakeImage()
@@ -58,7 +59,7 @@ def test_pattern_noise_on_2d_image(mock_save_qc):
 
 @mock.patch('banzai.qc.pattern_noise.save_qc_results')
 def test_pattern_noise_on_3d_image(mock_save_qc):
-    data = 100.0 * np.sin(np.arange(1e6 * 4) / 0.1) + 1000 + np.random.normal(0.0, 10.0, size=1e6 * 4)
+    data = 100.0 * np.sin(np.arange(1e6 * 4) / 0.1) + 1000.0 + np.random.normal(0.0, 10.0, size=1e6 * 4)
     data = data.reshape(4, 1000, 1000)
 
     image = FakeImage()
@@ -73,7 +74,7 @@ def test_pattern_noise_on_3d_image(mock_save_qc):
 
 @mock.patch('banzai.qc.pattern_noise.save_qc_results', return_value=None)
 def test_pattern_noise_in_only_one_quadrant(mock_save_qc):
-    data = np.random.normal(0.0, 10.0, size=1e6 * 4) + 1000
+    data = np.random.normal(0.0, 10.0, size=1e6 * 4) + 1000.0
     data = data.reshape(4, 1000, 1000)
     data[3] += 100.0 * np.sin(np.arange(1e6) / 0.1).reshape(1000, 1000)
 

--- a/banzai/tests/test_pattern_noise_qc.py
+++ b/banzai/tests/test_pattern_noise_qc.py
@@ -45,7 +45,7 @@ def test_pattern_noise_does_not_detect_stars():
 
 @mock.patch('banzai.qc.pattern_noise.save_qc_results')
 def test_pattern_noise_on_2d_image(mock_save_qc):
-    data = 100.0 * np.sin(np.arange(1e6) / 0.1) + 1000.0 + np.random.normal(0.0, 10.0, size=1e6)
+    data = 100.0 * np.sin(np.arange(1000000) / 0.1) + 1000.0 + np.random.normal(0.0, 10.0, size=1000000)
     data = data.reshape(1000, 1000)
 
     image = FakeImage()
@@ -59,7 +59,7 @@ def test_pattern_noise_on_2d_image(mock_save_qc):
 
 @mock.patch('banzai.qc.pattern_noise.save_qc_results')
 def test_pattern_noise_on_3d_image(mock_save_qc):
-    data = 100.0 * np.sin(np.arange(1e6 * 4) / 0.1) + 1000.0 + np.random.normal(0.0, 10.0, size=1e6 * 4)
+    data = 100.0 * np.sin(np.arange(1000000 * 4) / 0.1) + 1000.0 + np.random.normal(0.0, 10.0, size=1000000 * 4)
     data = data.reshape(4, 1000, 1000)
 
     image = FakeImage()
@@ -74,7 +74,7 @@ def test_pattern_noise_on_3d_image(mock_save_qc):
 
 @mock.patch('banzai.qc.pattern_noise.save_qc_results', return_value=None)
 def test_pattern_noise_in_only_one_quadrant(mock_save_qc):
-    data = np.random.normal(0.0, 10.0, size=1e6 * 4) + 1000.0
+    data = np.random.normal(0.0, 10.0, size=1000000 * 4) + 1000.0
     data = data.reshape(4, 1000, 1000)
     data[3] += 100.0 * np.sin(np.arange(1e6) / 0.1).reshape(1000, 1000)
 

--- a/banzai/tests/utils.py
+++ b/banzai/tests/utils.py
@@ -50,3 +50,17 @@ def throws_inhomogeneous_set_exception(stagetype, context, keyword, value):
         images += [FakeImage() for x in range(6)]
         stage.do_stage(images)
     assert 'Images have different {0}s'.format(keyword) == str(exception_info.value)
+
+
+def gaussian2d(image_shape, x0, y0, brightness, fwhm):
+    x = np.arange(image_shape[1])
+    y = np.arange(image_shape[0])
+    x2d, y2d = np.meshgrid(x, y)
+
+    sig = fwhm  / 2.35482
+
+    normfactor = brightness / 2.0 / np.pi * sig ** -2.0
+    exponent = -0.5 * sig ** -2.0
+    exponent *= (x2d - x0) ** 2.0 + (y2d - y0) ** 2.0
+
+    return normfactor * np.exp(exponent)

--- a/setup.cfg
+++ b/setup.cfg
@@ -60,6 +60,7 @@ install_requires =
     sep
     kombu
     requests
+    elasticsearch
 
 tests_require =
     pytest


### PR DESCRIPTION
I have added a quality control test that runs a 2-D FFT on images before they processed. If pattern noise is detected, it writes the result to the banzai_qc index in ElasticSearch. This is then checked by the data quality report which should alert us more quickly when part of the camera hardware has failed.