### PR TITLE
Feature/refactor group by keywords

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 -------------------
 - Refactored bias, dark, and flat makers to use a common superclass to remove
   code duplication.
+- Removed group_by_attributes property fom all stages except CalibratrionMaker
+- Added master_selection_criteria property to CalibrationComprarer
 
 0.13.0 (2018-11-12)
 -------------------

--- a/banzai/astrometry.py
+++ b/banzai/astrometry.py
@@ -28,10 +28,6 @@ class WCSSolver(Stage):
     def __init__(self, pipeline_context):
         super(WCSSolver, self).__init__(pipeline_context)
 
-    @property
-    def group_by_attributes(self):
-        return None
-
     def do_stage(self, images):
 
         for i, image in enumerate(images):

--- a/banzai/bias.py
+++ b/banzai/bias.py
@@ -31,7 +31,7 @@ class BiasSubtractor(ApplyCalibration):
         super(BiasSubtractor, self).__init__(pipeline_context)
 
     @property
-    def group_by_attributes(self):
+    def master_selection_criteria(self):
         return ['ccdsum']
 
     @property
@@ -68,10 +68,6 @@ class OverscanSubtractor(Stage):
     def __init__(self, pipeline_context):
         super(OverscanSubtractor, self).__init__(pipeline_context)
 
-    @property
-    def group_by_attributes(self):
-        return None
-
     def do_stage(self, images):
 
         for image in images:
@@ -93,10 +89,6 @@ class BiasMasterLevelSubtractor(Stage):
     def __init__(self, pipeline_context):
         super(BiasMasterLevelSubtractor, self).__init__(pipeline_context)
 
-    @property
-    def group_by_attributes(self):
-        return None
-
     def do_stage(self, images):
 
         for image in images:
@@ -113,7 +105,7 @@ class BiasComparer(CalibrationComparer):
         super(BiasComparer, self).__init__(pipeline_context)
 
     @property
-    def group_by_attributes(self):
+    def master_selection_criteria(self):
         return ['ccdsum']
 
     @property

--- a/banzai/bpm.py
+++ b/banzai/bpm.py
@@ -11,9 +11,6 @@ logger = logging.getLogger(__name__)
 
 
 class BPMUpdater(Stage):
-    @property
-    def group_by_attributes(self):
-        return None
 
     def do_stage(self, images):
         images_to_remove = []

--- a/banzai/calibrations.py
+++ b/banzai/calibrations.py
@@ -60,7 +60,7 @@ class CalibrationMaker(Stage):
             logger.warning('Not enough images to combine.')
             return []
         else:
-            image_config = image_utils.check_image_homogeneity(images)
+            image_config = image_utils.check_image_homogeneity(images, self.group_by_attributes)
 
             return self.make_master_calibration_frame(images, image_config)
 
@@ -127,7 +127,7 @@ class ApplyCalibration(Stage):
 
     @property
     @abc.abstractmethod
-    def group_by_attributes(self):
+    def master_selection_criteria(self):
         return []
 
     def on_missing_master_calibration(self, image):
@@ -154,7 +154,7 @@ class ApplyCalibration(Stage):
         pass
 
     def get_calibration_filename(self, image):
