### PR TITLE
Hotfix/preview logging

### DIFF
--- a/banzai/context.py
+++ b/banzai/context.py
@@ -1,22 +1,3 @@
-import sys
-import logging
-from lcogt_logging import LCOGTFormatter
-
-from banzai import logs
-
-logging.captureWarnings(True)
-
-# Set up the root logger
-root_logger = logging.getLogger()
-root_logger.setLevel(getattr(logging, 'DEBUG'))
-root_handler = logging.StreamHandler(sys.stdout)
-
-# Add handler
-formatter = LCOGTFormatter()
-root_handler.setFormatter(formatter)
-root_logger.addHandler(root_handler)
-
-
 class TelescopeCriterion:
     def __init__(self, attribute, comparison_operator, comparison_value, exclude=False):
         self.attribute = attribute
@@ -49,5 +30,3 @@ class PipelineContext(object):
         self.elasticsearch_qc_index = args.elasticsearch_qc_index
         self.no_bpm = args.no_bpm
         self.allowed_instrument_criteria = allowed_instrument_criteria
-
-        logs.set_log_level(self.log_level)

--- a/banzai/logs.py
+++ b/banzai/logs.py
@@ -37,5 +37,5 @@ def _image_to_tags(image_config):
 
 
 def set_log_level(log_level='INFO'):
-    for handler in logging.getLogger().handlers:
-        handler.setLevel(log_level.upper())
+    root_logger = logging.getLogger()
+    root_logger.setLevel(log_level.upper())

--- a/banzai/main.py
+++ b/banzai/main.py
@@ -369,7 +369,7 @@ def run_preview_pipeline():
 
     logs.set_log_level(args.log_level)
     # Need to keep the amqp logger level low, or else it send heartbeat check messages every second
-    logging.getLogger('amqp').setLevel('INFO')
+    logging.getLogger('amqp').setLevel(getattr(logging, 'INFO'))
 
     pipeline_context = PipelineContext(args, IMAGING_CRITERIA)
 

--- a/banzai/main.py
+++ b/banzai/main.py
@@ -368,8 +368,9 @@ def run_preview_pipeline():
     args.filename = None
 
     logs.set_log_level(args.log_level)
-    # Need to keep the amqp logger level low, or else it send heartbeat check messages every second
-    logging.getLogger('amqp').setLevel(getattr(logging, 'INFO'))
+    # Need to keep the amqp logger level at least as high as INFO,
+    # or else it send heartbeat check messages every second
+    logging.getLogger('amqp').setLevel(max(logger.level, getattr(logging, 'INFO')))
 
     pipeline_context = PipelineContext(args, IMAGING_CRITERIA)
 

--- a/banzai/main.py
+++ b/banzai/main.py
@@ -18,6 +18,7 @@ import operator
 from kombu import Exchange, Connection, Queue
 from kombu.mixins import ConsumerMixin
 
+from banzai import settings
 from banzai.context import PipelineContext
 import banzai.images
 from banzai import bias, dark, flats, trim, photometry, astrometry, qc
@@ -27,6 +28,7 @@ from banzai import preview
 from banzai.qc import pointing
 from banzai.utils import image_utils, date_utils
 from banzai.context import TelescopeCriterion
+from banzai import logs
 
 logger = logging.getLogger(__name__)
 
@@ -221,6 +223,7 @@ def reduce_night():
     args.filename = None
     args.max_preview_tries = 5
 
+    logs.set_log_level(args.log_level)
     pipeline_context = PipelineContext(args, IMAGING_CRITERIA)
 
     # Ping the configdb to get currently schedulable telescopes
@@ -296,6 +299,8 @@ def parse_end_of_night_command_line_arguments(selection_criteria):
     args.preview_mode = False
     args.max_preview_tries = 5
 
+    logs.set_log_level(args.log_level)
+
     return PipelineContext(args, selection_criteria)
 
 
@@ -361,6 +366,8 @@ def run_preview_pipeline():
     args.preview_mode = True
     args.raw_path = None
     args.filename = None
+
+    logs.set_log_level(args.log_level)
     pipeline_context = PipelineContext(args, IMAGING_CRITERIA)
 
     try:
@@ -376,7 +383,6 @@ def run_preview_pipeline():
                                                                           args.queue_name,
                                                                           PipelineContext(args, IMAGING_CRITERIA)))
         p.start()
-
 
 
 def run_individual_listener(broker_url, queue_name, pipeline_context):

--- a/banzai/main.py
+++ b/banzai/main.py
@@ -368,6 +368,9 @@ def run_preview_pipeline():
     args.filename = None
 
     logs.set_log_level(args.log_level)
+    # Need to keep the amqp logger level low, or else it send heartbeat check messages every second
+    logging.getLogger('amqp').setLevel('INFO')
+
     pipeline_context = PipelineContext(args, IMAGING_CRITERIA)
 
     try:

--- a/banzai/main.py
+++ b/banzai/main.py
@@ -195,7 +195,7 @@ def reduce_night():
     parser.add_argument("--processed-path", default='/archive/engineering',
                         help='Top level directory where the processed data will be stored')
 
-    parser.add_argument("--log-level", default='debug', choices=['debug', 'info', 'warning',
+    parser.add_argument("--log-level", default='info', choices=['debug', 'info', 'warning',
                                                                  'critical', 'fatal', 'error'])
     parser.add_argument('--post-to-archive', dest='post_to_archive', action='store_true',
                         default=False)
@@ -272,7 +272,7 @@ def parse_end_of_night_command_line_arguments(selection_criteria):
                         help='Top level directory where the raw data is stored')
     parser.add_argument("--processed-path", default='/archive/engineering/',
                         help='Top level directory where the processed data will be stored')
-    parser.add_argument("--log-level", default='debug', choices=['debug', 'info', 'warning',
+    parser.add_argument("--log-level", default='info', choices=['debug', 'info', 'warning',
                                                                  'critical', 'fatal', 'error'])
     parser.add_argument('--post-to-archive', dest='post_to_archive', action='store_true',
                         default=False)
@@ -332,7 +332,7 @@ def run_preview_pipeline():
 
     parser.add_argument("--processed-path", default='/archive/engineering',
                         help='Top level directory where the processed data will be stored')
-    parser.add_argument("--log-level", default='debug', choices=['debug', 'info', 'warning',
+    parser.add_argument("--log-level", default='info', choices=['debug', 'info', 'warning',
                                                                  'critical', 'fatal', 'error'])
     parser.add_argument('--post-to-archive', dest='post_to_archive', action='store_true',
                         default=False)

--- a/banzai/settings.py
+++ b/banzai/settings.py
@@ -7,10 +7,10 @@ logging.captureWarnings(True)
 
 # Set up the root logger
 root_logger = logging.getLogger()
-root_logger.setLevel(getattr(logging, 'DEBUG'))
 root_handler = logging.StreamHandler(sys.stdout)
 
 # Add handler
 formatter = LCOGTFormatter()
 root_handler.setFormatter(formatter)
+root_handler.setLevel(getattr(logging, 'DEBUG'))
 root_logger.addHandler(root_handler)


### PR DESCRIPTION
The recent changes to the logging caused the preview pipeline to report a heartbeat once per second. This is fixed by manually setting the `amqp` logger level to INFO. 

The logger is now set up in `settings.py`, and the level is set by the root logger. 