### PR TITLE
hotfix/missing_telescope_exception

### DIFF
--- a/banzai/dbs.py
+++ b/banzai/dbs.py
@@ -293,7 +293,6 @@ class TelescopeMissingException(Exception):
 
 
 def get_telescope_id(site, instrument, db_address=_DEFAULT_DB):
-    # TODO:  This dies if the telescope is not in the telescopes table. Maybe ping the configdb?
     db_session = get_session(db_address=db_address)
     criteria = (Telescope.site == site) & (Telescope.instrument == instrument)
     telescope = db_session.query(Telescope).filter(criteria).first()
@@ -301,8 +300,11 @@ def get_telescope_id(site, instrument, db_address=_DEFAULT_DB):
     if telescope is None:
         err_msg = '{site}/{instrument} is not in the database.'.format(site=site,
                                                                        instrument=instrument)
-        raise TelescopeMissingException(err_msg)
-    return telescope.id
+        logger.error(err_msg, extra={'tags': {'site': site, 'instrument': instrument}})
+        telescope_id = None
+    else:
+        telescope_id = telescope.id
+    return telescope_id
 
 
 def get_telescope(telescope_id, db_address=_DEFAULT_DB):

--- a/banzai/images.py
+++ b/banzai/images.py
@@ -49,7 +49,7 @@ class Image(object):
                 self.telescope_id = dbs.get_telescope_id(self.site, header.get('TELESCOP'),
                                                          db_address=pipeline_context.db_address)
                 self.instrument = header.get('TELESCOP')
-                
+
         self.epoch = str(header.get('DAY-OBS'))
         self.nx = header.get('NAXIS1')
         self.ny = header.get('NAXIS2')

--- a/banzai/images.py
+++ b/banzai/images.py
@@ -172,6 +172,8 @@ def read_images(image_list, pipeline_context):
     for filename in image_list:
         try:
             image = Image(pipeline_context, filename=filename)
+            if image.telescope_id is None:
+                raise dbs.TelescopeMissingException
             munge(image, pipeline_context)
             if image.bpm is None:
                 bpm = image_utils.get_bpm(image, pipeline_context)
@@ -181,6 +183,8 @@ def read_images(image_list, pipeline_context):
                 else:
                     image.bpm = bpm
                     images.append(image)
+            else:
+                images.append(image)
         except Exception as e:
             logger.error('Error loading {0}'.format(filename))
             logger.error(e)

--- a/banzai/images.py
+++ b/banzai/images.py
@@ -45,10 +45,11 @@ class Image(object):
         if self.site is not None and self.instrument is not None:
             self.telescope_id = dbs.get_telescope_id(self.site, self.instrument,
                                                      db_address=pipeline_context.db_address)
-        if self.telescope_id is None and header.get('TELESCOP') is not None:
-            self.telescope_id = dbs.get_telescope_id(self.site, header.get('TELESCOP'),
-                                                     db_address=pipeline_context.db_address)
-            self.instrument = header.get('TELESCOP')
+            if self.telescope_id is None and header.get('TELESCOP') is not None:
+                self.telescope_id = dbs.get_telescope_id(self.site, header.get('TELESCOP'),
+                                                         db_address=pipeline_context.db_address)
+                self.instrument = header.get('TELESCOP')
+                
         self.epoch = str(header.get('DAY-OBS'))
         self.nx = header.get('NAXIS1')
         self.ny = header.get('NAXIS2')

--- a/banzai/images.py
+++ b/banzai/images.py
@@ -45,8 +45,10 @@ class Image(object):
         if self.site is not None and self.instrument is not None:
             self.telescope_id = dbs.get_telescope_id(self.site, self.instrument,
                                                      db_address=pipeline_context.db_address)
-        else:
-            self.telescope_id = None
+        if self.telescope_id is None and header.get('TELESCOP') is not None:
+            self.telescope_id = dbs.get_telescope_id(self.site, header.get('TELESCOP'),
+                                                     db_address=pipeline_context.db_address)
+            self.instrument = header.get('TELESCOP')
         self.epoch = str(header.get('DAY-OBS'))
         self.nx = header.get('NAXIS1')
         self.ny = header.get('NAXIS2')

--- a/banzai/munge.py
+++ b/banzai/munge.py
@@ -37,7 +37,7 @@ def munge(image, pipeline_context):
                                         '[ADU] Saturation level used')
     if not image_has_valid_saturate_value(image):
         raise ValueError('Saturate value not valid {f}'.format(f=image.filename))
-    
+
     if image.header.get('CRPIX1') is None:
         image.header['CRPIX1'] = 0
     if image.header.get('CRPIX2') is None:

--- a/banzai/munge.py
+++ b/banzai/munge.py
@@ -37,6 +37,11 @@ def munge(image, pipeline_context):
                                         '[ADU] Saturation level used')
     if not image_has_valid_saturate_value(image):
         raise ValueError('Saturate value not valid {f}'.format(f=image.filename))
+    
+    if image.header.get('CRPIX1') is None:
+        image.header['CRPIX1'] = 0
+    if image.header.get('CRPIX2') is None:
+        image.header['CRPIX2'] = 0
 
 
 def sinistro_mode_is_supported(image):


### PR DESCRIPTION
Fixed read_images and get_telescope_id so that they do not crash if the telescope is not in the database.
The LCO database has NRES frames under TELESCOP id, not instrument. Thus whenever an instance of the Image class from images.py is created, using an NRES pipeline context, then we get an exception from get_telescope_id and so the Image instance is not created. 
Also fixed read_images so that it would not return an empty list if the fits file which was imported already had a BPM.