### PR TITLE
Broke headers out to an object

### DIFF
--- a/banzai/bias.py
+++ b/banzai/bias.py
@@ -4,7 +4,7 @@ import os.path
 
 import numpy as np
 
-from banzai.images import Image
+from banzai.image import Image
 from banzai import logs
 from banzai.stages import CalibrationMaker, ApplyCalibration, Stage, CalibrationComparer
 from banzai.utils import stats, fits_utils
@@ -117,7 +117,7 @@ class OverscanSubtractor(Stage):
             logs.add_tag(logging_tags, 'filename', os.path.basename(image.filename))
 
             # Subtract the overscan if it exists
-            if image.data_is_3d():
+            if image.is_data_3d():
                 for i in range(image.get_n_amps()):
                     overscan_level = _subtract_overscan_3d(image, i)
                     logs.add_tag(logging_tags, 'OVERSCN{0}'.format(i + 1), overscan_level)

--- a/banzai/crosstalk.py
+++ b/banzai/crosstalk.py
@@ -15,7 +15,7 @@ class CrosstalkCorrector(Stage):
 
     def do_stage(self, images):
         for image in images:
-            if image.data_is_3d():
+            if image.is_data_3d():
                 logging_tags = logs.image_config_to_tags(image, self.group_by_keywords)
                 logs.add_tag(logging_tags, 'filename', os.path.basename(image.filename))
                 n_amps = image.get_n_amps()

--- a/banzai/dark.py
+++ b/banzai/dark.py
@@ -5,7 +5,7 @@ import os.path
 
 from banzai.utils import stats, fits_utils
 from banzai import logs
-from banzai.images import Image
+from banzai.image import Image
 from banzai.stages import CalibrationMaker, ApplyCalibration, CalibrationComparer, Stage
 
 __author__ = 'cmccully'

--- a/banzai/flats.py
+++ b/banzai/flats.py
@@ -5,7 +5,7 @@ import os.path
 
 from banzai.utils import stats, fits_utils
 from banzai.stages import CalibrationMaker, ApplyCalibration, Stage, CalibrationComparer
-from banzai.images import Image
+from banzai.image import Image
 from banzai import logs
 
 __author__ = 'cmccully'

--- a/banzai/gain.py
+++ b/banzai/gain.py
@@ -26,7 +26,7 @@ class GainNormalizer(Stage):
                 self.logger.error('Gain missing. Rejecting image.', extra=logging_tags)
                 images_to_remove.append(image)
             else:
-                if image.data_is_3d():
+                if image.is_data_3d():
                     for i in range(image.get_n_amps()):
                         image.data[i] *= gain[i]
                     image.header['SATURATE'] *= min(gain)

--- a/banzai/image/header.py
+++ b/banzai/image/header.py
@@ -1,0 +1,25 @@
+from banzai import logs
+from banzai.utils import date_utils, fits_utils
+
+logger = logs.get_logger(__name__)
+
+class Header(object):
+    def __init__(self, header: dict):
+        self.request_number = header['REQNUM']
+        self.epoch = str(header['DAY-OBS'])
+        self.nx = header['NAXIS1']
+        self.ny = header['NAXIS2']
+        self.block_id = header['BLKUID']
+        self.molecule_id = header['MOLUID']
+        self.ccdsum = header['CCDSUM']
+        self.filter = header['FILTER']
+        self.obstype = header['OBSTYPE']
+        self.gain = eval(str(header['GAIN']))
+        self.site = header['SITEID']
+        self.instrument = header['INSTRUME']
+
+        self.exptime = float(header.get('EXPTIME', 0.0))
+        self.dateobs = date_utils.parse_date_obs(header.get('DATE-OBS', '1900-01-01T00:00:00.00000'))
+        self.readnoise = float(header.get('RDNOISE', 0.0))
+        self.ra, self.dec = fits_utils.parse_ra_dec(header)
+        self.pixel_scale = float(header.get('PIXSCALE', 0.0))

--- a/banzai/main.py
+++ b/banzai/main.py
@@ -18,7 +18,7 @@ import traceback
 from kombu import Exchange, Connection, Queue
 from kombu.mixins import ConsumerMixin
 
