### PR TITLE
read_images would only act properly on images without a BPM.

### DIFF
--- a/banzai/images.py
+++ b/banzai/images.py
@@ -136,6 +136,8 @@ def read_images(image_list, pipeline_context):
                 else:
                     image.bpm = bpm
                     images.append(image)
+            else:
+                images.append(image)
         except Exception as e:
             logger.error('Error loading {0}'.format(filename))
             logger.error(e)


### PR DESCRIPTION
Fixed banzai.images.read_images so that if image.bpm is not None, then read_images will fill out the image list as it should. Prior, it would return an empty list which would cause main.run to act on an empty list of images and do nothing.