### PR TITLE
hotfix/reduce night indentation 

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,8 @@
-0.13.0 (2018-11-08)
+0.13.0 (2018-11-12)
 -------------------
 - Refactored pipeline context so that we can subclass image types for BANZAI NRES.
+- Fixed bug (introduced in 0.11.3) where reduce night would 
+  only reduce data from a single telescope per site 
 
 0.12.1 (2018-11-08)
 -------------------

--- a/banzai/main.py
+++ b/banzai/main.py
@@ -268,23 +268,23 @@ def reduce_night():
         raw_path = os.path.join(pipeline_context.rawpath_root, pipeline_context.site,
                                 telescope.instrument, dayobs, 'raw')
 
-    # Run the reductions on the given dayobs
-    try:
-        make_master_bias(pipeline_context=pipeline_context, raw_path=raw_path)
-    except Exception as e:
-        logger.error(e)
-    try:
-        make_master_dark(pipeline_context=pipeline_context, raw_path=raw_path)
-    except Exception as e:
-        logger.error(e)
-    try:
-        make_master_flat(pipeline_context=pipeline_context, raw_path=raw_path)
-    except Exception as e:
-        logger.error(e)
-    try:
-        reduce_science_frames(pipeline_context=pipeline_context, raw_path=raw_path)
-    except Exception as e:
-        logger.error(e)
+        # Run the reductions on the given dayobs
+        try:
+            make_master_bias(pipeline_context=pipeline_context, raw_path=raw_path)
+        except Exception as e:
+            logger.error(e)
+        try:
+            make_master_dark(pipeline_context=pipeline_context, raw_path=raw_path)
+        except Exception as e:
+            logger.error(e)
+        try:
+            make_master_flat(pipeline_context=pipeline_context, raw_path=raw_path)
+        except Exception as e:
+            logger.error(e)
+        try:
+            reduce_science_frames(pipeline_context=pipeline_context, raw_path=raw_path)
+        except Exception as e:
+            logger.error(e)
 
 
 def get_preview_stages_todo(image_suffix):


### PR DESCRIPTION
Now I am also pining for loop ends in Python! 

When I refactored main, I took parts of `reduce_night` out of an `if` statement, but by mistake I also took the actual reduction steps out of the telescope for loop as well. This means that `reduce_night` is broken since version 0.11.3. (Chanunpa is still running 0.11.2). 