### PR TITLE
feature/refactor_qc_save

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+0.18.4 (2019-02-07)
+-------------------
+- Moved the function that adds quality control information to ElasticSearch
+  outside of Stage class and to the quality control utils
+
 0.18.3 (2019-02-05)
 -------------------
 - Fixed query for master calibration to work even when block start

--- a/banzai/calibrations.py
+++ b/banzai/calibrations.py
@@ -7,7 +7,7 @@ import numpy as np
 
 from banzai.stages import Stage
 from banzai import dbs, logs
-from banzai.utils import image_utils, stats, fits_utils
+from banzai.utils import image_utils, stats, fits_utils, qc
 
 logger = logging.getLogger(__name__)
 
@@ -208,7 +208,7 @@ class CalibrationComparer(ApplyCalibration):
                 msg = 'Flagging {caltype} as bad because it deviates too much from the previous master'
                 logger.error(msg.format(caltype=self.calibration_type), image=image, extra_tags=logging_tags)
 
-            self.save_qc_results(qc_results, image)
+            qc.save_qc_results(self.pipeline_context, qc_results, image)
 
         return images
 

--- a/banzai/qc/header_checker.py
+++ b/banzai/qc/header_checker.py
@@ -6,6 +6,7 @@ format and validates their values.
 import logging
 
 from banzai.stages import Stage
+from banzai.utils import qc
 
 logger = logging.getLogger(__name__)
 
@@ -92,7 +93,7 @@ class HeaderSanity(Stage):
             qc_results["header.keywords.missing.names"] = missing_keywords
         if are_keywords_na:
             qc_results["header.keywords.na.names"] = na_keywords
-        self.save_qc_results(qc_results, image)
+        qc.save_qc_results(self.pipeline_context, qc_results, image)
         return missing_keywords + na_keywords
 
     def check_ra_range(self, image, bad_keywords=None):
@@ -116,8 +117,9 @@ class HeaderSanity(Stage):
             if is_bad_ra_value:
                 sentence = 'The header CRVAL1 key got the unexpected value : {0}'.format(ra_value)
                 logger.error(sentence, image=image)
-            self.save_qc_results({"header.ra.failed": is_bad_ra_value,
-                                  "header.ra.value": ra_value}, image)
+            qc_results = {"header.ra.failed": is_bad_ra_value,
+                          "header.ra.value": ra_value}
+            qc.save_qc_results(self.pipeline_context, qc_results, image)
 
     def check_dec_range(self, image, bad_keywords=None):
         """
@@ -140,8 +142,9 @@ class HeaderSanity(Stage):
             if is_bad_dec_value:
                 sentence = 'The header CRVAL2 key got the unexpected value : {0}'.format(dec_value)
                 logger.error(sentence, image=image)
-            self.save_qc_results({"header.dec.failed": is_bad_dec_value,
-                                  "header.dec.value": dec_value}, image)
+            qc_results = {"header.dec.failed": is_bad_dec_value,
+                          "header.dec.value": dec_value}
+            qc.save_qc_results(self.pipeline_context, qc_results, image)
 
     def check_exptime_value(self, image, bad_keywords=None):
         """
@@ -166,4 +169,4 @@ class HeaderSanity(Stage):
                                'null or negative value'.format(exptime_value)
                     logger.error(sentence, image=image)
                 qc_results["header.exptime.failed"] = is_exptime_null
-            self.save_qc_results(qc_results, image)
+            qc.save_qc_results(self.pipeline_context, qc_results, image)

--- a/banzai/qc/pattern_noise.py
+++ b/banzai/qc/pattern_noise.py
@@ -6,6 +6,7 @@ from itertools import groupby
 from operator import itemgetter
 
 from banzai.stages import Stage
+from banzai.utils import qc
 from banzai.utils.stats import robust_standard_deviation
 
 logger = logging.getLogger(__name__)
@@ -34,13 +35,12 @@ class PatternNoiseDetector(Stage):
                 logger.error('Image found to have pattern noise.', image=image, extra_tags=logging_tags)
             else:
                 logger.info('No pattern noise found.', image=image, extra_tags=logging_tags)
