### PR TITLE
Hotfix/set preview mode

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+0.11.1 (2018-10-31)
+-------------------
+- Fixed bug where preview mode was not set to true when running preview pipeline
+
 0.11.0 (2018-10-30)
 -------------------
 - Added command-line option to ignore telescope schedulability requirement  

--- a/banzai/main.py
+++ b/banzai/main.py
@@ -316,7 +316,7 @@ def run_preview_pipeline():
                                 'kwargs': {'dest': 'queue_name', 'default': 'preview_pipeline',
                                            'help': 'Name of the queue to listen to from the fits exchange.'}}]
     pipeline_context = parse_args(IMAGING_CRITERIA, parser_description='Reduce LCO imaging data in real time.',
-                                  extra_console_arguments=extra_console_arguments)
+                                  extra_console_arguments=extra_console_arguments, preview_mode=True)
 
     # Need to keep the amqp logger level at least as high as INFO,
     # or else it send heartbeat check messages every second

--- a/setup.cfg
+++ b/setup.cfg
@@ -76,7 +76,7 @@ edit_on_github = True
 github_project = lcogt/banzai
 
 # version should be PEP440 compatible (http://www.python.org/dev/peps/pep-0440)
-version = 0.11.0
+version = 0.11.1
 
 [entry_points]
 banzai = banzai.main:main


### PR DESCRIPTION
`run_preview_pipeline` fixed to explicitly tell `pipeline_context` to run in preview mode. (And actually this is the issue that was causing the reduced images to be saved in `processed`, not the `rlevel` like I had said). 