### PR TITLE
Hotfix/stop reduction on missing master

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 0.14.4 (2018-11-28)
 -------------------
 - Fixed stages to return empty image list if an exception occured
+- Fixed small logging typos
 
 0.14.3 (2018-11-27)
 -------------------

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+0.14.4 (2018-11-28)
+-------------------
+- Fixed stages to return empty image list if an exception occured
+
 0.14.3 (2018-11-27)
 -------------------
 - Added catch to any logger errros to avoid crashing pipeline in case of logging

--- a/banzai/bias.py
+++ b/banzai/bias.py
@@ -68,7 +68,7 @@ class BiasSubtractor(ApplyCalibration):
                             'L1IDBIAS': image.header['L1IDBIAS']}
             logging_tags.update(master_logging_tags)
 
-            logger.info('Subtracting bias', image=image,  extra=logging_tags)
+            logger.info('Subtracting bias', image=image,  extra_tags=logging_tags)
         return images
 
 

--- a/banzai/calibrations.py
+++ b/banzai/calibrations.py
@@ -139,11 +139,11 @@ class ApplyCalibration(Stage):
             # Abort!
             return []
         else:
-            image_config = image_utils.check_image_homogeneity(images)
+            image_utils.check_image_homogeneity(images)
             master_calibration_filename = self.get_calibration_filename(images[0])
 
             if master_calibration_filename is None:
-                self.on_missing_master_calibration(image_config)
+                self.on_missing_master_calibration(images[0])
 
             master_calibration_image = Image(self.pipeline_context,
                                              filename=master_calibration_filename)

--- a/banzai/dbs.py
+++ b/banzai/dbs.py
@@ -275,8 +275,8 @@ def populate_bpm_table(directory, db_address=_DEFAULT_DB):
         telescope = get_telescope(header, db_address=db_address)
 
         if telescope is None:
-            logger.error('Telescope is missing from database', extra={'tags': {'site': header['SITEID'],
-                                                                               'instrument': header['INSTRUME']}})
+            logger.error('Telescope is missing from database', extra_tags={'site': header['SITEID'],
+                                                                           'instrument': header['INSTRUME']})
             continue
 
         bpm_attributes = {'telescope_id': telescope.id, 'filepath': os.path.abspath(directory),
@@ -328,7 +328,7 @@ def get_telescope(header, db_address=_DEFAULT_DB):
     if telescope is None:
         logger.error('Telescope {site}/{instrument} is not in the database, '
                      'extracting best-guess values from header'.format(site=site, instrument=instrument),
-                     extra={'tags': {'site': site, 'instrument': instrument}})
+                     extra_tags={'site': site, 'instrument': instrument})
         telescope = _guess_telescope_values_from_header(header, db_address)
     return telescope
 

--- a/banzai/stages.py
+++ b/banzai/stages.py
@@ -20,11 +20,12 @@ class Stage(abc.ABC):
     def run(self, images):
         if len(images) > 0:
             logger.info('Running {0}'.format(self.stage_name), image=images[0])
+        processed_images = []
         try:
-            images = self.do_stage(images)
+            processed_images = self.do_stage(images)
         except Exception:
             logger.error(logs.format_exception())
-        return images
+        return processed_images
 
     @abc.abstractmethod
     def do_stage(self, images):

--- a/setup.cfg
+++ b/setup.cfg
@@ -76,7 +76,7 @@ edit_on_github = True
 github_project = lcogt/banzai
 
 # version should be PEP440 compatible (http://www.python.org/dev/peps/pep-0440)
-version = 0.14.3
+version = 0.14.4
 
 [entry_points]
 banzai = banzai.main:main


### PR DESCRIPTION
When I refactored `stages.py` in 0.14.1, I had it return the images list if an exception was caught. This would cause the pipeline to continue in cases where it shouldn't, e.g. a missing master calibration frame for any of the `ApplyCalibration` steps. 

I also fixed a couple of logging typos. 