### PR TITLE
Hotfix/apply calibration grouping

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+0.15.1 (2018-12-05)
+-------------------
+- Fixed AppplyCalibration class to still use group_by (broken since 0.14.1)
+
 0.15.0 (2018-12-05)
 -------------------
 - Restructured settings to be an abstract class

--- a/banzai/calibrations.py
+++ b/banzai/calibrations.py
@@ -123,6 +123,24 @@ class ApplyCalibration(Stage):
         logger.error('Master Calibration file does not exist for {stage}'.format(stage=self.stage_name), image=image)
         raise MasterCalibrationDoesNotExist
 
+    def get_grouping(self, image):
+        grouping_criteria = [image.site, image.instrument, image.epoch]
+        if self.master_selection_criteria:
+            grouping_criteria += [getattr(image, keyword) for keyword in self.master_selection_criteria]
+        return grouping_criteria
+
+    def run(self, images):
+        images.sort(key=self.get_grouping)
+        processed_images = []
+        for _, image_set in itertools.groupby(images, self.get_grouping):
+            try:
+                image_set = list(image_set)
+                logger.info('Running {0}'.format(self.stage_name), image=image_set[0])
+                processed_images += self.do_stage(image_set)
+            except Exception:
+                logger.error(logs.format_exception())
+        return processed_images
+
     def do_stage(self, images):
         if len(images) == 0:
             # Abort!

--- a/setup.cfg
+++ b/setup.cfg
@@ -76,7 +76,7 @@ edit_on_github = True
 github_project = lcogt/banzai
 
 # version should be PEP440 compatible (http://www.python.org/dev/peps/pep-0440)
-version = 0.15.0
+version = 0.15.1
 
 [entry_points]
 banzai = banzai.main:main


### PR DESCRIPTION
In version 0.14.1 I removed the `get_grouping` method from `Stage` and added it only in `CalibrationMaker`. However, it still needs to be used in `ApplyCalibration` in the cases where an `ApplyCalibration` stage is passed multiple frames (in particular flats!)

Luckily, none of these cases have been in production, since the preview pipeline reduces images one at a time, and end of night has been running 0.13.0. 