### PR TITLE
Add header sanity check to pipeline

### DIFF
--- a/banzai/main.py
+++ b/banzai/main.py
@@ -28,7 +28,8 @@ from banzai.utils import image_utils, date_utils
 
 logger = logs.get_logger(__name__)
 
-ordered_stages = [qc.ThousandsTest,
+ordered_stages = [qc.HeaderSanity,
+                  qc.ThousandsTest,
                   qc.SaturationTest,
                   qc.PatternNoiseDetector,
                   bias.OverscanSubtractor,

--- a/banzai/qc/__init__.py
+++ b/banzai/qc/__init__.py
@@ -2,5 +2,7 @@ from banzai.qc.saturation import SaturationTest
 from banzai.qc.pointing import PointingTest
 from banzai.qc.sinistro_1000s import ThousandsTest
 from banzai.qc.pattern_noise import PatternNoiseDetector
+from banzai.qc.header_checker import HeaderSanity
 
-__all__ = ['SaturationTest', 'PointingTest', 'ThousandsTest', 'PatternNoiseDetector']
+__all__ = ['SaturationTest', 'PointingTest', 'ThousandsTest',
+           'PatternNoiseDetector', 'HeaderSanity']


### PR DESCRIPTION
The header sanity check method was already written, it just wasn't added to the pipeline stages. This fix adds it in. 