### PR TITLE
Feature/zeros error

### DIFF
--- a/banzai/qc/__init__.py
+++ b/banzai/qc/__init__.py
@@ -3,6 +3,7 @@ from banzai.qc.pointing import PointingTest
 from banzai.qc.sinistro_1000s import ThousandsTest
 from banzai.qc.pattern_noise import PatternNoiseDetector
 from banzai.qc.header_checker import HeaderSanity
+from banzai.qc.zeros import ZerosTest
 
 __all__ = ['SaturationTest', 'PointingTest', 'ThousandsTest',
-           'PatternNoiseDetector', 'HeaderSanity']
+           'PatternNoiseDetector', 'HeaderSanity', 'ZerosTest']

--- a/banzai/qc/zeros.py
+++ b/banzai/qc/zeros.py
@@ -10,7 +10,7 @@ logger = logging.getLogger(__name__)
 
 class ZerosTest(Stage):
     """
-    Reject any images that have ZEROS_THRESHOLD or more of their pixels exactly equal to 0.
+    Reject any images that have ZEROS_THRESHOLD or more of their pixels in a single amp exactly equal to 0.
 
     Notes
     =====
@@ -22,14 +22,17 @@ class ZerosTest(Stage):
         super(ZerosTest, self).__init__(pipeline_context)
 
     def do_stage(self, image):
-        npixels = np.product(image.data.shape)
-        fraction_0s = float(np.sum(image.data == 0)) / npixels
-        logging_tags = {'FRAC0': fraction_0s,
+        fraction_0s_list = []
+        for i_amp in range(image.get_n_amps()):
+            npixels = np.product(image.data[i_amp].shape)
+            fraction_0s_list.append(float(np.sum(image.data[i_amp] == 0)) / npixels)
+
+        has_0s_error = any([fraction_0s > self.ZEROS_THRESHOLD for fraction_0s in fraction_0s_list])
+        logging_tags = {'FRAC0': fraction_0s_list,
                         'threshold': self.ZEROS_THRESHOLD}
-        has_0s_error = fraction_0s > self.ZEROS_THRESHOLD
         qc_results = {'zeros_test.failed': has_0s_error,
-                      'zeros_test.fraction': fraction_0s,
-                      'zeros_testthreshold': self.ZEROS_THRESHOLD}
+                      'zeros_test.fraction': fraction_0s_list,
+                      'zeros_test.threshold': self.ZEROS_THRESHOLD}
         if has_0s_error:
             logger.error('Image is mostly 0s. Rejecting image', image=image, extra_tags=logging_tags)
             qc_results['rejected'] = True

--- a/banzai/qc/zeros.py
+++ b/banzai/qc/zeros.py
@@ -16,7 +16,7 @@ class ZerosTest(Stage):
     =====
     Sometimes when a camera fails, all pixels have a value of 0.
     """
-    ZEROS_THRESHOLD = 0.2
+    ZEROS_THRESHOLD = 0.95
 
     def __init__(self, pipeline_context):
         super(ZerosTest, self).__init__(pipeline_context)

--- a/banzai/qc/zeros.py
+++ b/banzai/qc/zeros.py
@@ -1,0 +1,41 @@
+import logging
+
+import numpy as np
+
+from banzai.stages import Stage
+from banzai.utils import qc
+
+logger = logging.getLogger(__name__)
+
+
+class ZerosTest(Stage):
+    """
+    Reject any images that have ZEROS_THRESHOLD or more of their pixels exactly equal to 0.
+
+    Notes
+    =====
+    Sometimes when a camera fails, all pixels have a value of 0.
+    """
+    ZEROS_THRESHOLD = 0.2
+
+    def __init__(self, pipeline_context):
+        super(ZerosTest, self).__init__(pipeline_context)
+
+    def do_stage(self, image):
+        npixels = np.product(image.data.shape)
+        fraction_0s = float(np.sum(image.data == 0)) / npixels
+        logging_tags = {'FRAC0': fraction_0s,
+                        'threshold': self.ZEROS_THRESHOLD}
+        has_0s_error = fraction_0s > self.ZEROS_THRESHOLD
+        qc_results = {'zeros_test.failed': has_0s_error,
+                      'zeros_test.fraction': fraction_0s,
+                      'zeros_testthreshold': self.ZEROS_THRESHOLD}
+        if has_0s_error:
+            logger.error('Image is mostly 0s. Rejecting image', image=image, extra_tags=logging_tags)
+            qc_results['rejected'] = True
+            return None
+        else:
+            logger.info('Measuring fraction of 0s.', image=image, extra_tags=logging_tags)
+        qc.save_qc_results(self.pipeline_context, qc_results, image)
+
+        return image

