### PR TITLE
Hotfix/block date na

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+0.18.2 (2019-02-01)
+-------------------
+- Added a catch for N/A in fits header dates
+
 0.18.1 (2019-01-31)
 -------------------
 - Breaking typo in Preview Pipeline removed 

--- a/banzai/utils/date_utils.py
+++ b/banzai/utils/date_utils.py
@@ -82,6 +82,8 @@ def parse_epoch_string(epoch_string):
 
 
 def parse_date_obs(date_obs_string):
+    if date_obs_string == 'N/A':
+        return None
     # Check if there are hours
     if 'T' not in date_obs_string:
         return datetime.datetime.strptime(date_obs_string, '%Y-%m-%d')

--- a/setup.cfg
+++ b/setup.cfg
@@ -77,7 +77,7 @@ edit_on_github = True
 github_project = lcogt/banzai
 
 # version should be PEP440 compatible (http://www.python.org/dev/peps/pep-0440)
-version = 0.18.1
+version = 0.18.2
 
 [entry_points]
 banzai = banzai.main:main


### PR DESCRIPTION
This fixes an issue when the block date is set to N/A because the image was taken by the control interface instead of being taken as part of a normal block.