### PR TITLE
feature/refactor_settings

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+0.15.0 (2018-12-05)
+-------------------
+- Restructured settings to be an abstract class
+- Methods in main.py must now specify which version of settings to use 
+- All parameters from settings are now added to the pipeline context
+
 0.14.4 (2018-11-28)
 -------------------
 - Fixed stages to return empty image list if an exception occured

--- a/banzai/bias.py
+++ b/banzai/bias.py
@@ -16,16 +16,8 @@ class BiasMaker(CalibrationStacker):
         super(BiasMaker, self).__init__(pipeline_context)
 
     @property
-    def group_by_attributes(self):
-        return ['ccdsum']
-
-    @property
     def calibration_type(self):
         return 'BIAS'
-
-    @property
-    def min_images(self):
-        return 5
 
     def make_master_calibration_frame(self, images):
         master_image = super(BiasMaker, self).make_master_calibration_frame(images)
@@ -37,10 +29,6 @@ class BiasMaker(CalibrationStacker):
 class BiasSubtractor(ApplyCalibration):
     def __init__(self, pipeline_context):
         super(BiasSubtractor, self).__init__(pipeline_context)
-
-    @property
-    def master_selection_criteria(self):
-        return ['ccdsum']
 
     @property
     def calibration_type(self):
@@ -111,10 +99,6 @@ class BiasMasterLevelSubtractor(Stage):
 class BiasComparer(CalibrationComparer):
     def __init__(self, pipeline_context):
         super(BiasComparer, self).__init__(pipeline_context)
-
-    @property
-    def master_selection_criteria(self):
-        return ['ccdsum']
 
     @property
     def calibration_type(self):

--- a/banzai/calibrations.py
+++ b/banzai/calibrations.py
@@ -1,14 +1,14 @@
 import logging
 import abc
 import itertools
+import os
 
 import numpy as np
 
 from banzai.stages import Stage
-from banzai import dbs
+from banzai import dbs, logs
 from banzai.images import Image
 from banzai.utils import image_utils, stats, fits_utils
-import os
 
 logger = logging.getLogger(__name__)
 
@@ -16,6 +16,7 @@ logger = logging.getLogger(__name__)
 class CalibrationMaker(Stage):
     def __init__(self, pipeline_context):
         super(CalibrationMaker, self).__init__(pipeline_context)
+        self.group_by_attributes = self.pipeline_context.GROUP_BY_ATTRIBUTES.get(self.calibration_type.upper(), [])
 
     @property
     @abc.abstractmethod
@@ -25,16 +26,6 @@ class CalibrationMaker(Stage):
     @abc.abstractmethod
     def make_master_calibration_frame(self, images, image_config):
         pass
-
-    @property
-    @abc.abstractmethod
-    def min_images(self):
-        return 5
-
-    @property
-    @abc.abstractmethod
-    def group_by_attributes(self):
-        return []
 
     def get_grouping(self, image):
         grouping_criteria = [image.site, image.instrument, image.epoch]
@@ -50,18 +41,17 @@ class CalibrationMaker(Stage):
                 image_set = list(image_set)
                 logger.info('Running {0}'.format(self.stage_name), image=image_set[0])
                 processed_images += self.do_stage(image_set)
-            except Exception as e:
-                logger.error(e)
+            except Exception:
+                logger.error(logs.format_exception())
         return processed_images
 
     def do_stage(self, images):
-        if len(images) < self.min_images:
+        if len(images) < self.pipeline_context.CALIBRATION_MIN_IMAGES:
             # Do nothing
             logger.warning('Not enough images to combine.')
             return []
         else:
             image_utils.check_image_homogeneity(images, self.group_by_attributes)
-
             return [self.make_master_calibration_frame(images)]
 
     def get_calibration_filename(self, image):
@@ -119,16 +109,13 @@ class MasterCalibrationDoesNotExist(Exception):
 class ApplyCalibration(Stage):
     def __init__(self, pipeline_context):
         super(ApplyCalibration, self).__init__(pipeline_context)
+        self.master_selection_criteria = self.pipeline_context.GROUP_BY_ATTRIBUTES.get(
+            self.calibration_type.upper(), [])
 
     @property
     @abc.abstractmethod
     def calibration_type(self):
         pass
-
-    @property
-    @abc.abstractmethod
-    def master_selection_criteria(self):
-        return []
 
     def on_missing_master_calibration(self, image):
         logger.error('Master Calibration file does not exist for {stage}'.format(stage=self.stage_name), image=image)
@@ -167,9 +154,6 @@ class CalibrationComparer(ApplyCalibration):
     @abc.abstractmethod
     def reject_images(self):
         pass
-
-    def __init__(self, pipeline_context):
-        super(ApplyCalibration, self).__init__(pipeline_context)
 
     def on_missing_master_calibration(self, image):
         msg = 'No master {caltype} frame exists. Assuming these images are ok.'

--- a/banzai/calibrations.py
+++ b/banzai/calibrations.py
@@ -16,7 +16,7 @@ logger = logging.getLogger(__name__)
 class CalibrationMaker(Stage):
     def __init__(self, pipeline_context):
         super(CalibrationMaker, self).__init__(pipeline_context)
-        self.group_by_attributes = self.pipeline_context.GROUP_BY_ATTRIBUTES.get(self.calibration_type.upper(), [])
+        self.group_by_attributes = self.pipeline_context.CALIBRATION_SET_CRITERIA.get(self.calibration_type.upper(), [])
 
     @property
     @abc.abstractmethod
@@ -46,9 +46,11 @@ class CalibrationMaker(Stage):
         return processed_images
 
     def do_stage(self, images):
-        if len(images) < self.pipeline_context.CALIBRATION_MIN_IMAGES:
+        min_images = self.pipeline_context.CALIBRATION_MIN_IMAGES.get(self.calibration_type.upper(), -1)
+        if len(images) < min_images:
             # Do nothing
-            logger.warning('Not enough images to combine.')
+            logger.warning('Number of images less than minimum requirement of {min_images}, not combining'.format(
+                min_images=min_images))
             return []
         else:
             image_utils.check_image_homogeneity(images, self.group_by_attributes)
@@ -109,7 +111,7 @@ class MasterCalibrationDoesNotExist(Exception):
 class ApplyCalibration(Stage):
     def __init__(self, pipeline_context):
         super(ApplyCalibration, self).__init__(pipeline_context)