--- a/banzai/settings.py
+++ b/banzai/settings.py
@@ -82,6 +82,7 @@ class ImagingSettings(Settings):
 
     ORDERED_STAGES = [bpm.BPMUpdater,
                       qc.HeaderSanity,
+                      qc.ZerosTest,
                       qc.ThousandsTest,
                       qc.SaturationTest,
                       bias.OverscanSubtractor,

--- a/banzai/tests/test_zeros_qc.py
+++ b/banzai/tests/test_zeros_qc.py
@@ -1,0 +1,65 @@
+import pytest
+import numpy as np
+
+from banzai.tests.utils import FakeImage
+from banzai.qc import ZerosTest
+
+
+@pytest.fixture(scope='module')
+def set_random_seed():
+    np.random.seed(81232385)
+
+
+def test_null_input_image():
+    tester = ZerosTest(None)
+    image = tester.run(None)
+    assert image is None
+
+
+def test_no_pixels_0():
+    tester = ZerosTest(None)
+    image = tester.do_stage(FakeImage())
+    assert image is not None
+
+
+def test_nonzero_but_no_pixels_0():
+    tester = ZerosTest(None)
+    image = FakeImage()
+    image.data += 5
+    image = tester.do_stage(image)
+    assert image is not None
+
+
+def test_image_all_0s():
+    tester = ZerosTest(None)
+    image = FakeImage()
+    image.data += 5
+    image.data[:, :] = 0
+    image = tester.do_stage(image)
+    assert image is None
+
+
+def test_image_5_percent_0(set_random_seed):
+    tester = ZerosTest(None)
+    nx = 101
+    ny = 103
+    image = FakeImage(nx=nx, ny=ny)
+    random_pixels_x = np.random.randint(0, nx - 1, size=int(0.05 * nx * ny))
+    random_pixels_y = np.random.randint(0, ny - 1, size=int(0.05 * nx * ny))
+    for i in zip(random_pixels_y, random_pixels_x):
+        image.data[i] = 0
+    image = tester.do_stage(image)
+    assert image is not None
+
+
+def test_image_30_percent_0(set_random_seed):
+    tester = ZerosTest(None)
+    nx = 101
+    ny = 103
+    image = FakeImage(nx=nx, ny=ny)
+    random_pixels_x = np.random.randint(0, nx - 1, size=int(0.3 * nx * ny))
+    random_pixels_y = np.random.randint(0, ny - 1, size=int(0.3 * nx * ny))
+    for i in zip(random_pixels_y, random_pixels_x):
+        image.data[i] = 0
+    image = tester.do_stage(image)
+    assert image is None

--- a/banzai/tests/test_zeros_qc.py
+++ b/banzai/tests/test_zeros_qc.py
@@ -39,27 +39,14 @@ def test_image_all_0s():
     assert image is None
 
 
-def test_image_5_percent_0(set_random_seed):
+def test_image_95_percent_0(set_random_seed):
     tester = ZerosTest(None)
     nx = 101
     ny = 103
     image = FakeImage(nx=nx, ny=ny)
-    random_pixels_x = np.random.randint(0, nx - 1, size=int(0.05 * nx * ny))
-    random_pixels_y = np.random.randint(0, ny - 1, size=int(0.05 * nx * ny))
+    random_pixels_x = np.random.randint(0, nx - 1, size=int(0.95 * nx * ny))
+    random_pixels_y = np.random.randint(0, ny - 1, size=int(0.95 * nx * ny))
     for i in zip(random_pixels_y, random_pixels_x):
         image.data[i] = 0
     image = tester.do_stage(image)
     assert image is not None
-
-
-def test_image_30_percent_0(set_random_seed):
-    tester = ZerosTest(None)
-    nx = 101
-    ny = 103
-    image = FakeImage(nx=nx, ny=ny)
-    random_pixels_x = np.random.randint(0, nx - 1, size=int(0.3 * nx * ny))
-    random_pixels_y = np.random.randint(0, ny - 1, size=int(0.3 * nx * ny))
-    for i in zip(random_pixels_y, random_pixels_x):
-        image.data[i] = 0
-    image = tester.do_stage(image)
-    assert image is None

--- a/banzai/tests/test_zeros_qc.py
+++ b/banzai/tests/test_zeros_qc.py
@@ -10,43 +10,62 @@ def set_random_seed():
     np.random.seed(81232385)
 
 
+def get_random_pixel_pairs(nx, ny, fraction):
+    return np.unravel_index(np.random.choice(range(nx * ny), size=int(fraction * nx * ny)), (ny, nx))
+
+
 def test_null_input_image():
     tester = ZerosTest(None)
     image = tester.run(None)
     assert image is None
 
 
-def test_no_pixels_0():
+def test_no_pixels_0_not_rejected():
     tester = ZerosTest(None)
-    image = tester.do_stage(FakeImage())
+    image = tester.do_stage(FakeImage(image_multiplier=5))
     assert image is not None
 
 
-def test_nonzero_but_no_pixels_0():
+def test_image_all_0s_rejected():
     tester = ZerosTest(None)
     image = FakeImage()
-    image.data += 5
-    image = tester.do_stage(image)
-    assert image is not None
-
-
-def test_image_all_0s():
-    tester = ZerosTest(None)
-    image = FakeImage()
-    image.data += 5
     image.data[:, :] = 0
     image = tester.do_stage(image)
     assert image is None
 
 
-def test_image_95_percent_0(set_random_seed):
+def test_image_50_percent_0_not_rejected(set_random_seed):
     tester = ZerosTest(None)
     nx = 101
     ny = 103
     image = FakeImage(nx=nx, ny=ny)
-    random_pixels_x = np.random.randint(0, nx - 1, size=int(0.95 * nx * ny))
-    random_pixels_y = np.random.randint(0, ny - 1, size=int(0.95 * nx * ny))
-    for i in zip(random_pixels_y, random_pixels_x):
-        image.data[i] = 0
+    random_pixels = get_random_pixel_pairs(nx, ny, 0.5)
+    for j,i in zip(random_pixels[0], random_pixels[1]):
+        image.data[i,i] = 0
     image = tester.do_stage(image)
     assert image is not None
+
+
+def test_image_99_percent_0_rejected(set_random_seed):
+    tester = ZerosTest(None)
+    nx = 101
+    ny = 103
+    image = FakeImage(nx=nx, ny=ny)
+    random_pixels = get_random_pixel_pairs(nx, ny, 0.99)
+    for j,i in zip(random_pixels[0], random_pixels[1]):
+        image.data[i] = 0
+    image = tester.do_stage(image)
+    assert image is None
+
+
+def test_single_amp_99_percent_0_rejected(set_random_seed):
+    tester = ZerosTest(None)
+    nx = 101
+    ny = 103
+    n_amps = 4
+    image = FakeImage(nx=nx, ny=ny, n_amps=n_amps)
+    random_pixels = get_random_pixel_pairs(nx, ny, 0.99)
+    for j,i in zip(random_pixels[0], random_pixels[1]):
+        image.data[0][i] = 0
+    image = tester.do_stage(image)
+    assert image is None


### PR DESCRIPTION
This QC check was created as a response to [issue #842](https://lcoglobal.redmineup.com/issues/842) and [issue #10189](https://issues.lco.global/issues/10189), where the all pixels in a camera / amp are exactly 0, signalling a failure of the camera. 