### PR TITLE
runtime_context was passed instead of runtime_context.ignore_schedula…

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+0.26.5 (2019-07-22)
+-------------------
+- Bug fix for ignore schedulability in call to need_to_process inside of process_image
+
 0.26.4 (2019-07-19)
 -------------------
 - Fix for uncaught exceptions in astrometry stage

--- a/banzai/celery.py
+++ b/banzai/celery.py
@@ -106,7 +106,7 @@ def process_image(path, runtime_context_dict):
     logger.info('Running process image.')
     runtime_context = Context(runtime_context_dict)
     try:
-        if realtime_utils.need_to_process_image(path, runtime_context,
+        if realtime_utils.need_to_process_image(path, runtime_context.ignore_schedulability,
                                                 db_address=runtime_context.db_address,
                                                 max_tries=runtime_context.max_tries):
             logger.info('Reducing frame', extra_tags={'filename': os.path.basename(path)})

--- a/banzai/celery.py
+++ b/banzai/celery.py
@@ -106,7 +106,8 @@ def process_image(path, runtime_context_dict):
     logger.info('Running process image.')
     runtime_context = Context(runtime_context_dict)
     try:
-        if realtime_utils.need_to_process_image(path, runtime_context.ignore_schedulability,
+        if realtime_utils.need_to_process_image(path,
+                                                ignore_schedulability=runtime_context.ignore_schedulability,
                                                 db_address=runtime_context.db_address,
                                                 max_tries=runtime_context.max_tries):
             logger.info('Reducing frame', extra_tags={'filename': os.path.basename(path)})

--- a/setup.cfg
+++ b/setup.cfg
@@ -84,7 +84,7 @@ edit_on_github = True
 github_project = lcogt/banzai
 
 # version should be PEP440 compatible (http://www.python.org/dev/peps/pep-0440)
-version = 0.26.4
+version = 0.26.5
 
 [options.entry_points]
 console_scripts =


### PR DESCRIPTION
This fixes a bug where runtime_context was passed to need_to_process_image in place of the ignore_schedubility bool. This has been changed to runtime_context.ignore_schedualbility. 

Because of python's truthyness, this bug did not cause a crash.