### PR TITLE
Fixed indent in logging message

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 0.18.2 (2019-02-01)
 -------------------
 - Added a catch for N/A in fits header dates
+- Fixed a log message bug that causes a crash when a frame reduction fails
 
 0.18.1 (2019-01-31)
 -------------------

--- a/banzai/main.py
+++ b/banzai/main.py
@@ -140,7 +140,7 @@ def run(image_path, pipeline_context):
         images = stage_to_run.run(images)
     if len(images):
         images[0].write(pipeline_context)
-    logger.info("Finished reducing frame", extra_tags={'filename': images[0].filename})
+        logger.info("Finished reducing frame", extra_tags={'filename': images[0].filename})
 
 
 def run_master_maker(image_path_list, pipeline_context, frame_type):


### PR DESCRIPTION
In `feature/calibs_from_db` I added a log message to denote the end of reduction. However I did not indent it correctly, and if the stages return an empty list then the logging message throws an error. 