### PR TITLE
Hotfix/bpm mismatch and stage logging

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,9 @@
-0.14.2 (2018-11-14)
+0.14.2 (2018-11-26)
 -------------------
 - If telescope isn't found in the database, parameters are populated from image header
+- Fixed BPM filename header keyword check in BPM stage
+- Fixed logging call in stages.py when image list is empty
+- Fixed logging call in create_master_calibration_header when keyword cannot be added
 
 0.14.1 (2018-11-13)
 -------------------

--- a/banzai/bpm.py
+++ b/banzai/bpm.py
@@ -17,7 +17,7 @@ class BPMUpdater(Stage):
         for image in images:
             add_bpm_to_image(image, self.pipeline_context)
             validate_bpm_size(image)
-            if image.header['L1IDMASK'][0] == '' and not self.pipeline_context.no_bpm:
+            if image.header.get('L1IDMASK') == '' and not self.pipeline_context.no_bpm:
                 logger.error("Can't add BPM to image, stopping reduction", image=image)
                 images_to_remove.append(image)
                 continue

--- a/banzai/bpm.py
+++ b/banzai/bpm.py
@@ -17,7 +17,7 @@ class BPMUpdater(Stage):
         for image in images:
             add_bpm_to_image(image, self.pipeline_context)
             validate_bpm_size(image)
-            if image.header.get('L1IDMASK') == '' and not self.pipeline_context.no_bpm:
+            if image.header.get('L1IDMASK', '') == '' and not self.pipeline_context.no_bpm:
                 logger.error("Can't add BPM to image, stopping reduction", image=image)
                 images_to_remove.append(image)
                 continue

--- a/banzai/stages.py
+++ b/banzai/stages.py
@@ -18,7 +18,7 @@ class Stage(abc.ABC):
         return '.'.join([__name__, self.__class__.__name__])
 
     def run(self, images):
-        if len(images):
+        if len(images) > 0:
             logger.info('Running {0}'.format(self.stage_name), image=images[0])
         try:
             images = self.do_stage(images)

--- a/banzai/stages.py
+++ b/banzai/stages.py
@@ -18,7 +18,8 @@ class Stage(abc.ABC):
         return '.'.join([__name__, self.__class__.__name__])
 
     def run(self, images):
-        logger.info('Running {0}'.format(self.stage_name), image=images[0])
+        if len(images):
+            logger.info('Running {0}'.format(self.stage_name), image=images[0])
         try:
             images = self.do_stage(images)
         except Exception:

--- a/banzai/tests/test_bias_level_subtractor.py
+++ b/banzai/tests/test_bias_level_subtractor.py
@@ -33,14 +33,14 @@ def test_header_biaslevel_is_1():
     subtractor = BiasMasterLevelSubtractor(None)
     images = subtractor.do_stage([FakeImage(image_multiplier=1.0) for x in range(6)])
     for image in images:
-        assert image.header['BIASLVL'][0] == 1
+        assert image.header.get('BIASLVL') == 1
 
 
 def test_header_mbiaslevel_is_2():
     subtractor = BiasMasterLevelSubtractor(None)
     images = subtractor.do_stage([FakeImage(image_multiplier=2.0) for x in range(6)])
     for image in images:
-        assert image.header['BIASLVL'][0] == 2.0
+        assert image.header.get('BIASLVL') == 2.0
 
 
 def test_bias_master_level_subtraction_is_reasonable():
@@ -56,4 +56,4 @@ def test_bias_master_level_subtraction_is_reasonable():
 
     for image in images:
         np.testing.assert_allclose(np.zeros(image.data.shape), image.data, atol=8 * read_noise)
-        np.testing.assert_allclose(image.header['BIASLVL'][0], input_bias, atol=1.0)
+        np.testing.assert_allclose(image.header.get('BIASLVL'), input_bias, atol=1.0)

--- a/banzai/tests/test_bias_subtractor.py
+++ b/banzai/tests/test_bias_subtractor.py
@@ -31,7 +31,7 @@ def test_header_has_biaslevel(mock_cal, mock_image):
     subtractor = BiasSubtractor(None)
     images = subtractor.do_stage([FakeImage() for x in range(6)])
     for image in images:
-        assert image.header['BIASLVL'][0] == 0
+        assert image.header.get('BIASLVL') == 0
 
 
 @mock.patch('banzai.calibrations.Image')
@@ -41,7 +41,7 @@ def test_header_biaslevel_is_1(mock_cal, mock_image):
     subtractor = BiasSubtractor(None)
     images = subtractor.do_stage([FakeImage() for x in range(6)])
     for image in images:
-        assert image.header['BIASLVL'][0] == 1
+        assert image.header.get('BIASLVL') == 1
 
 
 @mock.patch('banzai.calibrations.Image')
@@ -51,7 +51,7 @@ def test_header_biaslevel_is_2(mock_cal, mock_image):
     subtractor = BiasSubtractor(None)
     images = subtractor.do_stage([FakeImage() for x in range(6)])
     for image in images:
-        assert image.header['BIASLVL'][0] == 2
+        assert image.header.get('BIASLVL') == 2
 
 
 @mock.patch('banzai.calibrations.Image')
@@ -111,5 +111,5 @@ def test_bias_subtraction_is_reasonable(mock_cal, mock_image):
     images = subtractor.do_stage(images)
 
     for image in images:
-        assert np.abs(image.header['BIASLVL'][0] - input_bias) < 1.0
+        assert np.abs(image.header.get('BIASLVL') - input_bias) < 1.0
         assert np.abs(np.mean(image.data) - input_level + input_bias) < 1.0

--- a/banzai/tests/test_bpm.py
+++ b/banzai/tests/test_bpm.py
@@ -69,7 +69,7 @@ def test_adds_good_bpm(mock_load_bpm, mock_get_bpm_filename, set_random_seed):
     tester = BPMUpdater(FakeContextForBPM())
     image = tester.do_stage([image])[0]
     np.testing.assert_array_equal(image.bpm, bpm_to_load)
-    assert image.header['L1IDMASK'][0] == 'fake_bpm_filename'
+    assert image.header.get('L1IDMASK') == 'fake_bpm_filename'
 
 
 @mock.patch('banzai.bpm.dbs.get_bpm_filename')
@@ -82,7 +82,7 @@ def test_adds_good_bpm_3d(mock_load_bpm, mock_get_bpm_filename, set_random_seed)
     tester = BPMUpdater(FakeContextForBPM())
     image = tester.do_stage([image])[0]
     np.testing.assert_array_equal(image.bpm, bpm_to_load)
-    assert image.header['L1IDMASK'][0] == 'fake_bpm_filename'
+    assert image.header.get('L1IDMASK') == 'fake_bpm_filename'
 
 
 @mock.patch('banzai.bpm.dbs.get_bpm_filename')

--- a/banzai/tests/test_pointing.py
+++ b/banzai/tests/test_pointing.py
@@ -24,7 +24,7 @@ def test_no_offset():
 
     images = tester.do_stage(images)
     for image in images:
-        np.testing.assert_allclose(image.header['PNTOFST'][0], 0.0, atol=1e-7)
+        np.testing.assert_allclose(image.header.get('PNTOFST'), 0.0, atol=1e-7)
 
 
 def test_large_offset():
@@ -41,4 +41,4 @@ def test_large_offset():
 
     images = tester.do_stage(images)
     for image in images:
-        assert image.header['PNTOFST'][0] == 10.0
+        assert image.header.get('PNTOFST') == 10.0

--- a/banzai/tests/test_saturation_qc.py
+++ b/banzai/tests/test_saturation_qc.py
@@ -21,7 +21,7 @@ def test_no_pixels_saturated():
 
     images = tester.do_stage(images)
     for image in images:
-        assert image.header['SATFRAC'][0] == 0.0
+        assert image.header.get('SATFRAC') == 0.0
     assert len(images) == 6
 
 
@@ -37,7 +37,7 @@ def test_nonzero_but_no_pixels_saturated():
 
     images = tester.do_stage(images)
     for image in images:
-        assert image.header['SATFRAC'][0] == 0.0
+        assert image.header.get('SATFRAC') == 0.0
     assert len(images) == 6
 
 
@@ -60,7 +60,7 @@ def test_1_image_10_percent_saturated():
 
     images = tester.do_stage(images)
     for image in images:
-        assert image.header['SATFRAC'][0] == 0.0
+        assert image.header.get('SATFRAC') == 0.0
     assert len(images) == 5
 
 
@@ -79,7 +79,7 @@ def test_all_images_10_percent_saturated():
 
     images = tester.do_stage(images)
     for image in images:
-        assert np.abs(image.header['SATFRAC'][0] - 0.02) < 0.001
+        assert np.abs(image.header.get('SATFRAC') - 0.02) < 0.001
     assert len(images) == 0
 
 
@@ -98,5 +98,5 @@ def test_all_images_2_percent_saturated():
 
     images = tester.do_stage(images)
     for image in images:
-        assert np.abs(image.header['SATFRAC'][0] - 0.02) < 0.001
+        assert np.abs(image.header.get('SATFRAC') - 0.02) < 0.001
     assert len(images) == 6

--- a/banzai/tests/utils.py
+++ b/banzai/tests/utils.py
@@ -2,6 +2,7 @@ from datetime import datetime
 
 import pytest
 import numpy as np
+from astropy.io.fits import Header
 
 from banzai.utils import image_utils
 from banzai.stages import Stage
@@ -24,7 +25,7 @@ class FakeImage(Image):
         self.filename = 'test.fits'
         self.filter = filter
         self.dateobs = datetime(2016, 1, 1)
-        self.header = {}
+        self.header = Header()
         self.caltype = ''
         self.bpm = np.zeros((ny, nx), dtype=np.uint8)
         self.request_number = '0000331403'

--- a/banzai/utils/fits_utils.py
+++ b/banzai/utils/fits_utils.py
@@ -33,7 +33,7 @@ def create_master_calibration_header(images):
             if len(h) > 0:
                 header[h] = (images[0].header[h], images[0].header.comments[h])
         except ValueError as e:
-            logger.error('Could not add keyword {0}'.format(h), image=image)
+            logger.error('Could not add keyword {0}'.format(h), image=images[0])
             continue
 
     header = sanitizeheader(header)


### PR DESCRIPTION
This should fix a couple of issues that came up from all the recent changes: 
- In the BPM stage, I had not implemented the BPM filename header keyword check correctly, I've now changed it to use `header.get`
- If a stage was passed an empty list, it would crash on the logger which tried to get the 0th image
- `create_master_calibration_header` in `fits_utils.py` had an error in the logging call if a keyword could not be added