-        return dbs.get_master_calibration_image(image, self.calibration_type, self.group_by_attributes,
+        return dbs.get_master_calibration_image(image, self.calibration_type, self.master_selection_criteria,
                                                 db_address=self.pipeline_context.db_address)
 
 

--- a/banzai/crosstalk.py
+++ b/banzai/crosstalk.py
@@ -11,10 +11,6 @@ class CrosstalkCorrector(Stage):
     def __init__(self, pipeline_context):
         super(CrosstalkCorrector, self).__init__(pipeline_context)
 
-    @property
-    def group_by_attributes(self):
-        return None
-
     def do_stage(self, images):
         for image in images:
             if image.data_is_3d():

--- a/banzai/dark.py
+++ b/banzai/dark.py
@@ -13,10 +13,6 @@ class DarkNormalizer(Stage):
     def __init__(self, pipeline_context):
         super(DarkNormalizer, self).__init__(pipeline_context)
 
-    @property
-    def group_by_attributes(self):
-        return None
-
     def do_stage(self, images):
         for image in images:
             image.data /= image.exptime
@@ -50,7 +46,7 @@ class DarkSubtractor(ApplyCalibration):
         return 'dark'
 
     @property
-    def group_by_attributes(self):
+    def master_selection_criteria(self):
         return ['ccdsum']
 
     def apply_master_calibration(self, images, master_calibration_image):
@@ -72,7 +68,7 @@ class DarkComparer(CalibrationComparer):
         super(DarkComparer, self).__init__(pipeline_context)
 
     @property
-    def group_by_attributes(self):
+    def master_selection_criteria(self):
         return ['ccdsum']
 
     @property

--- a/banzai/dbs.py
+++ b/banzai/dbs.py
@@ -391,12 +391,12 @@ def get_telescopes_at_site(site, db_address=_DEFAULT_DB, ignore_schedulability=F
     return telescopes
 
 
-def get_master_calibration_image(image, calibration_type, group_by_keywords,
+def get_master_calibration_image(image, calibration_type, master_selection_criteria,
                                  db_address=_DEFAULT_DB):
     calibration_criteria = CalibrationImage.type == calibration_type.upper()
     calibration_criteria &= CalibrationImage.telescope_id == image.telescope.id
 
-    for criterion in group_by_keywords:
+    for criterion in master_selection_criteria:
         if criterion == 'filter':
             calibration_criteria &= CalibrationImage.filter_name == getattr(image, criterion)
         else:

--- a/banzai/flats.py
+++ b/banzai/flats.py
@@ -14,10 +14,6 @@ class FlatNormalizer(Stage):
     def __init__(self, pipeline_context):
         super(FlatNormalizer, self).__init__(pipeline_context)
 
-    @property
-    def group_by_attributes(self):
-        return None
-
     def do_stage(self, images):
         for image in images:
             # Get the sigma clipped mean of the central 25% of the image
@@ -65,7 +61,7 @@ class FlatDivider(ApplyCalibration):
         super(FlatDivider, self).__init__(pipeline_context)
 
     @property
-    def group_by_attributes(self):
+    def master_selection_criteria(self):
         return ['ccdsum', 'filter']
 
     @property
@@ -93,7 +89,7 @@ class FlatComparer(CalibrationComparer):
         super(FlatComparer, self).__init__(pipeline_context)
 
     @property
-    def group_by_attributes(self):
+    def master_selection_criteria(self):
         return ['ccdsum', 'filter']
 
     @property

--- a/banzai/gain.py
+++ b/banzai/gain.py
@@ -9,10 +9,6 @@ class GainNormalizer(Stage):
     def __init__(self, pipeline_context):
         super(GainNormalizer, self).__init__(pipeline_context)
 
-    @property
-    def group_by_attributes(self):
-        return None
-
     def do_stage(self, images):
         images_to_remove = []
         for image in images:

--- a/banzai/mosaic.py
+++ b/banzai/mosaic.py
@@ -12,10 +12,6 @@ class MosaicCreator(Stage):
     def __init__(self, pipeline_context):
         super(MosaicCreator, self).__init__(pipeline_context)
 
-    @property
-    def group_by_attributes(self):
-        return None
-
     def do_stage(self, images):
         for image in images:
             if image.data_is_3d():

--- a/banzai/photometry.py
+++ b/banzai/photometry.py
@@ -20,10 +20,6 @@ class SourceDetector(Stage):
     def __init__(self, pipeline_context):
         super(SourceDetector, self).__init__(pipeline_context)
 
-    @property
-    def group_by_attributes(self):
-        return None
-
     def do_stage(self, images):
         for i, image in enumerate(images):
             try:

--- a/banzai/qc/header_checker.py
+++ b/banzai/qc/header_checker.py
@@ -29,10 +29,6 @@ class HeaderSanity(Stage):
                                          'CRVAL1', 'CRVAL2', 'CRPIX1',
                                          'CRPIX2', 'EXPTIME']
 
-    @property
-    def group_by_attributes(self):
-        return None
-
     def do_stage(self, images):
         """
         Run stage to validate header.

--- a/banzai/qc/pattern_noise.py
+++ b/banzai/qc/pattern_noise.py
@@ -23,10 +23,6 @@ class PatternNoiseDetector(Stage):
     def __init__(self, pipeline_context):
         super(PatternNoiseDetector, self).__init__(pipeline_context)
 
-    @property
-    def group_by_attributes(self):
-        return None
-
     def do_stage(self, images):
         for image in images:
             pattern_noise_is_bad, fraction_pixels_above_threshold = self.check_for_pattern_noise(image.data)

--- a/banzai/qc/pointing.py
+++ b/banzai/qc/pointing.py
@@ -21,10 +21,6 @@ class PointingTest(Stage):
     def __init__(self, pipeline_context):
         super(PointingTest, self).__init__(pipeline_context)
 
-    @property
-    def group_by_attributes(self):
-        return None
-
     def do_stage(self, images):
         for image in images:
             try:

--- a/banzai/qc/saturation.py
+++ b/banzai/qc/saturation.py
@@ -19,10 +19,6 @@ class SaturationTest(Stage):
     def __init__(self, pipeline_context):
         super(SaturationTest, self).__init__(pipeline_context)
 
-    @property
-    def group_by_attributes(self):
-        return None
-
     def do_stage(self, images):
         images_to_remove = []
         for image in images:

--- a/banzai/qc/sinistro_1000s.py
+++ b/banzai/qc/sinistro_1000s.py
@@ -24,10 +24,6 @@ class ThousandsTest(Stage):
     def __init__(self, pipeline_context):
         super(ThousandsTest, self).__init__(pipeline_context)
 
-    @property
-    def group_by_attributes(self):
-        return None
-
     def do_stage(self, images):
         images_to_remove = []
         for image in images:

--- a/banzai/stages.py
+++ b/banzai/stages.py
@@ -18,31 +18,13 @@ class Stage(abc.ABC):
     def stage_name(self):
         return '.'.join([__name__, self.__class__.__name__])
 
-    @property
-    @abc.abstractmethod
-    def group_by_attributes(self):
-        return []
-
-    def get_grouping(self, image):
-        grouping_criteria = [image.site, image.instrument, image.epoch]
-        if self.group_by_attributes:
-            grouping_criteria += [getattr(image, keyword) for keyword in self.group_by_attributes]
-        return grouping_criteria
-
-    def run_stage(self, image_set):
-        image_set = list(image_set)
-        logger.info('Running {0}'.format(self.stage_name), image=image_set[0])
-        return self.do_stage(image_set)
-
     def run(self, images):
-        images.sort(key=self.get_grouping)
-        processed_images = []
-        for _, image_set in itertools.groupby(images, self.get_grouping):
-            try:
-                processed_images += self.run_stage(image_set)
-            except Exception as e:
-                logger.error(e)
-        return processed_images
+        logger.info('Running {0}'.format(self.stage_name), image=image_set[0])
+        try:
+            images = self.do_stage(images)
+        except Exception as e:
+            logger.error(e)
+        return images
 
     @abc.abstractmethod
     def do_stage(self, images):

--- a/banzai/stages.py
+++ b/banzai/stages.py
@@ -19,7 +19,7 @@ class Stage(abc.ABC):
         return '.'.join([__name__, self.__class__.__name__])
 
     def run(self, images):
-        logger.info('Running {0}'.format(self.stage_name), image=image_set[0])
+        logger.info('Running {0}'.format(self.stage_name), image=images[0])
         try:
             images = self.do_stage(images)
         except Exception as e:

--- a/banzai/tests/test_array_utils.py
+++ b/banzai/tests/test_array_utils.py
@@ -1,7 +1,7 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
-from banzai.utils import array_utils
-from astropy.table import Table
 import numpy as np
+from astropy.table import Table
+
+from banzai.utils import array_utils
 
 
 def test_pruning_nans():

--- a/banzai/tests/test_astrometry.py
+++ b/banzai/tests/test_astrometry.py
@@ -1,8 +1,7 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
-
-from banzai import astrometry
 from astropy import units
 from astropy.coordinates import SkyCoord
+
+from banzai import astrometry
 
 
 def test_ra_dec_string_conversion():

--- a/banzai/tests/test_bias_comparer.py
+++ b/banzai/tests/test_bias_comparer.py
@@ -23,9 +23,9 @@ def test_no_input_images(set_random_seed):
     assert len(images) == 0
 
 
-def test_group_by_keywords(set_random_seed):
+def test_master_selection_criteria(set_random_seed):
     comparer = BiasComparer(None)
-    assert comparer.group_by_attributes == ['ccdsum']
+    assert comparer.master_selection_criteria == ['ccdsum']
 
 
 @mock.patch('banzai.calibrations.Image')

--- a/banzai/tests/test_bias_comparer.py
+++ b/banzai/tests/test_bias_comparer.py
@@ -1,9 +1,9 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
-from banzai.bias import BiasComparer
-from banzai.tests.utils import FakeImage, throws_inhomogeneous_set_exception, FakeContext
+import pytest
 import mock
 import numpy as np
-import pytest
+
+from banzai.bias import BiasComparer
+from banzai.tests.utils import FakeImage, throws_inhomogeneous_set_exception, FakeContext
 
 
 @pytest.fixture(scope='module')

--- a/banzai/tests/test_bias_level_subtractor.py
+++ b/banzai/tests/test_bias_level_subtractor.py
@@ -22,11 +22,6 @@ def test_no_input_images():
     assert len(images) == 0
 
 
-def test_group_by_keywords():
-    subtractor = BiasMasterLevelSubtractor(None)
-    assert subtractor.group_by_attributes is None
-
-
 def test_header_has_biaslevel():
     subtractor = BiasMasterLevelSubtractor(None)
     images = subtractor.do_stage([FakeImage() for x in range(6)])

--- a/banzai/tests/test_bias_maker.py
+++ b/banzai/tests/test_bias_maker.py
@@ -1,11 +1,9 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
-from banzai.bias import BiasMaker
+import mock
 import numpy as np
 from astropy.io import fits
 
+from banzai.bias import BiasMaker
 from banzai.tests.utils import FakeImage, FakeContext, throws_inhomogeneous_set_exception
-
-import mock
 
 
 class FakeBiasImage(FakeImage):

--- a/banzai/tests/test_bias_maker.py
+++ b/banzai/tests/test_bias_maker.py
@@ -23,7 +23,7 @@ def test_min_images():
     assert len(processed_images) == 0
 
 
-def test_group_by_keywords():
+def test_group_by_attributes():
     maker = BiasMaker(None)
     assert maker.group_by_attributes == ['ccdsum']
 

--- a/banzai/tests/test_bias_subtractor.py
+++ b/banzai/tests/test_bias_subtractor.py
@@ -19,9 +19,9 @@ def test_no_input_images():
     assert len(images) == 0
 
 
-def test_group_by_keywords():
+def test_master_selection_criteria():
     subtractor = BiasSubtractor(None)
-    assert subtractor.group_by_attributes == ['ccdsum']
+    assert subtractor.master_selection_criteria == ['ccdsum']
 
 
 @mock.patch('banzai.calibrations.Image')

--- a/banzai/tests/test_crosstalk_corrector.py
+++ b/banzai/tests/test_crosstalk_corrector.py
@@ -9,11 +9,6 @@ def test_no_input_images():
     assert len(images) == 0
 
 
-def test_group_by_keywords():
-    tester = CrosstalkCorrector(None)
-    assert tester.group_by_attributes is None
-
-
 def test_crosstalk():
     tester = CrosstalkCorrector(None)
     nx = 101

--- a/banzai/tests/test_crosstalk_corrector.py
+++ b/banzai/tests/test_crosstalk_corrector.py
@@ -1,6 +1,7 @@
+import numpy as np
+
 from banzai.tests.utils import FakeImage
 from banzai.crosstalk import CrosstalkCorrector
-import numpy as np
 
 
 def test_no_input_images():

--- a/banzai/tests/test_dark_comparer.py
+++ b/banzai/tests/test_dark_comparer.py
@@ -23,9 +23,9 @@ def test_no_input_images():
     assert len(images) == 0
 
 
-def test_group_by_keywords():
+def test_master_selection_criteria():
     comparer = DarkComparer(None)
-    assert comparer.group_by_attributes == ['ccdsum']
+    assert comparer.master_selection_criteria == ['ccdsum']
 
 
 @mock.patch('banzai.calibrations.Image')

--- a/banzai/tests/test_dark_maker.py
+++ b/banzai/tests/test_dark_maker.py
@@ -1,12 +1,10 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
-from banzai.utils import stats
-from banzai.dark import DarkMaker
+import mock
 import numpy as np
 from astropy.io import fits
 
+from banzai.utils import stats
+from banzai.dark import DarkMaker
 from banzai.tests.utils import FakeImage, FakeContext, throws_inhomogeneous_set_exception
-
-import mock
 
 
 class FakeDarkImage(FakeImage):

--- a/banzai/tests/test_dark_maker.py
+++ b/banzai/tests/test_dark_maker.py
@@ -23,7 +23,7 @@ def test_min_images():
     assert len(processed_images) == 0
 
 
-def test_group_by_keywords():
+def test_group_by_attributes():
     maker = DarkMaker(None)
     assert maker.group_by_attributes == ['ccdsum']
 

--- a/banzai/tests/test_dark_normalizer.py
+++ b/banzai/tests/test_dark_normalizer.py
@@ -16,11 +16,6 @@ def test_no_input_images(set_random_seed):
     assert len(images) == 0
 
 
-def test_group_by_keywords(set_random_seed):
-    normalizer = DarkNormalizer(None)
-    assert normalizer.group_by_attributes is None
-
-
 def test_dark_normalization_is_reasonable(set_random_seed):
     nx = 101
     ny = 103

--- a/banzai/tests/test_dark_normalizer.py
+++ b/banzai/tests/test_dark_normalizer.py
@@ -1,8 +1,8 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
+import pytest
+import numpy as np
+
 from banzai.dark import DarkNormalizer
 from banzai.tests.utils import FakeImage
-import numpy as np
-import pytest
 
 
 @pytest.fixture(scope='module')

--- a/banzai/tests/test_dbs.py
+++ b/banzai/tests/test_dbs.py
@@ -1,9 +1,10 @@
-from banzai import dbs
-import mock
 import os
 import json
 
+import mock
 from astropy.utils.data import get_pkg_data_filename
+
+from banzai import dbs
 
 
 class FakeResponse(object):

--- a/banzai/tests/test_end_to_end.py
+++ b/banzai/tests/test_end_to_end.py
@@ -1,9 +1,11 @@
-import pytest
 import os
 from glob import glob
+import argparse
+
+import pytest
+
 from banzai.dbs import populate_bpm_table, create_db, get_session, CalibrationImage
 from banzai.utils import fits_utils
-import argparse
 
 DATA_ROOT = os.path.join(os.sep, 'archive', 'engineering')
 

--- a/banzai/tests/test_fits_utils.py
+++ b/banzai/tests/test_fits_utils.py
@@ -1,7 +1,7 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
 import numpy as np
 from astropy.table import Table
 from astropy.io import fits
+
 from banzai.utils import fits_utils
 
 

--- a/banzai/tests/test_flat_comparer.py
+++ b/banzai/tests/test_flat_comparer.py
@@ -23,9 +23,9 @@ def test_no_input_images(set_random_seed):
     assert len(images) == 0
 
 
-def test_group_by_keywords(set_random_seed):
+def test_master_selection_criteria(set_random_seed):
     comparer = FlatComparer(FakeContext())
-    assert comparer.group_by_attributes == ['ccdsum', 'filter']
+    assert comparer.master_selection_criteria == ['ccdsum', 'filter']
 
 
 @mock.patch('banzai.calibrations.Image')

--- a/banzai/tests/test_flat_maker.py
+++ b/banzai/tests/test_flat_maker.py
@@ -1,8 +1,6 @@
 import mock
-import numpy as np
 from astropy.io import fits
 
-from banzai.utils import stats
 from banzai.flats import FlatMaker
 from banzai.tests.utils import FakeImage, FakeContext, throws_inhomogeneous_set_exception
 
@@ -26,7 +24,7 @@ def test_group_by_attributes():
     assert maker.group_by_attributes == ['ccdsum', 'filter']
 
 
-@mock.patch('banzai.flats.Image')
+@mock.patch('banzai.calibrations.Image')
 def test_header_cal_type_dark(mock_image):
 
     maker = FlatMaker(FakeContext())
@@ -38,26 +36,26 @@ def test_header_cal_type_dark(mock_image):
     assert header['OBSTYPE'].upper() == 'SKYFLAT'
 
 
-@mock.patch('banzai.flats.Image')
+@mock.patch('banzai.calibrations.Image')
 def test_raises_an_exception_if_ccdsums_are_different(mock_images):
     throws_inhomogeneous_set_exception(FlatMaker, FakeContext(), 'ccdsum', '1 1')
 
 
-@mock.patch('banzai.flats.Image')
+@mock.patch('banzai.calibrations.Image')
 def test_raises_an_exception_if_epochs_are_different(mock_images):
     throws_inhomogeneous_set_exception(FlatMaker, FakeContext(), 'epoch', '20160102')
 
 
-@mock.patch('banzai.flats.Image')
+@mock.patch('banzai.calibrations.Image')
 def test_raises_an_exception_if_nx_are_different(mock_images):
     throws_inhomogeneous_set_exception(FlatMaker, FakeContext(), 'nx', 105)
 
 
-@mock.patch('banzai.flats.Image')
+@mock.patch('banzai.calibrations.Image')
 def test_raises_an_exception_if_ny_are_different(mock_images):
     throws_inhomogeneous_set_exception(FlatMaker, FakeContext(), 'ny', 107)
 
 
-@mock.patch('banzai.flats.Image')
+@mock.patch('banzai.calibrations.Image')
 def test_raises_an_exception_if_filters_are_different(mock_images):
     throws_inhomogeneous_set_exception(FlatMaker, FakeContext(), 'filter', 'w')

--- a/banzai/tests/test_flat_maker.py
+++ b/banzai/tests/test_flat_maker.py
@@ -1,0 +1,63 @@
+import mock
+import numpy as np
+from astropy.io import fits
+
+from banzai.utils import stats
+from banzai.flats import FlatMaker
+from banzai.tests.utils import FakeImage, FakeContext, throws_inhomogeneous_set_exception
+
+
+class FakeFlatImage(FakeImage):
+    def __init__(self, *args, **kwargs):
+        super(FakeFlatImage, self).__init__(*args, **kwargs)
+        self.caltype = 'skyflat'
+        self.header = fits.Header()
+        self.header['OBSTYPE'] = 'SKYFLAT'
+
+
+def test_min_images():
+    dark_maker = FlatMaker(None)
+    processed_images = dark_maker.do_stage([])
+    assert len(processed_images) == 0
+
+
+def test_group_by_attributes():
+    maker = FlatMaker(None)
+    assert maker.group_by_attributes == ['ccdsum', 'filter']
+
+
+@mock.patch('banzai.flats.Image')
+def test_header_cal_type_dark(mock_image):
+
+    maker = FlatMaker(FakeContext())
+
+    maker.do_stage([FakeFlatImage() for x in range(6)])
+
+    args, kwargs = mock_image.call_args
+    header = kwargs['header']
+    assert header['OBSTYPE'].upper() == 'SKYFLAT'
+
+
+@mock.patch('banzai.flats.Image')
+def test_raises_an_exception_if_ccdsums_are_different(mock_images):
+    throws_inhomogeneous_set_exception(FlatMaker, FakeContext(), 'ccdsum', '1 1')
+
+
+@mock.patch('banzai.flats.Image')
+def test_raises_an_exception_if_epochs_are_different(mock_images):
+    throws_inhomogeneous_set_exception(FlatMaker, FakeContext(), 'epoch', '20160102')
+
+
+@mock.patch('banzai.flats.Image')
+def test_raises_an_exception_if_nx_are_different(mock_images):
+    throws_inhomogeneous_set_exception(FlatMaker, FakeContext(), 'nx', 105)
+
+
+@mock.patch('banzai.flats.Image')
+def test_raises_an_exception_if_ny_are_different(mock_images):
+    throws_inhomogeneous_set_exception(FlatMaker, FakeContext(), 'ny', 107)
+
+
+@mock.patch('banzai.flats.Image')
+def test_raises_an_exception_if_filters_are_different(mock_images):
+    throws_inhomogeneous_set_exception(FlatMaker, FakeContext(), 'filter', 'w')

--- a/banzai/tests/test_flat_normalizer.py
+++ b/banzai/tests/test_flat_normalizer.py
@@ -1,8 +1,8 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
+import pytest
+import numpy as np
+
 from banzai.flats import FlatNormalizer
 from banzai.tests.utils import FakeImage
-import numpy as np
-import pytest
 
 
 @pytest.fixture(scope='module')

--- a/banzai/tests/test_flat_normalizer.py
+++ b/banzai/tests/test_flat_normalizer.py
@@ -16,11 +16,6 @@ def test_no_input_images(set_random_seed):
     assert len(images) == 0
 
 
-def test_group_by_keywords(set_random_seed):
-    normalizer = FlatNormalizer(None)
-    assert normalizer.group_by_attributes is None
-
-
 def test_header_has_flatlevel(set_random_seed):
     normalizer = FlatNormalizer(None)
     images = normalizer.do_stage([FakeImage(image_multiplier=2.0) for _ in range(6)])

--- a/banzai/tests/test_gain_normalizer.py
+++ b/banzai/tests/test_gain_normalizer.py
@@ -1,8 +1,7 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
+import numpy as np
+
 from banzai.gain import GainNormalizer, validate_gain
 from banzai.tests.utils import FakeImage
-
-import numpy as np
 
 
 class FakeGainImage(FakeImage):

--- a/banzai/tests/test_gain_normalizer.py
+++ b/banzai/tests/test_gain_normalizer.py
@@ -17,11 +17,6 @@ def test_no_input_images():
     assert len(images) == 0
 
 
-def test_group_by_keywords():
-    gain_normalizer = GainNormalizer(None)
-    assert gain_normalizer.group_by_attributes is None
-
-
 def test_gain_header_missing():
     gain_normalizer = GainNormalizer(None)
     images = gain_normalizer.do_stage([FakeGainImage() for x in range(6)])

--- a/banzai/tests/test_header_checker.py
+++ b/banzai/tests/test_header_checker.py
@@ -23,11 +23,6 @@ def test_no_input_images():
     assert len(images) == 0
 
 
-def test_group_by_keywords():
-    tester = header_checker.HeaderSanity(None)
-    assert tester.group_by_attributes is None
-
-
 def test_all_keywords_missing():
     logger.error = mock.MagicMock()
     tester = header_checker.HeaderSanity(None)

--- a/banzai/tests/test_image.py
+++ b/banzai/tests/test_image.py
@@ -1,9 +1,10 @@
-from banzai.images import Image, DataTable, regenerate_data_table_from_fits_hdu_list
-from banzai.tests.utils import FakeContext, FakeImage
-import numpy as np
 import pytest
+import numpy as np
 from astropy.table import Table
 from astropy.io import fits
+
+from banzai.images import Image, DataTable, regenerate_data_table_from_fits_hdu_list
+from banzai.tests.utils import FakeContext, FakeImage
 
 
 @pytest.fixture(scope='module')

--- a/banzai/tests/test_image_criteria.py
+++ b/banzai/tests/test_image_criteria.py
@@ -1,8 +1,10 @@
-from banzai.context import TelescopeCriterion
-from banzai.utils.image_utils import image_passes_criteria
 from collections import namedtuple
 import operator
+
 import mock
+
+from banzai.context import TelescopeCriterion
+from banzai.utils.image_utils import image_passes_criteria
 
 FakeTelescope = namedtuple('FakeTelescope', ['schedulable', 'camera_type'])
 

--- a/banzai/tests/test_median_utils.py
+++ b/banzai/tests/test_median_utils.py
@@ -1,6 +1,6 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
-from banzai.utils import median_utils
 import numpy as np
+
+from banzai.utils import median_utils
 
 
 def _compare_median1d(a, mask):

--- a/banzai/tests/test_mosaic_maker.py
+++ b/banzai/tests/test_mosaic_maker.py
@@ -1,8 +1,7 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
+import numpy as np
 
 from banzai.mosaic import get_mosaic_size, MosaicCreator
 from banzai.tests.utils import FakeImage
-import numpy as np
 
 
 class FakeMosaicImage(FakeImage):

--- a/banzai/tests/test_mosaic_maker.py
+++ b/banzai/tests/test_mosaic_maker.py
@@ -35,11 +35,6 @@ def test_no_input_images():
     assert len(images) == 0
 
 
-def test_group_by_keywords():
-    mosaic_creator = MosaicCreator(None)
-    assert mosaic_creator.group_by_attributes is None
-
-
 def test_2d_images():
     pass
 

--- a/banzai/tests/test_need_to_make_preview.py
+++ b/banzai/tests/test_need_to_make_preview.py
@@ -1,8 +1,10 @@
+import operator
+
 import mock
+
 from banzai.dbs import TelescopeMissingException
 from banzai.preview import need_to_make_preview
 from banzai.context import TelescopeCriterion
-import operator
 
 md5_hash1 = '49a6bb35cdd3859224c0214310b1d9b6'
 md5_hash2 = 'aec5ef355e7e43a59fedc88ac95caed6'

--- a/banzai/tests/test_overscan_subtactor.py
+++ b/banzai/tests/test_overscan_subtactor.py
@@ -1,8 +1,7 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
+import numpy as np
+
 from banzai.bias import OverscanSubtractor
 from banzai.tests.utils import FakeImage
-
-import numpy as np
 
 
 class FakeOverscanImage(FakeImage):

--- a/banzai/tests/test_overscan_subtactor.py
+++ b/banzai/tests/test_overscan_subtactor.py
@@ -17,11 +17,6 @@ def test_no_input_images():
     assert len(images) == 0
 
 
-def test_group_by_keywords():
-    subtractor = OverscanSubtractor(None)
-    assert subtractor.group_by_attributes is None
-
-
 def test_header_has_overscan_when_biassec_unknown():
     subtractor = OverscanSubtractor(None)
     images = subtractor.do_stage([FakeOverscanImage() for x in range(6)])

--- a/banzai/tests/test_pattern_noise_qc.py
+++ b/banzai/tests/test_pattern_noise_qc.py
@@ -34,11 +34,6 @@ def test_no_input_images(set_random_seed):
     assert len(images) == 0
 
 
-def test_group_by_keywords(set_random_seed):
-    detector = pattern_noise.PatternNoiseDetector(None)
-    assert detector.group_by_attributes is None
-
-
 def test_pattern_noise_detects_noise_when_it_should(set_random_seed):
     data = generate_data(has_pattern_noise=True)
     detector = pattern_noise.PatternNoiseDetector(None)

--- a/banzai/tests/test_pipeline_context.py
+++ b/banzai/tests/test_pipeline_context.py
@@ -1,5 +1,6 @@
-from banzai.context import PipelineContext
 from argparse import Namespace
+
+from banzai.context import PipelineContext
 
 
 def test_pipeline_context_gets_arguments_from_argparse():

--- a/banzai/tests/test_pointing.py
+++ b/banzai/tests/test_pointing.py
@@ -1,7 +1,7 @@
 import numpy as np
 
 from banzai.qc.pointing import PointingTest
-from .utils import FakeImage
+from banzai.tests.utils import FakeImage
 
 
 def test_no_input_images():

--- a/banzai/tests/test_pointing.py
+++ b/banzai/tests/test_pointing.py
@@ -10,11 +10,6 @@ def test_no_input_images():
     assert len(images) == 0
 
 
-def test_group_by_keywords():
-    tester = PointingTest(None)
-    assert tester.group_by_attributes is None
-
-
 def test_no_offset():
     tester = PointingTest(None)
     nx = 101

--- a/banzai/tests/test_quick_select.py
+++ b/banzai/tests/test_quick_select.py
@@ -1,6 +1,6 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
-from banzai.utils import median_utils
 import numpy as np
+
+from banzai.utils import median_utils
 
 
 def test_quick_select_arange():

--- a/banzai/tests/test_saturation_qc.py
+++ b/banzai/tests/test_saturation_qc.py
@@ -1,6 +1,7 @@
+import numpy as np
+
 from banzai.tests.utils import FakeImage
 from banzai.qc import SaturationTest
-import numpy as np
 
 
 def test_no_input_images():

--- a/banzai/tests/test_saturation_qc.py
+++ b/banzai/tests/test_saturation_qc.py
@@ -9,11 +9,6 @@ def test_no_input_images():
     assert len(images) == 0
 
 
-def test_group_by_keywords():
-    tester = SaturationTest(None)
-    assert tester.group_by_attributes is None
-
-
 def test_no_pixels_saturated():
     tester = SaturationTest(None)
     nx = 101

--- a/banzai/tests/test_saving_qc.py
+++ b/banzai/tests/test_saving_qc.py
@@ -1,6 +1,7 @@
-import numpy as np
-from banzai.tests.utils import FakeImage, FakeContext, FakeStage
 import mock
+import numpy as np
+
+from banzai.tests.utils import FakeImage, FakeContext, FakeStage
 from banzai.utils.qc import format_qc_results
 
 

--- a/banzai/tests/test_stats.py
+++ b/banzai/tests/test_stats.py
@@ -1,8 +1,8 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
-from banzai.utils import stats
+import pytest
 import numpy as np
 from numpy import ma
-import pytest
+
+from banzai.utils import stats
 
 
 @pytest.fixture(scope='module')

--- a/banzai/tests/test_thousands_qc.py
+++ b/banzai/tests/test_thousands_qc.py
@@ -1,6 +1,7 @@
+import numpy as np
+
 from banzai.tests.utils import FakeImage
 from banzai.qc import ThousandsTest
-import numpy as np
 
 
 def test_no_input_images():

--- a/banzai/tests/test_thousands_qc.py
+++ b/banzai/tests/test_thousands_qc.py
@@ -9,11 +9,6 @@ def test_no_input_images():
     assert len(images) == 0
 
 
-def test_group_by_keywords():
-    tester = ThousandsTest(None)
-    assert tester.group_by_attributes is None
-
-
 def test_no_pixels_1000():
     tester = ThousandsTest(None)
     nx = 101

--- a/banzai/tests/utils.py
+++ b/banzai/tests/utils.py
@@ -10,7 +10,7 @@ from banzai.images import Image
 
 class FakeImage(Image):
     def __init__(self, nx=101, ny=103, image_multiplier=1.0,
-                 ccdsum='2 2', epoch='20160101', n_amps=1):
+                 ccdsum='2 2', epoch='20160101', n_amps=1, filter='U'):
         self.nx = nx
         self.ny = ny
         self.telescope_id = -1
@@ -22,7 +22,7 @@ class FakeImage(Image):
         if n_amps > 1:
             self.data = np.stack(n_amps*[self.data])
         self.filename = 'test.fits'
-        self.filter = 'U'
+        self.filter = filter
         self.dateobs = datetime(2016, 1, 1)
         self.header = {}
         self.caltype = ''

--- a/banzai/tests/utils.py
+++ b/banzai/tests/utils.py
@@ -1,8 +1,9 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
-import pytest
-from banzai.utils import image_utils
-import numpy as np
 from datetime import datetime
+
+import pytest
+import numpy as np
+
+from banzai.utils import image_utils
 from banzai.stages import Stage
 from banzai.images import Image
 

--- a/banzai/trim.py
+++ b/banzai/trim.py
@@ -32,10 +32,6 @@ class Trimmer(Stage):
     def __init__(self, pipeline_context):
         super(Trimmer, self).__init__(pipeline_context)
 
-    @property
-    def group_by_attributes(self):
-        return None
-
     def do_stage(self, images):
 
         for image in images:

--- a/banzai/utils/image_utils.py
+++ b/banzai/utils/image_utils.py
@@ -65,8 +65,11 @@ def make_image_list(raw_path):
     return image_list
 
 
-def check_image_homogeneity(images):
-    for attribute in ['nx', 'ny', 'ccdsum', 'epoch', 'site', 'instrument']:
+def check_image_homogeneity(images, group_by_attributes=None):
+    attribute_list = ['nx', 'ny', 'ccdsum', 'epoch', 'site', 'instrument']
+    if group_by_attributes is not None:
+        attribute_list += group_by_attributes
+    for attribute in attribute_list:
         if len(set([getattr(image, attribute) for image in images])) > 1:
             raise InhomogeneousSetException('Images have different {0}s'.format(attribute))
     return images[0]


### PR DESCRIPTION
Curtis, I know that you are working on a stacking refactor, and this branch may have some overlap, but I think the changes here could be complementary to what you are working on, and perhaps take care of some housekeeping that you may otherwise need to do.

Basically, I've removed `group_by_keywords` completely from the main `Stage` class, and also from all stages which subclass `Stage` directly and from their corresponding tests. I also simplified the `run` method since grouping is no longer needed, and removed the `run_stage` method. 

I then moved `group_by_keywords` to the `CalibrationMaker` class, as well as the `get_grouping` method. For the `ApplyCalibration` class, I've added the property `master_selection_criteria` which is used to find matching master calibration images. 