### PR TITLE
Fix/astropy truncate warning

### DIFF
--- a/banzai/astrometry.py
+++ b/banzai/astrometry.py
@@ -96,8 +96,8 @@ def add_ra_dec_to_catalog(image):
     ras, decs = image_wcs.all_pix2world(image.data_tables['catalog']['x'], image.data_tables['catalog']['y'], 1)
     image.data_tables['catalog']['ra'] = ras
     image.data_tables['catalog']['dec'] = decs
-    image.data_tables['catalog']['ra'].unit = 'degrees'
-    image.data_tables['catalog']['dec'].unit = 'degrees'
+    image.data_tables['catalog']['ra'].unit = 'degree'
+    image.data_tables['catalog']['dec'].unit = 'degree'
     image.data_tables['catalog']['ra'].description = 'Right Ascension'
     image.data_tables['catalog']['dec'].description = 'Declination'
 

--- a/banzai/utils/fits_utils.py
+++ b/banzai/utils/fits_utils.py
@@ -41,7 +41,7 @@ def create_master_calibration_header(images):
     observation_dates = [image.dateobs for image in images]
     mean_dateobs = date_utils.mean_date(observation_dates)
 
-    header['DATE-OBS'] = date_utils.date_obs_to_string(mean_dateobs)
+    header['DATE-OBS'] = (date_utils.date_obs_to_string(mean_dateobs), '[UTC] Mean observation start time')
 
     header.add_history("Images combined to create master calibration image:")
     for image in images:


### PR DESCRIPTION
I think some of the tables changes have brought back the astropy units warnings. This branch fixes those, as well as the header truncation warning. 