-            self.save_qc_results({'pattern_noise.failed': pattern_noise_is_bad,
-                                  'pattern_noise.snr_threshold': self.SNR_THRESHOLD,
-                                  'pattern_noise.min_fraction_pixels_above_threshold':
-                                      self.MIN_FRACTION_PIXELS_ABOVE_THRESHOLD,
-                                  'pattern_noise.min_adjacent_pixels': self.MIN_ADJACENT_PIXELS,
-                                  'patter_noise.fraction_pixels_above_threshold': fraction_pixels_above_threshold
-                                  }, image)
+            qc_results = {'pattern_noise.failed': pattern_noise_is_bad,
+                          'pattern_noise.snr_threshold': self.SNR_THRESHOLD,
+                          'pattern_noise.min_fraction_pixels_above_threshold': self.MIN_FRACTION_PIXELS_ABOVE_THRESHOLD,
+                          'pattern_noise.min_adjacent_pixels': self.MIN_ADJACENT_PIXELS,
+                          'patter_noise.fraction_pixels_above_threshold': fraction_pixels_above_threshold}
+            qc.save_qc_results(self.pipeline_context, qc_results, image)
         return images
 
     def check_for_pattern_noise(self, data):

--- a/banzai/qc/pointing.py
+++ b/banzai/qc/pointing.py
@@ -4,6 +4,7 @@ import astropy.units as u
 from astropy.coordinates import SkyCoord
 
 from banzai.stages import Stage
+from banzai.utils import qc
 
 logger = logging.getLogger(__name__)
 
@@ -50,12 +51,12 @@ class PointingTest(Stage):
                 logger.error('Pointing offset exceeds threshold', image=image, extra_tags=logging_tags)
             elif pointing_warning:
                 logger.warning('Pointing offset exceeds threshhold', image=image, extra_tags=logging_tags)