-        self.master_selection_criteria = self.pipeline_context.GROUP_BY_ATTRIBUTES.get(
+        self.master_selection_criteria = self.pipeline_context.CALIBRATION_SET_CRITERIA.get(
             self.calibration_type.upper(), [])
 
     @property

--- a/banzai/context.py
+++ b/banzai/context.py
@@ -1,11 +1,6 @@
-import importlib
-
-
 class TelescopeCriterion:
     def __init__(self, attribute, comparison_operator, comparison_value, exclude=False):
         self.attribute = attribute
-        if not callable(comparison_operator):
-            comparison_operator = getattr(importlib.import_module(comparison_operator[0]), comparison_operator[1])
         self.comparison_operator = comparison_operator
         self.comparison_value = comparison_value
         self.exclude = exclude

--- a/banzai/context.py
+++ b/banzai/context.py
@@ -16,7 +16,7 @@ class TelescopeCriterion:
 
 
 class PipelineContext(object):
-    def __init__(self, command_line_args, allowed_instrument_criteria, image_class,
+    def __init__(self, command_line_args, config,
                  processed_path='/archive/engineering/', post_to_archive=False, fpack=True, rlevel=91,
                  db_address='mysql://cmccully:password@localhost/test', log_level='INFO', preview_mode=False,
                  max_tries=5, post_to_elasticsearch=False, elasticsearch_url='http://elasticsearch.lco.gtn:9200',
@@ -34,6 +34,9 @@ class PipelineContext(object):
 
         for keyword in vars(command_line_args):
             super(PipelineContext, self).__setattr__(keyword, getattr(command_line_args, keyword))
+
+        for key, value in config.items():
+            super(PipelineContext, self).__setattr__(key, value)
 
     def __delattr__(self, item):
         raise TypeError('Deleting attribute is not allowed. PipelineContext is immutable')

--- a/banzai/context.py
+++ b/banzai/context.py
@@ -4,7 +4,9 @@ import importlib
 class TelescopeCriterion:
     def __init__(self, attribute, comparison_operator, comparison_value, exclude=False):
         self.attribute = attribute
-        self.comparison_operator = getattr(importlib.import_module(comparison_operator[0]), comparison_operator[1])
+        if not callable(comparison_operator):
+            comparison_operator = getattr(importlib.import_module(comparison_operator[0]), comparison_operator[1])
+        self.comparison_operator = comparison_operator
         self.comparison_value = comparison_value
         self.exclude = exclude
 
@@ -26,8 +28,6 @@ class PipelineContext(object):
                  elasticsearch_doc_type='qc', elasticsearch_qc_index='banzai_qc', **kwargs):
         # TODO: preview_mode will be removed once we start processing everything in real time.
         # TODO: no_bpm can also be removed once we are in "do our best" mode
-        allowed_instrument_criteria = [TelescopeCriterion(*args) for args in allowed_instrument_criteria]
-        image_class = getattr(importlib.import_module('banzai.'+image_class[0]), image_class[1])
         local_variables = locals()
         for variable in local_variables:
             if variable == 'kwargs':

--- a/banzai/context.py
+++ b/banzai/context.py
@@ -1,9 +1,12 @@
+import importlib
+
+
 class TelescopeCriterion:
     def __init__(self, attribute, comparison_operator, comparison_value, exclude=False):
         self.attribute = attribute
+        self.comparison_operator = getattr(importlib.import_module(comparison_operator[0]), comparison_operator[1])
         self.comparison_value = comparison_value
         self.exclude = exclude
-        self.comparison_operator = comparison_operator
 
     def telescope_passes(self, telescope):
         test = self.comparison_operator(getattr(telescope, self.attribute), self.comparison_value)
@@ -23,6 +26,8 @@ class PipelineContext(object):
                  elasticsearch_doc_type='qc', elasticsearch_qc_index='banzai_qc', **kwargs):
         # TODO: preview_mode will be removed once we start processing everything in real time.
         # TODO: no_bpm can also be removed once we are in "do our best" mode
+        allowed_instrument_criteria = [TelescopeCriterion(*args) for args in allowed_instrument_criteria]
+        image_class = getattr(importlib.import_module('banzai.'+image_class[0]), image_class[1])
         local_variables = locals()
         for variable in local_variables:
             if variable == 'kwargs':

--- a/banzai/context.py
+++ b/banzai/context.py
@@ -1,3 +1,6 @@
+import inspect
+
+
 class TelescopeCriterion:
     def __init__(self, attribute, comparison_operator, comparison_value, exclude=False):
         self.attribute = attribute
@@ -35,8 +38,9 @@ class PipelineContext(object):
         for keyword in vars(command_line_args):
             super(PipelineContext, self).__setattr__(keyword, getattr(command_line_args, keyword))
 
-        for key, value in config.items():
-            super(PipelineContext, self).__setattr__(key, value)
+        for key, value in dict(inspect.getmembers(config)).items():
+            if not key.startswith('_'):
+                super(PipelineContext, self).__setattr__(key, value)
 
     def __delattr__(self, item):
         raise TypeError('Deleting attribute is not allowed. PipelineContext is immutable')

--- a/banzai/context.py
+++ b/banzai/context.py
@@ -19,7 +19,7 @@ class TelescopeCriterion:
 
 
 class PipelineContext(object):
-    def __init__(self, command_line_args, config,
+    def __init__(self, command_line_args, settings,
                  processed_path='/archive/engineering/', post_to_archive=False, fpack=True, rlevel=91,
                  db_address='mysql://cmccully:password@localhost/test', log_level='INFO', preview_mode=False,
                  max_tries=5, post_to_elasticsearch=False, elasticsearch_url='http://elasticsearch.lco.gtn:9200',
@@ -38,7 +38,7 @@ class PipelineContext(object):
         for keyword in vars(command_line_args):
             super(PipelineContext, self).__setattr__(keyword, getattr(command_line_args, keyword))
 
-        for key, value in dict(inspect.getmembers(config)).items():
+        for key, value in dict(inspect.getmembers(settings)).items():
             if not key.startswith('_'):
                 super(PipelineContext, self).__setattr__(key, value)
 

--- a/banzai/dark.py
+++ b/banzai/dark.py
@@ -25,16 +25,8 @@ class DarkMaker(CalibrationStacker):
         super(DarkMaker, self).__init__(pipeline_context)
 
     @property
-    def group_by_attributes(self):
-        return ['ccdsum']
-
-    @property
     def calibration_type(self):
         return 'DARK'
-
-    @property
-    def min_images(self):
-        return 5
 
 
 class DarkSubtractor(ApplyCalibration):
@@ -44,10 +36,6 @@ class DarkSubtractor(ApplyCalibration):
     @property
     def calibration_type(self):
         return 'dark'
-
-    @property
-    def master_selection_criteria(self):
-        return ['ccdsum']
 
     def apply_master_calibration(self, images, master_calibration_image):
         master_dark_data = master_calibration_image.data
@@ -66,10 +54,6 @@ class DarkSubtractor(ApplyCalibration):
 class DarkComparer(CalibrationComparer):
     def __init__(self, pipeline_context):
         super(DarkComparer, self).__init__(pipeline_context)
-
-    @property
-    def master_selection_criteria(self):
-        return ['ccdsum']
 
     @property
     def calibration_type(self):

--- a/banzai/flats.py
+++ b/banzai/flats.py
@@ -34,14 +34,6 @@ class FlatMaker(CalibrationStacker):
     def calibration_type(self):
         return 'skyflat'
 
-    @property
-    def group_by_attributes(self):
-        return ['ccdsum', 'filter']
-
-    @property
-    def min_images(self):
-        return 5
-
     def make_master_calibration_frame(self, images):
         master_image = super(FlatMaker, self).make_master_calibration_frame(images)
         master_image.bpm = np.logical_or(master_image.bpm, master_image.data < 0.2)
@@ -53,10 +45,6 @@ class FlatDivider(ApplyCalibration):
     def __init__(self, pipeline_context):
 
         super(FlatDivider, self).__init__(pipeline_context)
-
-    @property
-    def master_selection_criteria(self):
-        return ['ccdsum', 'filter']
 
     @property
     def calibration_type(self):
@@ -81,10 +69,6 @@ class FlatDivider(ApplyCalibration):
 class FlatComparer(CalibrationComparer):
     def __init__(self, pipeline_context):
         super(FlatComparer, self).__init__(pipeline_context)
-
-    @property
-    def master_selection_criteria(self):
-        return ['ccdsum', 'filter']
 
     @property
     def calibration_type(self):

--- a/banzai/images.py
+++ b/banzai/images.py
@@ -205,7 +205,7 @@ def read_images(image_list, pipeline_context):
     images = []
     for filename in image_list:
         try:
-            image = pipeline_context.IMAGE_CLASS(pipeline_context, filename=filename)
+            image = pipeline_context.FRAME_CLASS(pipeline_context, filename=filename)
             if image.telescope is None:
                 logger.error("Image telescope attribute is None, removing from list", image=image)
                 continue

--- a/banzai/images.py
+++ b/banzai/images.py
@@ -205,7 +205,7 @@ def read_images(image_list, pipeline_context):
     images = []
     for filename in image_list:
         try:
-            image = pipeline_context.image_class(pipeline_context, filename=filename)
+            image = pipeline_context.IMAGE_CLASS(pipeline_context, filename=filename)
             if image.telescope is None:
                 logger.error("Image telescope attribute is None, removing from list", image=image)
                 continue

--- a/banzai/main.py
+++ b/banzai/main.py
@@ -14,7 +14,6 @@ import logging
 import copy
 import importlib
 import sys
-import inspect
 
 from kombu import Exchange, Connection, Queue
 from kombu.mixins import ConsumerMixin
@@ -120,8 +119,8 @@ def parse_args(settings_version="Imaging", extra_console_arguments=None,
 
     logs.set_log_level(args.log_level)
 
-    config = inspect.getmembers(vars(settings)[settings_version], lambda a: not (inspect.isroutine(a)))
-    config = dict([c for c in config if not (c[0].startswith('__') and c[0].endswith('__'))])
+    config = vars(settings)[settings_version]
+    config = {key: config[key] for key in dir(config) if not key.startswith('_')}
 
     selection_criteria = config.pop("INSTRUMENT_CRITERIA")
     schedulable_criteria = config.pop("SCHEDULABLE_CRITERIA")

--- a/banzai/main.py
+++ b/banzai/main.py
@@ -21,7 +21,7 @@ from lcogt_logging import LCOGTFormatter
 
 from banzai import settings
 from banzai import dbs, preview, logs
-from banzai.context import PipelineContext
+from banzai.context import PipelineContext, TelescopeCriterion
 from banzai.utils import image_utils, date_utils
 from banzai.images import read_images
 
@@ -121,6 +121,8 @@ def parse_args(selection_criteria, image_class, extra_console_arguments=None,
 
     if not args.ignore_schedulability:
         selection_criteria += settings.SCHEDULABLE_CRITERIA
+    selection_criteria = [TelescopeCriterion(*args) for args in selection_criteria]
+    image_class = getattr(importlib.import_module('banzai.' + image_class[0]), image_class[1])
 
     pipeline_context = PipelineContext(args, selection_criteria, image_class, **kwargs)
 

--- a/banzai/main.py
+++ b/banzai/main.py
@@ -120,7 +120,7 @@ def parse_args(settings_version="Imaging", extra_console_arguments=None,
     logs.set_log_level(args.log_level)
 
     config = vars(settings)[settings_version]
-    config = {key: config[key] for key in dir(config) if not key.startswith('_')}
+    config = {key: getattr(config, key) for key in dir(config) if not key.startswith('_')}
 
     selection_criteria = config.pop("INSTRUMENT_CRITERIA")
     schedulable_criteria = config.pop("SCHEDULABLE_CRITERIA")

--- a/banzai/main.py
+++ b/banzai/main.py
@@ -74,8 +74,7 @@ def get_stages_todo(pipeline_context, last_stage=None, extra_stages=None):
         last_index = pipeline_context.ORDERED_STAGES.index(last_stage) + 1
 
     stages_todo = pipeline_context.ORDERED_STAGES[:last_index] + extra_stages
-    stages_todo = [getattr(importlib.import_module('banzai.'+module_name), stage_name)
-                   for (module_name, stage_name) in stages_todo]
+
     return stages_todo
 
 
@@ -129,8 +128,6 @@ def parse_settings(settings_version, ignore_schedulability=False):
     config = vars(settings)[settings_version]()
     if not ignore_schedulability:
         config.SELECTION_CRITERIA += config.SCHEDULABLE_CRITERIA
-    config.SELECTION_CRITERIA = [TelescopeCriterion(*args) for args in config.SELECTION_CRITERIA]
-    config.IMAGE_CLASS = getattr(importlib.import_module('banzai.' + config.IMAGE_CLASS[0]), config.IMAGE_CLASS[1])
     config = {key: getattr(config, key) for key in dir(config) if not key.startswith('_')}
     return config
 

--- a/banzai/main.py
+++ b/banzai/main.py
@@ -127,7 +127,7 @@ def parse_args(settings_version="Imaging", extra_console_arguments=None,
 def parse_settings(settings_version, ignore_schedulability=False):
     config = vars(settings)[settings_version]()
     if not ignore_schedulability:
-        config.SELECTION_CRITERIA += config.SCHEDULABLE_CRITERIA
+        config.FRAME_SELECTION_CRITERIA += config.SCHEDULABLE_CRITERIA
     config = {key: getattr(config, key) for key in dir(config) if not key.startswith('_')}
     return config
 
@@ -153,7 +153,7 @@ def process_directory(pipeline_context, raw_path, image_types=None, last_stage=N
     stages_to_do = get_stages_todo(pipeline_context, last_stage, extra_stages=extra_stages)
     image_list = image_utils.make_image_list(raw_path)
     image_list = image_utils.select_images(image_list, image_types,
-                                           pipeline_context.SELECTION_CRITERIA,
+                                           pipeline_context.FRAME_SELECTION_CRITERIA,
                                            db_address=pipeline_context.db_address)
     if calibration_maker:
         try:

--- a/banzai/main.py
+++ b/banzai/main.py
@@ -174,7 +174,7 @@ def process_directory(pipeline_context, raw_path, image_types=None, last_stage=N
 def process_single_frame(pipeline_context, raw_path, filename, last_stage=None, extra_stages=None, log_message=''):
     if len(log_message) > 0:
         logger.info(log_message, extra_tags={'raw_path': raw_path, 'filename': filename})
-    stages_to_do = get_stages_todo(last_stage, extra_stages=extra_stages)
+    stages_to_do = get_stages_todo(pipeline_context, last_stage, extra_stages=extra_stages)
     try:
         run(stages_to_do, [os.path.join(raw_path, filename)], pipeline_context, calibration_maker=False)
     except Exception:
@@ -304,18 +304,21 @@ def reduce_night():
             logger.error(logs.format_exception())
 
 
-def get_preview_stages_todo(pipline_context, image_suffix):
-    if image_suffix in pipline_context.BIAS_SUFFIXES:
-        stages = get_stages_todo(last_stage=pipline_context.BIAS_LAST_STAGE,
-                                 extra_stages=pipline_context.BIAS_EXTRA_STAGES_PREVIEW)
-    elif image_suffix in pipline_context.DARK_SUFFIXES:
-        stages = get_stages_todo(last_stage=pipline_context.DARK_LAST_STAGE,
-                                 extra_stages=pipline_context.DARK_EXTRA_STAGES_PREVIEW)
-    elif image_suffix in pipline_context.FLAT_SUFFIXES:
-        stages = get_stages_todo(last_stage=pipline_context.FLAT_LAST_STAGE,
-                                 extra_stages=pipline_context.FLAT_EXTRA_STAGES_PREVIEW)
+def get_preview_stages_todo(pipeline_context, image_suffix):
+    if image_suffix in pipeline_context.BIAS_SUFFIXES:
+        stages = get_stages_todo(pipeline_context,
+                                 last_stage=pipeline_context.BIAS_LAST_STAGE,
+                                 extra_stages=pipeline_context.BIAS_EXTRA_STAGES_PREVIEW)
+    elif image_suffix in pipeline_context.DARK_SUFFIXES:
+        stages = get_stages_todo(pipeline_context,
+                                 last_stage=pipeline_context.DARK_LAST_STAGE,
+                                 extra_stages=pipeline_context.DARK_EXTRA_STAGES_PREVIEW)
+    elif image_suffix in pipeline_context.FLAT_SUFFIXES:
+        stages = get_stages_todo(pipeline_context,
+                                 last_stage=pipeline_context.FLAT_LAST_STAGE,
+                                 extra_stages=pipeline_context.FLAT_EXTRA_STAGES_PREVIEW)
     else:
-        stages = get_stages_todo()
+        stages = get_stages_todo(pipeline_context)
     return stages
 
 

--- a/banzai/settings.py
+++ b/banzai/settings.py
@@ -1,7 +1,28 @@
 import operator
+from abc import ABC
 
 
-class Settings:
+class Settings(ABC):
+
+    @property
+    def SELECTION_CRITERIA(self):
+        raise NotImplementedError
+
+    @property
+    def IMAGE_CLASS(self):
+        raise NotImplementedError
+
+    @property
+    def ORDERED_STAGES(self):
+        raise NotImplementedError
+
+    @property
+    def CALIBRATION_MIN_IMAGES(self):
+        raise NotImplementedError
+
+    @property
+    def GROUP_BY_ATTRIBUTES(self):
+        raise NotImplementedError
 
     SCHEDULABLE_CRITERIA = [('schedulable', operator.eq, True)]
 
@@ -22,15 +43,15 @@ class Settings:
     EXPERIMENTAL_IMAGE_TYPES = ['EXPERIMENTAL']
 
     SINISTRO_IMAGE_TYPES = SCIENCE_IMAGE_TYPES + BIAS_IMAGE_TYPES + DARK_IMAGE_TYPES + FLAT_IMAGE_TYPES +\
-    TRAILED_IMAGE_TYPES + EXPERIMENTAL_IMAGE_TYPES
+        TRAILED_IMAGE_TYPES + EXPERIMENTAL_IMAGE_TYPES
 
     PREVIEW_ELIGIBLE_SUFFIXES = SCIENCE_SUFFIXES + BIAS_SUFFIXES + DARK_SUFFIXES + FLAT_SUFFIXES
 
 
 class Imaging(Settings):
 
-    INSTRUMENT_CRITERIA = [('camera_type', operator.contains, 'FLOYDS', True),
-                           ('camera_type', operator.contains, 'NRES', True)]
+    SELECTION_CRITERIA = [('camera_type', operator.contains, 'FLOYDS', True),
+                          ('camera_type', operator.contains, 'NRES', True)]
 
     IMAGE_CLASS = ('images', 'Image')
 
@@ -51,6 +72,13 @@ class Imaging(Settings):
                       ('astrometry', 'WCSSolver'),
                       ('qc', 'PointingTest')]
 
+    CALIBRATION_MIN_IMAGES = 5
+    GROUP_BY_ATTRIBUTES = {
+        'BIAS': ['ccdsum'],
+        'DARK': ['ccdsum'],
+        'SKYFLAT': ['ccdsum', 'filter']
+    }
+
     BIAS_LAST_STAGE = ('trim', 'Trimmer')
     BIAS_EXTRA_STAGES = [('bias', 'BiasMasterLevelSubtractor'), ('bias', 'BiasComparer'), ('bias', 'BiasMaker')]
     BIAS_EXTRA_STAGES_PREVIEW = [('bias', 'BiasMasterLevelSubtractor'),  ('bias', 'BiasComparer')]
@@ -65,10 +93,3 @@ class Imaging(Settings):
     FLAT_EXTRA_STAGES_PREVIEW = [('flats', 'FlatNormalizer'), ('qc', 'PatternNoiseDetector'), ('flats', 'FlatComparer')]
 
     SINISTRO_LAST_STAGE = ('mosaic', 'MosaicCreator')
-
-    CALIBRATION_MIN_IMAGES = 5
-    GROUP_BY_ATTRIBUTES = {
-        'BIAS': ['ccdsum'],
-        'DARK': ['ccdsum'],
-        'SKYFLAT': ['ccdsum', 'filter']
-    }

--- a/banzai/settings.py
+++ b/banzai/settings.py
@@ -8,11 +8,11 @@ from banzai import qc, bias, crosstalk, gain, mosaic, bpm, trim, dark, flats, ph
 class Settings(ABC):
 
     @property
-    def SELECTION_CRITERIA(self):
+    def FRAME_SELECTION_CRITERIA(self):
         raise NotImplementedError
 
     @property
-    def IMAGE_CLASS(self):
+    def FRAME_CLASS(self):
         raise NotImplementedError
 
     @property
@@ -24,7 +24,7 @@ class Settings(ABC):
         raise NotImplementedError
 
     @property
-    def GROUP_BY_ATTRIBUTES(self):
+    def CALIBRATION_SET_CRITERIA(self):
         raise NotImplementedError
 
     SCHEDULABLE_CRITERIA = [TelescopeCriterion('schedulable', operator.eq, True)]
@@ -53,10 +53,10 @@ class Settings(ABC):
 
 class Imaging(Settings):
 
-    SELECTION_CRITERIA = [TelescopeCriterion('camera_type', operator.contains, 'FLOYDS', exclude=True),
-                          TelescopeCriterion('camera_type', operator.contains, 'NRES', exclude=True)]
+    FRAME_SELECTION_CRITERIA = [TelescopeCriterion('camera_type', operator.contains, 'FLOYDS', exclude=True),
+                                TelescopeCriterion('camera_type', operator.contains, 'NRES', exclude=True)]
 
-    IMAGE_CLASS = images.Image
+    FRAME_CLASS = images.Image
 
     ORDERED_STAGES = [bpm.BPMUpdater,
                       qc.HeaderSanity,
@@ -75,9 +75,13 @@ class Imaging(Settings):
                       astrometry.WCSSolver,
                       qc.pointing.PointingTest]
 
-    CALIBRATION_MIN_IMAGES = 5
+    CALIBRATION_MIN_IMAGES = {
+        'BIAS': 5,
+        'DARK': 5,
+        'SKYFLAT': 5,
+    }
 
-    GROUP_BY_ATTRIBUTES = {
+    CALIBRATION_SET_CRITERIA = {
         'BIAS': ['ccdsum'],
         'DARK': ['ccdsum'],
         'SKYFLAT': ['ccdsum', 'filter']

--- a/banzai/settings.py
+++ b/banzai/settings.py
@@ -51,7 +51,7 @@ class Settings(ABC):
     PREVIEW_ELIGIBLE_SUFFIXES = SCIENCE_SUFFIXES + BIAS_SUFFIXES + DARK_SUFFIXES + FLAT_SUFFIXES
 
 
-class Imaging(Settings):
+class ImagingSettings(Settings):
 
     FRAME_SELECTION_CRITERIA = [TelescopeCriterion('camera_type', operator.contains, 'FLOYDS', exclude=True),
                                 TelescopeCriterion('camera_type', operator.contains, 'NRES', exclude=True)]

--- a/banzai/settings.py
+++ b/banzai/settings.py
@@ -1,79 +1,55 @@
-import sys
-import logging
-import operator
+INSTRUMENT_CRITERIA = [('camera_type', ('operator', 'contains'), 'FLOYDS', True),
+                    ('camera_type', ('operator', 'contains'), 'NRES', True)]
 
-from lcogt_logging import LCOGTFormatter
+SCHEDULABLE_CRITERIA = [('schedulable', ('operator', 'eq'), True)]
 
-from banzai.context import TelescopeCriterion
-from banzai import qc, bias, crosstalk, gain, mosaic, bpm, trim, dark, flats, photometry, astrometry, images
+IMAGE_CLASS = ('images', 'Image')
 
-
-# Logger set up
-logging.captureWarnings(True)
-
-# Set up the root logger
-root_logger = logging.getLogger()
-root_handler = logging.StreamHandler(sys.stdout)
-
-# Add handler
-formatter = LCOGTFormatter()
-root_handler.setFormatter(formatter)
-root_handler.setLevel(getattr(logging, 'DEBUG'))
-root_logger.addHandler(root_handler)
-
-# Stage and image type settings
-
-IMAGING_CRITERIA = [TelescopeCriterion('camera_type', operator.contains, 'FLOYDS', exclude=True),
-                    TelescopeCriterion('camera_type', operator.contains, 'NRES', exclude=True)]
-
-SCHEDULABLE_CRITERIA = [TelescopeCriterion('schedulable', operator.eq, True)]
-
-ORDERED_STAGES = [bpm.BPMUpdater,
-                  qc.HeaderSanity,
-                  qc.ThousandsTest,
-                  qc.SaturationTest,
-                  bias.OverscanSubtractor,
-                  crosstalk.CrosstalkCorrector,
-                  gain.GainNormalizer,
-                  mosaic.MosaicCreator,
-                  trim.Trimmer,
-                  bias.BiasSubtractor,
-                  dark.DarkSubtractor,
-                  flats.FlatDivider,
-                  qc.PatternNoiseDetector,
-                  photometry.SourceDetector,
-                  astrometry.WCSSolver,
-                  qc.pointing.PointingTest]
+ORDERED_STAGES = [('bpm', 'BPMUpdater'),
+                  ('qc', 'HeaderSanity'),
+                  ('qc', 'ThousandsTest'),
+                  ('qc', 'SaturationTest'),
+                  ('bias', 'OverscanSubtractor'),
+                  ('crosstalk', 'CrosstalkCorrector'),
+                  ('gain', 'GainNormalizer'),
+                  ('mosaic', 'MosaicCreator'),
+                  ('trim', 'Trimmer'),
+                  ('bias', 'BiasSubtractor'),
+                  ('dark', 'DarkSubtractor'),
+                  ('flats', 'FlatDivider'),
+                  ('qc', 'PatternNoiseDetector'),
+                  ('photometry', 'SourceDetector'),
+                  ('astrometry', 'WCSSolver'),
+                  ('qc', 'PointingTest')]
 
 
 BIAS_IMAGE_TYPES = ['BIAS']
 BIAS_SUFFIXES = ['b00.fits']
-BIAS_LAST_STAGE = trim.Trimmer
-BIAS_EXTRA_STAGES = [bias.BiasMasterLevelSubtractor, bias.BiasComparer, bias.BiasMaker]
-BIAS_EXTRA_STAGES_PREVIEW = [bias.BiasMasterLevelSubtractor, bias.BiasComparer]
+BIAS_LAST_STAGE = ('trim', 'Trimmer')
+BIAS_EXTRA_STAGES = [('bias', 'BiasMasterLevelSubtractor'), ('bias', 'BiasComparer'), ('bias', 'BiasMaker')]
+BIAS_EXTRA_STAGES_PREVIEW = [('bias', 'BiasMasterLevelSubtractor'),  ('bias', 'BiasComparer')]
 
 DARK_IMAGE_TYPES = ['DARK']
 DARK_SUFFIXES = ['d00.fits']
-DARK_LAST_STAGE = bias.BiasSubtractor
-DARK_EXTRA_STAGES = [dark.DarkNormalizer, dark.DarkComparer, dark.DarkMaker]
-DARK_EXTRA_STAGES_PREVIEW = [dark.DarkNormalizer, dark.DarkComparer]
+DARK_LAST_STAGE = ('bias', 'BiasSubtractor')
+DARK_EXTRA_STAGES = [('dark', 'DarkNormalizer'), ('dark', 'DarkComparer'), ('dark', 'DarkMaker')]
+DARK_EXTRA_STAGES_PREVIEW = [('dark', 'DarkNormalizer'), ('dark', 'DarkComparer')]
 
 FLAT_IMAGE_TYPES = ['SKYFLAT']
 FLAT_SUFFIXES = ['f00.fits']
-FLAT_LAST_STAGE = dark.DarkSubtractor
-FLAT_EXTRA_STAGES = [flats.FlatNormalizer, qc.PatternNoiseDetector, flats.FlatComparer, flats.FlatMaker]
-FLAT_EXTRA_STAGES_PREVIEW = [flats.FlatNormalizer, qc.PatternNoiseDetector, flats.FlatComparer]
+FLAT_LAST_STAGE = ('dark', 'DarkSubtractor')
+FLAT_EXTRA_STAGES = [('flats', 'FlatNormalizer'), ('qc', 'PatternNoiseDetector'), ('flats', 'FlatComparer'),
+                     ('flats', 'FlatMaker')]
+FLAT_EXTRA_STAGES_PREVIEW = [('flats', 'FlatNormalizer'), ('qc', 'PatternNoiseDetector'), ('flats', 'FlatComparer')]
 
 TRAILED_IMAGE_TYPES = ['TRAILED']
 
 EXPERIMENTAL_IMAGE_TYPES = ['EXPERIMENTAL']
 
 SINISTRO_IMAGE_TYPES = ['EXPOSE', 'STANDARD', 'BIAS', 'DARK', 'SKYFLAT', 'TRAILED', 'EXPERIMENTAL']
-SINISTRO_LAST_STAGE = mosaic.MosaicCreator
+SINISTRO_LAST_STAGE = ('mosaic', 'MosaicCreator')
 
 SCIENCE_IMAGE_TYPES = ['EXPOSE', 'STANDARD']
 SCIENCE_SUFFIXES = ['e00.fits', 's00.fits']
 
 PREVIEW_ELIGIBLE_SUFFIXES = SCIENCE_SUFFIXES + BIAS_SUFFIXES + DARK_SUFFIXES + FLAT_SUFFIXES
-
-IMAGE_CLASS = images.Image

--- a/banzai/settings.py
+++ b/banzai/settings.py
@@ -1,55 +1,74 @@
-INSTRUMENT_CRITERIA = [('camera_type', ('operator', 'contains'), 'FLOYDS', True),
-                    ('camera_type', ('operator', 'contains'), 'NRES', True)]
-
-SCHEDULABLE_CRITERIA = [('schedulable', ('operator', 'eq'), True)]
-
-IMAGE_CLASS = ('images', 'Image')
-
-ORDERED_STAGES = [('bpm', 'BPMUpdater'),
-                  ('qc', 'HeaderSanity'),
-                  ('qc', 'ThousandsTest'),
-                  ('qc', 'SaturationTest'),
-                  ('bias', 'OverscanSubtractor'),
-                  ('crosstalk', 'CrosstalkCorrector'),
-                  ('gain', 'GainNormalizer'),
-                  ('mosaic', 'MosaicCreator'),
-                  ('trim', 'Trimmer'),
-                  ('bias', 'BiasSubtractor'),
-                  ('dark', 'DarkSubtractor'),
-                  ('flats', 'FlatDivider'),
-                  ('qc', 'PatternNoiseDetector'),
-                  ('photometry', 'SourceDetector'),
-                  ('astrometry', 'WCSSolver'),
-                  ('qc', 'PointingTest')]
+import operator
 
 
-BIAS_IMAGE_TYPES = ['BIAS']
-BIAS_SUFFIXES = ['b00.fits']
-BIAS_LAST_STAGE = ('trim', 'Trimmer')
-BIAS_EXTRA_STAGES = [('bias', 'BiasMasterLevelSubtractor'), ('bias', 'BiasComparer'), ('bias', 'BiasMaker')]
-BIAS_EXTRA_STAGES_PREVIEW = [('bias', 'BiasMasterLevelSubtractor'),  ('bias', 'BiasComparer')]
+class Settings:
 
-DARK_IMAGE_TYPES = ['DARK']
-DARK_SUFFIXES = ['d00.fits']
-DARK_LAST_STAGE = ('bias', 'BiasSubtractor')
-DARK_EXTRA_STAGES = [('dark', 'DarkNormalizer'), ('dark', 'DarkComparer'), ('dark', 'DarkMaker')]
-DARK_EXTRA_STAGES_PREVIEW = [('dark', 'DarkNormalizer'), ('dark', 'DarkComparer')]
+    SCHEDULABLE_CRITERIA = [('schedulable', operator.eq, True)]
 
-FLAT_IMAGE_TYPES = ['SKYFLAT']
-FLAT_SUFFIXES = ['f00.fits']
-FLAT_LAST_STAGE = ('dark', 'DarkSubtractor')
-FLAT_EXTRA_STAGES = [('flats', 'FlatNormalizer'), ('qc', 'PatternNoiseDetector'), ('flats', 'FlatComparer'),
-                     ('flats', 'FlatMaker')]
-FLAT_EXTRA_STAGES_PREVIEW = [('flats', 'FlatNormalizer'), ('qc', 'PatternNoiseDetector'), ('flats', 'FlatComparer')]
+    BIAS_IMAGE_TYPES = ['BIAS']
+    BIAS_SUFFIXES = ['b00.fits']
 
-TRAILED_IMAGE_TYPES = ['TRAILED']
+    DARK_IMAGE_TYPES = ['DARK']
+    DARK_SUFFIXES = ['d00.fits']
 
-EXPERIMENTAL_IMAGE_TYPES = ['EXPERIMENTAL']
+    FLAT_IMAGE_TYPES = ['SKYFLAT']
+    FLAT_SUFFIXES = ['f00.fits']
 
-SINISTRO_IMAGE_TYPES = ['EXPOSE', 'STANDARD', 'BIAS', 'DARK', 'SKYFLAT', 'TRAILED', 'EXPERIMENTAL']
-SINISTRO_LAST_STAGE = ('mosaic', 'MosaicCreator')
+    SCIENCE_IMAGE_TYPES = ['EXPOSE', 'STANDARD']
+    SCIENCE_SUFFIXES = ['e00.fits', 's00.fits']
 
-SCIENCE_IMAGE_TYPES = ['EXPOSE', 'STANDARD']
-SCIENCE_SUFFIXES = ['e00.fits', 's00.fits']
+    TRAILED_IMAGE_TYPES = ['TRAILED']
 
-PREVIEW_ELIGIBLE_SUFFIXES = SCIENCE_SUFFIXES + BIAS_SUFFIXES + DARK_SUFFIXES + FLAT_SUFFIXES
+    EXPERIMENTAL_IMAGE_TYPES = ['EXPERIMENTAL']
+
+    SINISTRO_IMAGE_TYPES = SCIENCE_IMAGE_TYPES + BIAS_IMAGE_TYPES + DARK_IMAGE_TYPES + FLAT_IMAGE_TYPES +\
+    TRAILED_IMAGE_TYPES + EXPERIMENTAL_IMAGE_TYPES
+
+    PREVIEW_ELIGIBLE_SUFFIXES = SCIENCE_SUFFIXES + BIAS_SUFFIXES + DARK_SUFFIXES + FLAT_SUFFIXES
+
+
+class Imaging(Settings):
+
+    INSTRUMENT_CRITERIA = [('camera_type', operator.contains, 'FLOYDS', True),
+                           ('camera_type', operator.contains, 'NRES', True)]
+
+    IMAGE_CLASS = ('images', 'Image')
+
+    ORDERED_STAGES = [('bpm', 'BPMUpdater'),
+                      ('qc', 'HeaderSanity'),
+                      ('qc', 'ThousandsTest'),
+                      ('qc', 'SaturationTest'),
+                      ('bias', 'OverscanSubtractor'),
+                      ('crosstalk', 'CrosstalkCorrector'),
+                      ('gain', 'GainNormalizer'),
+                      ('mosaic', 'MosaicCreator'),
+                      ('trim', 'Trimmer'),
+                      ('bias', 'BiasSubtractor'),
+                      ('dark', 'DarkSubtractor'),
+                      ('flats', 'FlatDivider'),
+                      ('qc', 'PatternNoiseDetector'),
+                      ('photometry', 'SourceDetector'),
+                      ('astrometry', 'WCSSolver'),
+                      ('qc', 'PointingTest')]
+
+    BIAS_LAST_STAGE = ('trim', 'Trimmer')
+    BIAS_EXTRA_STAGES = [('bias', 'BiasMasterLevelSubtractor'), ('bias', 'BiasComparer'), ('bias', 'BiasMaker')]
+    BIAS_EXTRA_STAGES_PREVIEW = [('bias', 'BiasMasterLevelSubtractor'),  ('bias', 'BiasComparer')]
+
+    DARK_LAST_STAGE = ('bias', 'BiasSubtractor')
+    DARK_EXTRA_STAGES = [('dark', 'DarkNormalizer'), ('dark', 'DarkComparer'), ('dark', 'DarkMaker')]
+    DARK_EXTRA_STAGES_PREVIEW = [('dark', 'DarkNormalizer'), ('dark', 'DarkComparer')]
+
+    FLAT_LAST_STAGE = ('dark', 'DarkSubtractor')
+    FLAT_EXTRA_STAGES = [('flats', 'FlatNormalizer'), ('qc', 'PatternNoiseDetector'), ('flats', 'FlatComparer'),
+                         ('flats', 'FlatMaker')]
+    FLAT_EXTRA_STAGES_PREVIEW = [('flats', 'FlatNormalizer'), ('qc', 'PatternNoiseDetector'), ('flats', 'FlatComparer')]
+
+    SINISTRO_LAST_STAGE = ('mosaic', 'MosaicCreator')
+
+    CALIBRATION_MIN_IMAGES = 5
+    GROUP_BY_ATTRIBUTES = {
+        'BIAS': ['ccdsum'],
+        'DARK': ['ccdsum'],
+        'SKYFLAT': ['ccdsum', 'filter']
+    }

--- a/banzai/settings.py
+++ b/banzai/settings.py
@@ -1,31 +1,36 @@
 import operator
-from abc import ABC
+import abc
 
 from banzai.context import TelescopeCriterion
 from banzai import qc, bias, crosstalk, gain, mosaic, bpm, trim, dark, flats, photometry, astrometry, images
 
 
-class Settings(ABC):
+class Settings(abc.ABC):
 
     @property
+    @abc.abstractmethod
     def FRAME_SELECTION_CRITERIA(self):
-        raise NotImplementedError
+        pass
 
     @property
+    @abc.abstractmethod
     def FRAME_CLASS(self):
-        raise NotImplementedError
+        pass
 
     @property
+    @abc.abstractmethod
     def ORDERED_STAGES(self):
-        raise NotImplementedError
+        pass
 
     @property
+    @abc.abstractmethod
     def CALIBRATION_MIN_IMAGES(self):
-        raise NotImplementedError
+        pass
 
     @property
+    @abc.abstractmethod
     def CALIBRATION_SET_CRITERIA(self):
-        raise NotImplementedError
+        pass
 
     SCHEDULABLE_CRITERIA = [TelescopeCriterion('schedulable', operator.eq, True)]
 

--- a/banzai/settings.py
+++ b/banzai/settings.py
@@ -1,6 +1,9 @@
 import operator
 from abc import ABC
 
+from banzai.context import TelescopeCriterion
+from banzai import qc, bias, crosstalk, gain, mosaic, bpm, trim, dark, flats, photometry, astrometry, images
+
 
 class Settings(ABC):
 
@@ -24,7 +27,7 @@ class Settings(ABC):
     def GROUP_BY_ATTRIBUTES(self):
         raise NotImplementedError
 
-    SCHEDULABLE_CRITERIA = [('schedulable', operator.eq, True)]
+    SCHEDULABLE_CRITERIA = [TelescopeCriterion('schedulable', operator.eq, True)]
 
     BIAS_IMAGE_TYPES = ['BIAS']
     BIAS_SUFFIXES = ['b00.fits']
@@ -50,46 +53,46 @@ class Settings(ABC):
 
 class Imaging(Settings):
 
-    SELECTION_CRITERIA = [('camera_type', operator.contains, 'FLOYDS', True),
-                          ('camera_type', operator.contains, 'NRES', True)]
+    SELECTION_CRITERIA = [TelescopeCriterion('camera_type', operator.contains, 'FLOYDS', exclude=True),
+                          TelescopeCriterion('camera_type', operator.contains, 'NRES', exclude=True)]
 
-    IMAGE_CLASS = ('images', 'Image')
+    IMAGE_CLASS = images.Image
 
-    ORDERED_STAGES = [('bpm', 'BPMUpdater'),
-                      ('qc', 'HeaderSanity'),
-                      ('qc', 'ThousandsTest'),
-                      ('qc', 'SaturationTest'),
-                      ('bias', 'OverscanSubtractor'),
-                      ('crosstalk', 'CrosstalkCorrector'),
-                      ('gain', 'GainNormalizer'),
-                      ('mosaic', 'MosaicCreator'),
-                      ('trim', 'Trimmer'),
-                      ('bias', 'BiasSubtractor'),
-                      ('dark', 'DarkSubtractor'),
-                      ('flats', 'FlatDivider'),
-                      ('qc', 'PatternNoiseDetector'),
-                      ('photometry', 'SourceDetector'),
-                      ('astrometry', 'WCSSolver'),
-                      ('qc', 'PointingTest')]
+    ORDERED_STAGES = [bpm.BPMUpdater,
+                      qc.HeaderSanity,
+                      qc.ThousandsTest,
+                      qc.SaturationTest,
+                      bias.OverscanSubtractor,
+                      crosstalk.CrosstalkCorrector,
+                      gain.GainNormalizer,
+                      mosaic.MosaicCreator,
+                      trim.Trimmer,
+                      bias.BiasSubtractor,
+                      dark.DarkSubtractor,
+                      flats.FlatDivider,
+                      qc.PatternNoiseDetector,
+                      photometry.SourceDetector,
+                      astrometry.WCSSolver,
+                      qc.pointing.PointingTest]
 
     CALIBRATION_MIN_IMAGES = 5
+
     GROUP_BY_ATTRIBUTES = {
         'BIAS': ['ccdsum'],
         'DARK': ['ccdsum'],
         'SKYFLAT': ['ccdsum', 'filter']
     }
 
-    BIAS_LAST_STAGE = ('trim', 'Trimmer')
-    BIAS_EXTRA_STAGES = [('bias', 'BiasMasterLevelSubtractor'), ('bias', 'BiasComparer'), ('bias', 'BiasMaker')]
-    BIAS_EXTRA_STAGES_PREVIEW = [('bias', 'BiasMasterLevelSubtractor'),  ('bias', 'BiasComparer')]
+    BIAS_LAST_STAGE = trim.Trimmer
+    BIAS_EXTRA_STAGES = [bias.BiasMasterLevelSubtractor, bias.BiasComparer, bias.BiasMaker]
+    BIAS_EXTRA_STAGES_PREVIEW = [bias.BiasMasterLevelSubtractor, bias.BiasComparer]
 
-    DARK_LAST_STAGE = ('bias', 'BiasSubtractor')
-    DARK_EXTRA_STAGES = [('dark', 'DarkNormalizer'), ('dark', 'DarkComparer'), ('dark', 'DarkMaker')]
-    DARK_EXTRA_STAGES_PREVIEW = [('dark', 'DarkNormalizer'), ('dark', 'DarkComparer')]
+    DARK_LAST_STAGE = bias.BiasSubtractor
+    DARK_EXTRA_STAGES = [dark.DarkNormalizer, dark.DarkComparer, dark.DarkMaker]
+    DARK_EXTRA_STAGES_PREVIEW = [dark.DarkNormalizer, dark.DarkComparer]
 
-    FLAT_LAST_STAGE = ('dark', 'DarkSubtractor')
-    FLAT_EXTRA_STAGES = [('flats', 'FlatNormalizer'), ('qc', 'PatternNoiseDetector'), ('flats', 'FlatComparer'),
-                         ('flats', 'FlatMaker')]
-    FLAT_EXTRA_STAGES_PREVIEW = [('flats', 'FlatNormalizer'), ('qc', 'PatternNoiseDetector'), ('flats', 'FlatComparer')]
+    FLAT_LAST_STAGE = dark.DarkSubtractor
+    FLAT_EXTRA_STAGES = [flats.FlatNormalizer, qc.PatternNoiseDetector, flats.FlatComparer, flats.FlatMaker]
+    FLAT_EXTRA_STAGES_PREVIEW = [flats.FlatNormalizer, qc.PatternNoiseDetector, flats.FlatComparer]
 
-    SINISTRO_LAST_STAGE = ('mosaic', 'MosaicCreator')
+    SINISTRO_LAST_STAGE = mosaic.MosaicCreator

--- a/banzai/tests/test_bias_comparer.py
+++ b/banzai/tests/test_bias_comparer.py
@@ -18,13 +18,13 @@ class FakeBiasImage(FakeImage):
 
 
 def test_no_input_images(set_random_seed):
-    comparer = BiasComparer(None)
+    comparer = BiasComparer(FakeContext())
     images = comparer.do_stage([])
     assert len(images) == 0
 
 
 def test_master_selection_criteria(set_random_seed):
-    comparer = BiasComparer(None)
+    comparer = BiasComparer(FakeContext())
     assert comparer.master_selection_criteria == ['ccdsum']
 
 

--- a/banzai/tests/test_bias_maker.py
+++ b/banzai/tests/test_bias_maker.py
@@ -16,13 +16,13 @@ class FakeBiasImage(FakeImage):
 
 
 def test_min_images():
-    bias_maker = BiasMaker(None)
+    bias_maker = BiasMaker(FakeContext())
     processed_images = bias_maker.do_stage([])
     assert len(processed_images) == 0
 
 
 def test_group_by_attributes():
-    maker = BiasMaker(None)
+    maker = BiasMaker(FakeContext())
     assert maker.group_by_attributes == ['ccdsum']
 
 

--- a/banzai/tests/test_bias_subtractor.py
+++ b/banzai/tests/test_bias_subtractor.py
@@ -3,7 +3,7 @@ import mock
 import numpy as np
 
 from banzai.bias import BiasSubtractor
-from banzai.tests.utils import FakeImage, throws_inhomogeneous_set_exception
+from banzai.tests.utils import FakeImage, throws_inhomogeneous_set_exception, FakeContext
 from banzai.calibrations import MasterCalibrationDoesNotExist
 
 
@@ -14,13 +14,13 @@ class FakeBiasImage(FakeImage):
 
 
 def test_no_input_images():
-    subtractor = BiasSubtractor(None)
+    subtractor = BiasSubtractor(FakeContext())
     images = subtractor.do_stage([])
     assert len(images) == 0
 
 
 def test_master_selection_criteria():
-    subtractor = BiasSubtractor(None)
+    subtractor = BiasSubtractor(FakeContext())
     assert subtractor.master_selection_criteria == ['ccdsum']
 
 
@@ -28,7 +28,7 @@ def test_master_selection_criteria():
 @mock.patch('banzai.calibrations.ApplyCalibration.get_calibration_filename')
 def test_header_has_biaslevel(mock_cal, mock_image):
     mock_image.return_value = FakeBiasImage()
-    subtractor = BiasSubtractor(None)
+    subtractor = BiasSubtractor(FakeContext())
     images = subtractor.do_stage([FakeImage() for x in range(6)])
     for image in images:
         assert image.header.get('BIASLVL') == 0
@@ -38,7 +38,7 @@ def test_header_has_biaslevel(mock_cal, mock_image):
 @mock.patch('banzai.calibrations.ApplyCalibration.get_calibration_filename')
 def test_header_biaslevel_is_1(mock_cal, mock_image):
     mock_image.return_value = FakeBiasImage(bias_level=1)
-    subtractor = BiasSubtractor(None)
+    subtractor = BiasSubtractor(FakeContext())
     images = subtractor.do_stage([FakeImage() for x in range(6)])
     for image in images:
         assert image.header.get('BIASLVL') == 1
@@ -48,7 +48,7 @@ def test_header_biaslevel_is_1(mock_cal, mock_image):
 @mock.patch('banzai.calibrations.ApplyCalibration.get_calibration_filename')
 def test_header_biaslevel_is_2(mock_cal, mock_image):
     mock_image.return_value = FakeBiasImage(bias_level=2.0)
-    subtractor = BiasSubtractor(None)
+    subtractor = BiasSubtractor(FakeContext())
     images = subtractor.do_stage([FakeImage() for x in range(6)])
     for image in images:
         assert image.header.get('BIASLVL') == 2
@@ -57,27 +57,27 @@ def test_header_biaslevel_is_2(mock_cal, mock_image):
 @mock.patch('banzai.calibrations.Image')
 @mock.patch('banzai.calibrations.ApplyCalibration.get_calibration_filename')
 def test_raises_an_exception_if_ccdsums_are_different(mock_cal, mock_images):
-    throws_inhomogeneous_set_exception(BiasSubtractor, None, 'ccdsum', '1 1')
+    throws_inhomogeneous_set_exception(BiasSubtractor, FakeContext(), 'ccdsum', '1 1')
 
 
 @mock.patch('banzai.calibrations.Image')
 @mock.patch('banzai.calibrations.ApplyCalibration.get_calibration_filename')
 def test_raises_an_exception_if_epochs_are_different(mock_cal, mock_images):
-    throws_inhomogeneous_set_exception(BiasSubtractor, None, 'epoch', '20160102')
+    throws_inhomogeneous_set_exception(BiasSubtractor, FakeContext(), 'epoch', '20160102')
 
 
 @mock.patch('banzai.calibrations.Image')
 @mock.patch('banzai.calibrations.ApplyCalibration.get_calibration_filename')
 def test_raises_an_exception_if_nx_are_different(mock_cal, mock_images):
     mock_cal.return_value = 'test.fits'
-    throws_inhomogeneous_set_exception(BiasSubtractor, None, 'nx', 105)
+    throws_inhomogeneous_set_exception(BiasSubtractor, FakeContext(), 'nx', 105)
 
 
 @mock.patch('banzai.calibrations.Image')
 @mock.patch('banzai.calibrations.ApplyCalibration.get_calibration_filename')
 def test_raises_an_exception_if_ny_are_different(mock_cal, mock_images):
     mock_cal.return_value = 'test.fits'
-    throws_inhomogeneous_set_exception(BiasSubtractor, None, 'ny', 107)
+    throws_inhomogeneous_set_exception(BiasSubtractor, FakeContext(), 'ny', 107)
 
 
 @mock.patch('banzai.calibrations.Image')
@@ -85,7 +85,7 @@ def test_raises_an_exception_if_ny_are_different(mock_cal, mock_images):
 def test_raises_exception_if_no_master_calibration(mock_cal, mock_images):
     mock_cal.return_value = None
     mock_images.return_value = FakeBiasImage()
-    subtractor = BiasSubtractor(None)
+    subtractor = BiasSubtractor(FakeContext())
 
     with pytest.raises(MasterCalibrationDoesNotExist):
         images = subtractor.do_stage([FakeImage() for x in range(6)])
@@ -105,7 +105,7 @@ def test_bias_subtraction_is_reasonable(mock_cal, mock_image):
     fake_master_bias.data = np.random.normal(0.0, input_readnoise, size=(ny, nx))
     mock_image.return_value = fake_master_bias
 
-    subtractor = BiasSubtractor(None)
+    subtractor = BiasSubtractor(FakeContext())
     images = [FakeImage(image_multiplier=input_level) for x in range(6)]
 
     images = subtractor.do_stage(images)

--- a/banzai/tests/test_dark_comparer.py
+++ b/banzai/tests/test_dark_comparer.py
@@ -18,13 +18,13 @@ class FakeDarkImage(FakeImage):
 
 
 def test_no_input_images():
-    comparer = DarkComparer(None)
+    comparer = DarkComparer(FakeContext())
     images = comparer.do_stage([])
     assert len(images) == 0
 
 
 def test_master_selection_criteria():
-    comparer = DarkComparer(None)
+    comparer = DarkComparer(FakeContext())
     assert comparer.master_selection_criteria == ['ccdsum']
 
 

--- a/banzai/tests/test_dark_maker.py
+++ b/banzai/tests/test_dark_maker.py
@@ -16,13 +16,13 @@ class FakeDarkImage(FakeImage):
 
 
 def test_min_images():
-    dark_maker = DarkMaker(None)
+    dark_maker = DarkMaker(FakeContext())
     processed_images = dark_maker.do_stage([])
     assert len(processed_images) == 0
 
 
 def test_group_by_attributes():
-    maker = DarkMaker(None)
+    maker = DarkMaker(FakeContext())
     assert maker.group_by_attributes == ['ccdsum']
 
 

--- a/banzai/tests/test_flat_comparer.py
+++ b/banzai/tests/test_flat_comparer.py
@@ -18,7 +18,7 @@ class FakeFlatImage(FakeImage):
 
 
 def test_no_input_images(set_random_seed):
-    comparer = FlatComparer(None)
+    comparer = FlatComparer(FakeContext())
     images = comparer.do_stage([])
     assert len(images) == 0
 
@@ -61,7 +61,7 @@ def test_does_not_raise_exception_if_no_master_calibration(mock_save_qc, mock_ca
     mock_cal.return_value = None
     mock_images.return_value = FakeFlatImage(10000.0)
 
-    comparer = FlatComparer(None)
+    comparer = FlatComparer(FakeContext())
     images = comparer.do_stage([FakeFlatImage(10000.0) for x in range(6)])
     assert len(images) == 6
 

--- a/banzai/tests/test_flat_maker.py
+++ b/banzai/tests/test_flat_maker.py
@@ -14,13 +14,13 @@ class FakeFlatImage(FakeImage):
 
 
 def test_min_images():
-    flat_maker = FlatMaker(None)
+    flat_maker = FlatMaker(FakeContext())
     processed_images = flat_maker.do_stage([])
     assert len(processed_images) == 0
 
 
 def test_group_by_attributes():
-    maker = FlatMaker(None)
+    maker = FlatMaker(FakeContext())
     assert maker.group_by_attributes == ['ccdsum', 'filter']
 
 

--- a/banzai/tests/test_pipeline_context.py
+++ b/banzai/tests/test_pipeline_context.py
@@ -5,7 +5,7 @@ from banzai.context import PipelineContext
 
 def test_pipeline_context_gets_arguments_from_argparse():
     args = Namespace(a=1, b=2, c=5)
-    pipeline_context = PipelineContext(args, [], None)
+    pipeline_context = PipelineContext(args, {})
     assert pipeline_context.a == 1
     assert pipeline_context.b == 2
     assert pipeline_context.c == 5
@@ -13,7 +13,7 @@ def test_pipeline_context_gets_arguments_from_argparse():
 
 def test_pipeline_context_gets_arguments_from_kwargs():
     kwargs = {'a': 6, 'b': 7, 'c': 11}
-    pipeline_context = PipelineContext(Namespace(), [], None, **kwargs)
+    pipeline_context = PipelineContext(Namespace(), {}, **kwargs)
     assert pipeline_context.a == 6
     assert pipeline_context.b == 7
     assert pipeline_context.c == 11

--- a/banzai/tests/test_pipeline_context.py
+++ b/banzai/tests/test_pipeline_context.py
@@ -5,7 +5,7 @@ from banzai.context import PipelineContext
 
 def test_pipeline_context_gets_arguments_from_argparse():
     args = Namespace(a=1, b=2, c=5)
-    pipeline_context = PipelineContext(args, {})
+    pipeline_context = PipelineContext(args, None)
     assert pipeline_context.a == 1
     assert pipeline_context.b == 2
     assert pipeline_context.c == 5
@@ -13,7 +13,7 @@ def test_pipeline_context_gets_arguments_from_argparse():
 
 def test_pipeline_context_gets_arguments_from_kwargs():
     kwargs = {'a': 6, 'b': 7, 'c': 11}
-    pipeline_context = PipelineContext(Namespace(), {}, **kwargs)
+    pipeline_context = PipelineContext(Namespace(), None, **kwargs)
     assert pipeline_context.a == 6
     assert pipeline_context.b == 7
     assert pipeline_context.c == 11

--- a/banzai/tests/utils.py
+++ b/banzai/tests/utils.py
@@ -5,10 +5,10 @@ import pytest
 import numpy as np
 from astropy.io.fits import Header
 
-from banzai import settings
 from banzai.utils import image_utils
 from banzai.stages import Stage
 from banzai.images import Image
+import banzai.settings
 
 
 class FakeImage(Image):
@@ -50,11 +50,10 @@ class FakeImage(Image):
 
 
 class FakeContext(object):
-    def __init__(self, preview_mode=False, settings_version=settings.Imaging):
+    def __init__(self, preview_mode=False, settings=banzai.settings.ImagingSettings()):
         self.processed_path = '/tmp'
         self.preview_mode = preview_mode
-        config = settings_version()
-        for key, value in dict(inspect.getmembers(config)).items():
+        for key, value in dict(inspect.getmembers(settings)).items():
             if not key.startswith('_'):
                 setattr(self, key, value)
 

--- a/banzai/tests/utils.py
+++ b/banzai/tests/utils.py
@@ -8,6 +8,7 @@ from banzai import settings
 from banzai.utils import image_utils
 from banzai.stages import Stage
 from banzai.images import Image
+from banzai.main import parse_settings
 
 
 class FakeImage(Image):
@@ -52,11 +53,9 @@ class FakeContext(object):
     def __init__(self, preview_mode=False, settings_version="Imaging"):
         self.processed_path = '/tmp'
         self.preview_mode = preview_mode
-        config = vars(settings)[settings_version]
-        config = {key: getattr(config, key) for key in dir(config) if not key.startswith('_')}
+        config = parse_settings(settings_version)
         for key, value in config.items():
-            if not key.startswith('_'):
-                setattr(self, key, value)
+            setattr(self, key, value)
 
 
 class FakeStage(Stage):

--- a/banzai/tests/utils.py
+++ b/banzai/tests/utils.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+import inspect
 
 import pytest
 import numpy as np
@@ -8,7 +9,6 @@ from banzai import settings
 from banzai.utils import image_utils
 from banzai.stages import Stage
 from banzai.images import Image
-from banzai.main import parse_settings
 
 
 class FakeImage(Image):
@@ -50,12 +50,13 @@ class FakeImage(Image):
 
 
 class FakeContext(object):
-    def __init__(self, preview_mode=False, settings_version="Imaging"):
+    def __init__(self, preview_mode=False, settings_version=settings.Imaging):
         self.processed_path = '/tmp'
         self.preview_mode = preview_mode
-        config = parse_settings(settings_version)
-        for key, value in config.items():
-            setattr(self, key, value)
+        config = settings_version()
+        for key, value in dict(inspect.getmembers(config)).items():
+            if not key.startswith('_'):
+                setattr(self, key, value)
 
 
 class FakeStage(Stage):

--- a/banzai/tests/utils.py
+++ b/banzai/tests/utils.py
@@ -4,6 +4,7 @@ import pytest
 import numpy as np
 from astropy.io.fits import Header
 
+from banzai import settings
 from banzai.utils import image_utils
 from banzai.stages import Stage
 from banzai.images import Image
@@ -48,9 +49,14 @@ class FakeImage(Image):
 
 
 class FakeContext(object):
-    def __init__(self, preview_mode=False):
+    def __init__(self, preview_mode=False, settings_version="Imaging"):
         self.processed_path = '/tmp'
         self.preview_mode = preview_mode
+        config = vars(settings)[settings_version]
+        config = {key: getattr(config, key) for key in dir(config) if not key.startswith('_')}
+        for key, value in config.items():
+            if not key.startswith('_'):
+                setattr(self, key, value)
 
 
 class FakeStage(Stage):

--- a/setup.cfg
+++ b/setup.cfg
@@ -76,7 +76,7 @@ edit_on_github = True
 github_project = lcogt/banzai
 
 # version should be PEP440 compatible (http://www.python.org/dev/peps/pep-0440)
-version = 0.14.4
+version = 0.15.0
 
 [entry_points]
 banzai = banzai.main:main


### PR DESCRIPTION
I've stripped all banzai-related imports from `settings.py` and made everything a string. Strings that represent classes or objects are parsed in `main.py`.

I've also restructured `settings.py` into a configuration file. There is a main `Settings` class that can have settings that are shared between imaging & NRES, e.g. the schedulability criterion. It also has a few fixed properties, e.g. selection criteria, that all subclasses must implement. The `Imaging` class then has imaging-specific settings. The version of settings you want can be specified from `main.py`.  

Now in `main.py`, `settings` is only referenced once, in the `parse_args` method. Here, a configuration object is created and passed directly to `PipelineContext`, where all attributes are added to the context object. 