### PR TITLE
hotfix/image_utils_logging_typo

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+0.14.3 (2018-11-27)
+-------------------
+- Added catch to any logger errros to avoid crashing pipeline in case of logging
+  message typos
+- Fixed a logging message typo in image_utils
+
 0.14.2 (2018-11-26)
 -------------------
 - If telescope isn't found in the database, parameters are populated from image header

--- a/banzai/logs.py
+++ b/banzai/logs.py
@@ -5,6 +5,8 @@ import sys
 
 from banzai.utils import date_utils
 
+logger = logging.getLogger(__name__)
+
 
 class BanzaiLogger(logging.getLoggerClass()):
     def __init__(self, name, level='NOTSET'):
@@ -16,14 +18,18 @@ class BanzaiLogger(logging.getLoggerClass()):
 
 
 def _create_logging_tags_dictionary(kwargs):
-    tags = {}
-    image = kwargs.pop('image', None)
-    extra_tags = kwargs.pop('extra_tags', None)
-    if image:
-        tags.update(_image_to_tags(image))
-    if extra_tags:
-        tags.update(extra_tags)
-    kwargs['extra'] = {'tags': tags}
+    try:
+        tags = {}
+        image = kwargs.pop('image', None)
+        extra_tags = kwargs.pop('extra_tags', None)
+        if image:
+            tags.update(_image_to_tags(image))
+        if extra_tags:
+            tags.update(extra_tags)
+        kwargs['extra'] = {'tags': tags}
+    except Exception:
+        logger.error(format_exception())
+        kwargs = {'extra': {'tags': {'error': 'Check implementation of this logging message'}}}
     return kwargs
 
 

--- a/banzai/main.py
+++ b/banzai/main.py
@@ -242,7 +242,7 @@ def reduce_night():
     try:
         dbs.populate_telescope_tables(db_address=pipeline_context.db_address)
     except Exception:
-        logger.error('Could not connect to the configdb. ' + logs.format_exception())
+        logger.error('Could not connect to the configdb: {error}'.format(error=logs.format_exception()))
 
     try:
         timezone = dbs.get_timezone(pipeline_context.site, db_address=pipeline_context.db_address)
@@ -323,7 +323,7 @@ def run_preview_pipeline():
     try:
         dbs.populate_telescope_tables(db_address=pipeline_context.db_address)
     except Exception:
-        logger.error('Could not connect to the configdb. ' + logs.format_exception())
+        logger.error('Could not connect to the configdb: {error}'.format(error=logs.format_exception()))
 
     logger.info('Starting pipeline preview mode listener')
 
@@ -393,5 +393,5 @@ class PreviewModeListener(ConsumerMixin):
                     preview.set_preview_file_as_processed(path, db_address=self.pipeline_context.db_address)
 
             except Exception:
-                logger.error("Exception producing preview frame. {error}".format(error=logs.format_exception()),
+                logger.error("Exception producing preview frame: {error}".format(error=logs.format_exception()),
                              extra_tags={'filename': os.path.basename(path)})

--- a/banzai/utils/image_utils.py
+++ b/banzai/utils/image_utils.py
@@ -106,7 +106,7 @@ def save_images(pipeline_context, images, master_calibration=False):
             try:
                 file_utils.post_to_archive_queue(filepath)
             except Exception:
-                logger.error("Could not post to ingester: " + logs.format_exception(),
+                logger.error("Could not post to ingester: {error}".format(error=logs.format_exception()),
                              extra_tags={'filename': filepath})
                 continue
     return output_files

--- a/banzai/utils/image_utils.py
+++ b/banzai/utils/image_utils.py
@@ -102,7 +102,7 @@ def save_images(pipeline_context, images, master_calibration=False):
                                       db_address=pipeline_context.db_address)
 
         if pipeline_context.post_to_archive:
-            logger.info('Posting file to the archive', extra_tags={'filename', image_filename})
+            logger.info('Posting file to the archive', extra_tags={'filename': image_filename})
             try:
                 file_utils.post_to_archive_queue(filepath)
             except Exception:

--- a/setup.cfg
+++ b/setup.cfg
@@ -76,7 +76,7 @@ edit_on_github = True
 github_project = lcogt/banzai
 
 # version should be PEP440 compatible (http://www.python.org/dev/peps/pep-0440)
-version = 0.14.2
+version = 0.14.3
 
 [entry_points]
 banzai = banzai.main:main


### PR DESCRIPTION
The preview pipeline error in 0.14.2 was caused by a typo in the `extra_tags` dictionary passed to the logger when pushing to the archive. 

I also modified the logger to catch any logging errors so that small typos like this won't crash the pipeline in the future. 

Finally, there were a couple of places where the output of `logs.format_exception()` was added to a string. This doesn't work because the output is actually a list of strings, so I've changed all these statements to use `format`. 