-            self.save_qc_results({'pointing.failed': pointing_severe,
-                                  'pointing.failed_threshold': self.SEVERE_THRESHOLD,
-                                  'pointing.warning': pointing_warning,
-                                  'pointing.warning_threshold': self.WARNING_THRESHOLD,
-                                  'pointing.offset': angular_separation},
-                                 image)
+            qc_results = {'pointing.failed': pointing_severe,
+                          'pointing.failed_threshold': self.SEVERE_THRESHOLD,
+                          'pointing.warning': pointing_warning,
+                          'pointing.warning_threshold': self.WARNING_THRESHOLD,
+                          'pointing.offset': angular_separation}
+            qc.save_qc_results(self.pipeline_context, qc_results, image)
 
             image.header['PNTOFST'] = (
                 angular_separation, '[arcsec] offset of requested and solved center'

--- a/banzai/qc/saturation.py
+++ b/banzai/qc/saturation.py
@@ -1,6 +1,7 @@
 import logging
 
 from banzai.stages import Stage
+from banzai.utils import qc
 
 logger = logging.getLogger(__name__)
 
@@ -41,7 +42,7 @@ class SaturationTest(Stage):
             else:
                 image.header['SATFRAC'] = (saturation_fraction,
                                            "Fraction of Pixels that are Saturated")
-            self.save_qc_results(qc_results, image)
+            qc.save_qc_results(self.pipeline_context, qc_results, image)
         for image in images_to_remove:
             images.remove(image)
 

--- a/banzai/qc/sinistro_1000s.py
+++ b/banzai/qc/sinistro_1000s.py
@@ -3,6 +3,7 @@ import logging
 import numpy as np
 
 from banzai.stages import Stage
+from banzai.utils import qc
 
 logger = logging.getLogger(__name__)
 
@@ -41,7 +42,7 @@ class ThousandsTest(Stage):
                 images_to_remove.append(image)
             else:
                 logger.info('Measuring fraction of 1000s.', image=image, extra_tags=logging_tags)
-            self.save_qc_results(qc_results, image)
+            qc.save_qc_results(self.pipeline_context, qc_results, image)
         for image in images_to_remove:
             images.remove(image)
 

--- a/banzai/stages.py
+++ b/banzai/stages.py
@@ -1,9 +1,7 @@
 import logging
 import abc
-from banzai import logs
-import elasticsearch
 
-from banzai.utils.qc import format_qc_results
+from banzai import logs
 
 logger = logging.getLogger(__name__)
 
@@ -30,34 +28,3 @@ class Stage(abc.ABC):
     @abc.abstractmethod
     def do_stage(self, images):
         return images
-
-    def save_qc_results(self, qc_results, image, **kwargs):
-        """
-        Save the Quality Control results to ElasticSearch
-
-        Parameters
-        ----------
-        qc_results : dict
-                     Dictionary of key value pairs to be saved to ElasticSearch
-        image : banzai.images.Image
-                Image that should be linked
-
-        Notes
-        -----
-        File name, site, camera, dayobs and timestamp are always saved in the database.
-        """
-
-        es_output = {}
-        if getattr(self.pipeline_context, 'post_to_elasticsearch', False):
-            filename, results_to_save = format_qc_results(qc_results, image)
-            es = elasticsearch.Elasticsearch(self.pipeline_context.elasticsearch_url)
-            try:
-                es_output = es.update(index=self.pipeline_context.elasticsearch_qc_index,
-                                      doc_type=self.pipeline_context.elasticsearch_doc_type,
-                                      id=filename, body={'doc': results_to_save, 'doc_as_upsert': True},
-                                      retry_on_conflict=5, timestamp=results_to_save['@timestamp'], **kwargs)
-            except Exception:
-                error_message = 'Cannot update elasticsearch index to URL \"{url}\": {exception}'
-                logger.error(error_message.format(url=self.pipeline_context.elasticsearch_url,
-                                                  exception=logs.format_exception()))
-        return es_output

--- a/banzai/tests/test_bias_comparer.py
+++ b/banzai/tests/test_bias_comparer.py
@@ -46,8 +46,7 @@ def test_raises_an_exception_if_ny_are_different(mock_cal, set_random_seed):
 
 
 @mock.patch('banzai.calibrations.ApplyCalibration.get_calibration_filename')
-@mock.patch('banzai.stages.Stage.save_qc_results')
-def test_flags_bad_if_no_master_calibration(mock_save_qc, mock_cal, set_random_seed):
+def test_flags_bad_if_no_master_calibration(mock_cal, set_random_seed):
     mock_cal.return_value = None
     nx = 101
     ny = 103
@@ -58,8 +57,7 @@ def test_flags_bad_if_no_master_calibration(mock_save_qc, mock_cal, set_random_s
 
 
 @mock.patch('banzai.calibrations.ApplyCalibration.get_calibration_filename')
-@mock.patch('banzai.stages.Stage.save_qc_results')
-def test_does_not_reject_noisy_images(mock_save_qc, mock_cal, set_random_seed):
+def test_does_not_reject_noisy_images(mock_cal, set_random_seed):
     mock_cal.return_value = 'test.fits'
     master_readnoise = 3.0
     nx = 101
@@ -77,8 +75,7 @@ def test_does_not_reject_noisy_images(mock_save_qc, mock_cal, set_random_seed):
 
 
 @mock.patch('banzai.calibrations.ApplyCalibration.get_calibration_filename')
-@mock.patch('banzai.stages.Stage.save_qc_results')
-def test_does_flag_bad_images(mock_save_qc, mock_cal, set_random_seed):
+def test_does_flag_bad_images(mock_cal, set_random_seed):
     mock_cal.return_value = 'test.fits'
     master_readnoise = 3.0
     nx = 101

--- a/banzai/tests/test_dark_comparer.py
+++ b/banzai/tests/test_dark_comparer.py
@@ -46,8 +46,7 @@ def test_raises_an_exception_if_ny_are_different(mock_cal):
 
 
 @mock.patch('banzai.calibrations.ApplyCalibration.get_calibration_filename')
-@mock.patch('banzai.stages.Stage.save_qc_results')
-def test_flags_bad_if_no_master_calibration(mock_save_qc, mock_cal):
+def test_flags_bad_if_no_master_calibration(mock_cal):
     mock_cal.return_value = None
     context = FakeContext()
     context.FRAME_CLASS = FakeDarkImage
@@ -57,8 +56,7 @@ def test_flags_bad_if_no_master_calibration(mock_save_qc, mock_cal):
 
 
 @mock.patch('banzai.calibrations.ApplyCalibration.get_calibration_filename')
-@mock.patch('banzai.stages.Stage.save_qc_results')
-def test_does_not_flag_noisy_images(mock_save_qc, mock_cal, set_random_seed):
+def test_does_not_flag_noisy_images(mock_cal, set_random_seed):
     mock_cal.return_value = 'test.fits'
     master_dark_fraction = 0.05
     nx = 101
@@ -81,8 +79,7 @@ def test_does_not_flag_noisy_images(mock_save_qc, mock_cal, set_random_seed):
 
 
 @mock.patch('banzai.calibrations.ApplyCalibration.get_calibration_filename')
-@mock.patch('banzai.stages.Stage.save_qc_results')
-def test_does_flag_bad_images(mock_save_qc, mock_cal, set_random_seed):
+def test_does_flag_bad_images( mock_cal, set_random_seed):
     mock_cal.return_value = 'test.fits'
     master_dark_fraction = 0.05
     nx = 101

--- a/banzai/tests/test_flat_comparer.py
+++ b/banzai/tests/test_flat_comparer.py
@@ -46,8 +46,7 @@ def test_raises_an_exception_if_ny_are_different(mock_cal, set_random_seed):
 
 
 @mock.patch('banzai.calibrations.ApplyCalibration.get_calibration_filename')
-@mock.patch('banzai.stages.Stage.save_qc_results')
-def test_flag_bad_if_no_master_calibration(mock_save_qc, mock_cal, set_random_seed):
+def test_flag_bad_if_no_master_calibration( mock_cal, set_random_seed):
     mock_cal.return_value = None
     context = make_context_with_master_flat(flat_level=10000.0)
     comparer = FlatComparer(context)
@@ -56,8 +55,7 @@ def test_flag_bad_if_no_master_calibration(mock_save_qc, mock_cal, set_random_se
 
 
 @mock.patch('banzai.calibrations.ApplyCalibration.get_calibration_filename')
-@mock.patch('banzai.stages.Stage.save_qc_results')
-def test_does_not_flag_noisy_images(mock_save_qc, mock_cal, set_random_seed):
+def test_does_not_flag_noisy_images(mock_cal, set_random_seed):
     mock_cal.return_value = 'test.fits'
     master_flat_variation = 0.025
     nx = 101
@@ -84,8 +82,7 @@ class FakeFlatComparer(FlatComparer):
 
 
 @mock.patch('banzai.calibrations.ApplyCalibration.get_calibration_filename')
-@mock.patch('banzai.stages.Stage.save_qc_results')
-def test_does_flag_bad_images(mock_save_qc, mock_cal, set_random_seed):
+def test_does_flag_bad_images(mock_cal, set_random_seed):
     mock_cal.return_value = 'test.fits'
     nx = 101
     ny = 103

--- a/banzai/tests/test_saving_qc.py
+++ b/banzai/tests/test_saving_qc.py
@@ -1,13 +1,13 @@
 import mock
 import numpy as np
 
+from banzai.utils import qc
 from banzai.tests.utils import FakeImage, FakeContext, FakeStage
-from banzai.utils.qc import format_qc_results
 
 
 def test_format_qc_results_basic_info():
     image = FakeImage()
-    filename, results = format_qc_results({}, image)
+    filename, results = qc.format_qc_results({}, image)
     assert results['site'] == image.site
     assert results['instrument'] == image.camera
     assert results['dayobs'] == image.epoch
@@ -17,31 +17,31 @@ def test_format_qc_results_basic_info():
 
 
 def test_format_qc_results_new_info():
-    filename, results = format_qc_results({"key1": "value1",
-                                           "key2": "value2"},
-                                            FakeImage())
+    filename, results = qc.format_qc_results({"key1": "value1",
+                                              "key2": "value2"},
+                                             FakeImage())
     assert results["key1"] == "value1"
     assert results["key2"] == "value2"
 
 
 def test_format_qc_results_numpy_bool():
-    filename, results = format_qc_results({"normal_bool": True,
-                                           "numpy_bool": np.bool_(True)},
-                                           FakeImage())
+    filename, results = qc.format_qc_results({"normal_bool": True,
+                                              "numpy_bool": np.bool_(True)},
+                                             FakeImage())
     assert type(results["normal_bool"]) == bool
     assert type(results["numpy_bool"]) == bool
 
 
 def test_save_qc_results_no_post_to_elasticsearch_attribute():
     stage = FakeStage(FakeContext())
-    assert stage.save_qc_results({}, FakeImage()) == {}
+    assert qc.save_qc_results(stage.pipeline_context, {}, FakeImage()) == {}
 
 
-@mock.patch('banzai.stages.elasticsearch.Elasticsearch')
+@mock.patch('banzai.utils.qc.elasticsearch.Elasticsearch')
 def test_save_qc_results(mock_es):
     context = FakeContext()
     context.post_to_elasticsearch = True
     context.elasticsearch_url = '/'
     stage = FakeStage(context)
-    stage.save_qc_results({}, FakeImage())
+    qc.save_qc_results(stage.pipeline_context, {}, FakeImage())
     assert mock_es.called

--- a/setup.cfg
+++ b/setup.cfg
@@ -77,7 +77,7 @@ edit_on_github = True
 github_project = lcogt/banzai
 
 # version should be PEP440 compatible (http://www.python.org/dev/peps/pep-0440)
-version = 0.18.3
+version = 0.18.4
 
 [entry_points]
 banzai = banzai.main:main


### PR DESCRIPTION
For migrating to a single image per stage, we discussed moving the `save_qc_results` method outside of the `Stage` class, since it will be required by both individual-type stages as well as stacker-type stages, which will likely be separate classes. 