-import banzai.images
+import banzai.image
 from banzai import bias, dark, flats, trim, photometry, astrometry, qc
 from banzai import dbs
 from banzai import logs
@@ -317,7 +317,7 @@ def run(stages_to_do, pipeline_context, image_types=[], calibration_maker=False,
     image_list = image_utils.select_images(image_list, image_types,
                                            pipeline_context.allowed_instrument_criteria,
                                            db_address=pipeline_context.db_address)
-    images = banzai.images.read_images(image_list, pipeline_context)
+    images = banzai.image.image.read_images(image_list, pipeline_context)
 
     for stage in stages_to_do:
         stage_to_run = stage(pipeline_context)

--- a/banzai/mosaic.py
+++ b/banzai/mosaic.py
@@ -16,7 +16,7 @@ class MosaicCreator(Stage):
 
     def do_stage(self, images):
         for image in images:
-            if image.data_is_3d():
+            if image.is_data_3d():
 
                 logging_tags = logs.image_config_to_tags(image, self.group_by_keywords)
                 logs.add_tag(logging_tags, 'filename', os.path.basename(image.filename))

--- a/banzai/munge.py
+++ b/banzai/munge.py
@@ -42,7 +42,7 @@ def sinistro_mode_is_supported(image):
 
     Parameters
     ----------
-    image: banzai.images.Image
+    image: banzai.image.Image
            Sinistro image to check
 
     Returns
@@ -122,7 +122,7 @@ def image_has_valid_saturate_value(image):
 
     Parameters
     ----------
-    image: banzai.images.Image
+    image: banzai.image.Image
 
     Returns
     -------

--- a/banzai/stages.py
+++ b/banzai/stages.py
@@ -5,7 +5,7 @@ import elasticsearch
 
 from banzai import dbs
 from banzai import logs
-from banzai.images import Image
+from banzai.image import Image
 from banzai.utils import image_utils
 from banzai.utils.qc import format_qc_results
 
@@ -66,7 +66,7 @@ class Stage(abc.ABC):
         ----------
         qc_results : dict
                      Dictionary of key value pairs to be saved to ElasticSearch
-        image : banzai.images.Image
+        image : banzai.image.Image
                 Image that should be linked
 
         Notes

--- a/banzai/tests/test_image.py
+++ b/banzai/tests/test_image.py
@@ -1,4 +1,4 @@
-from banzai.images import Image
+from banzai.image import Image
 from banzai.tests.utils import FakeContext, FakeImage
 import numpy as np
 import pytest
@@ -16,12 +16,12 @@ def test_null_filename():
 
 def test_3d_is_3d():
     test_image = FakeImage(n_amps=4)
-    assert test_image.data_is_3d()
+    assert test_image.is_data_3d()
 
 
 def test_2d_is_not_3d():
     test_image = FakeImage()
-    assert not test_image.data_is_3d()
+    assert not test_image.is_data_3d()
 
 
 def test_get_n_amps_3d():

--- a/banzai/tests/utils.py
+++ b/banzai/tests/utils.py
@@ -4,7 +4,7 @@ from banzai.utils import image_utils
 import numpy as np
 from datetime import datetime
 from banzai.stages import Stage
-from banzai.images import Image
+from banzai.image import Image
 
 
 class FakeImage(Image):

--- a/banzai/utils/image_utils.py
+++ b/banzai/utils/image_utils.py
@@ -164,7 +164,7 @@ def load_bpm_file(bpm_filename, image):
 def bpm_has_valid_size(bpm, image):
 
     # If 3d, check and make sure the number of extensions is the same
-    if image.data_is_3d():
+    if image.is_data_3d():
         y_slices, x_slices = fits_utils.parse_region_keyword(image.extension_headers[0]['DATASEC'])
         is_valid = image.data.shape[0] == bpm.shape[0]
     else:


### PR DESCRIPTION
It seems like there is an `Image` object that is comprised of other objects such as a `Header` object.

From a high level, everything that is needed to create an `Image` should be given to the `Image` constructor (would be nice if it was just a filename of a file to read from), and then instance objects of `Image` can be populated with that data inside `Image`.