### PR TITLE
Hotfix/get master no block start

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+0.18.3 (2019-02-05)
+-------------------
+- Fixed query for master calibration to work even when block start
+  time is null
+
 0.18.2 (2019-02-01)
 -------------------
 - Added a catch for N/A in fits header dates

--- a/banzai/dbs.py
+++ b/banzai/dbs.py
@@ -438,7 +438,7 @@ def get_master_calibration_image(image, calibration_type, master_selection_crite
 
     # During real-time reduction, we want to avoid using different master calibrations for the same block,
     # therefore we make sure the the calibration frame used was created before the block start time
-    if realtime_reduction:
+    if realtime_reduction and image.block_start is not None:
         calibration_criteria &= CalibrationImage.datecreated < image.block_start
 
     db_session = get_session(db_address=db_address)

--- a/setup.cfg
+++ b/setup.cfg
@@ -77,7 +77,7 @@ edit_on_github = True
 github_project = lcogt/banzai
 
 # version should be PEP440 compatible (http://www.python.org/dev/peps/pep-0440)
-version = 0.18.2
+version = 0.18.3
 
 [entry_points]
 banzai = banzai.main:main


### PR DESCRIPTION
If `image.block_start` is `None` (which happens when frames are taken using the control interface), `dbs.get_master_calibration_image` will fail if `realtime_recution=True` since in this case it checks the image block start. An example of the resulting error can be found [here](http://logs.lco.gtn/app/kibana#/doc/logstash-*/logstash-2019.02.04/log?id=AWi67ExRcvbaS1d2ynkl&_g=(refreshInterval:(display:Off,pause:!f,value:0),time:(from:now-24h,mode:quick,to:now))). 

I've updated `dbs.get_master_calibration_image` to check whether `image.block_start` is `None`. Alternatively, we could set `image.block_start` to be the same as `image.dateobs` if it's missing from the header. 