### PR TITLE
Add extra error handling to astrometry stage

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+0.26.4 (2019-07-19)
+-------------------
+- Fix for uncaught exceptions in astrometry stage
+
 0.26.3 (2019-07-17)
 -------------------
 - Updates end-to-end tests to mock the lake

--- a/banzai/astrometry.py
+++ b/banzai/astrometry.py
@@ -61,8 +61,8 @@ class WCSSolver(Stage):
             else:
                 try:
                     logger.error('Astrometry service encountered an error.', image=image,
-                                extra_tags={'astrometry_message': astrometry_response.json().get('message', ''),
-                                            'astrometry_solve_id': astrometry_response.json().get('solve_id', 'UnknownID')})
+                                 extra_tags={'astrometry_message': astrometry_response.json().get('message', ''),
+                                             'astrometry_solve_id': astrometry_response.json().get('solve_id', 'UnknownID')})
                 except:
                     logger.error('Astrometry service encountered an error.', image=image)
 

--- a/banzai/astrometry.py
+++ b/banzai/astrometry.py
@@ -59,9 +59,12 @@ class WCSSolver(Stage):
                 logger.error('Astrometry service query malformed: {msg}'.format(msg=astrometry_response.json()),
                              image=image)
             else:
-                logger.error('Astrometry service encountered an error.', image=image,
-                             extra_tags={'astrometry_message': astrometry_response.json().get('message', ''),
-                                         'astrometry_solve_id': astrometry_response.json().get('solve_id', 'UnknownID')})
+                try:
+                    logger.error('Astrometry service encountered an error.', image=image,
+                                extra_tags={'astrometry_message': astrometry_response.json().get('message', ''),
+                                            'astrometry_solve_id': astrometry_response.json().get('solve_id', 'UnknownID')})
+                except:
+                    logger.error('Astrometry service encountered an error.', image=image)
 
             image.header['WCSERR'] = FAILED_WCS
             return image

--- a/setup.cfg
+++ b/setup.cfg
@@ -84,7 +84,7 @@ edit_on_github = True
 github_project = lcogt/banzai
 
 # version should be PEP440 compatible (http://www.python.org/dev/peps/pep-0440)
-version = 0.26.3
+version = 0.26.4
 
 [options.entry_points]
 console_scripts =


### PR DESCRIPTION
This added `try...except` clause guards against some of the more exotic HTTP errors coming from the astrometry service, which do not contain any JSON in the response. When attempting to log an error, try to log the JSON, and if an exception is raised, simply log that an error occurred and the image filename.