### PR TITLE
Hotfix/preview criteria varable name

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 0.15.1 (2018-12-05)
 -------------------
 - Fixed AppplyCalibration class to still use group_by (broken since 0.14.1)
+- Fixed typo that broke preview pipeline in 0.15.0
 
 0.15.0 (2018-12-05)
 -------------------

--- a/banzai/main.py
+++ b/banzai/main.py
@@ -393,7 +393,7 @@ class PreviewModeListener(ConsumerMixin):
 
         if is_eligible_for_preview:
             try:
-                if preview.need_to_make_preview(path, self.pipeline_context.allowed_instrument_criteria,
+                if preview.need_to_make_preview(path, self.pipeline_context.FRAME_SELECTION_CRITERIA,
                                                 db_address=self.pipeline_context.db_address,
                                                 max_tries=self.pipeline_context.max_tries):
                     stages_to_do = get_preview_stages_todo(self.pipeline_context, image_suffix)


### PR DESCRIPTION
In 0.15.0 I forgot to update the name of the criteria variable passed to `need_to_make_preview`, breaking the preview pipeline