### PR TITLE
Feature/enable reduction for standby

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+0.26.8 (2019-08-06)
+-------------------
+- Add ability to automatically reduce data from instruments in STANDBY state.
+
 0.26.7 (2019-07-24)
 -------------------
 - Fixed a typo in the photometry stage

--- a/banzai/dbs.py
+++ b/banzai/dbs.py
@@ -29,6 +29,8 @@ _DEFAULT_DB = 'mysql://cmccully:password@localhost/test'
 
 _CONFIGDB_ADDRESS = 'http://configdb.lco.gtn/sites/'
 
+INSTRUMENT_STATES_TO_REDUCE = ['SCHEDULABLE', 'STANDBY']
+
 Base = declarative_base()
 
 logger = logging.getLogger('banzai')
@@ -174,7 +176,7 @@ def parse_configdb(configdb_address=_CONFIGDB_ADDRESS):
                                       'camera': sci_cam['code'],
                                       'name': ins.get('code'),
                                       'type': sci_cam['camera_type']['code'],
-                                      'schedulable': ins['state'] == 'SCHEDULABLE'}
+                                      'schedulable': ins['state'] in INSTRUMENT_STATES_TO_REDUCE}
                         # hotfix for configdb
                         if instrument['name'] is None:
                             instrument['name'] = instrument['camera']

--- a/banzai/tests/data/configdb_example.json
+++ b/banzai/tests/data/configdb_example.json
@@ -555,7 +555,7 @@
               "instrument_set": [
                 {
                   "id": 66,
-                  "state": "SCHEDULABLE",
+                  "state": "STANDBY",
                   "telescope": "http://configdb.lco.gtn/telescopes/22/?format=json",
                   "science_camera": {
                     "id": 71,

--- a/banzai/tests/e2e-k8s.yaml
+++ b/banzai/tests/e2e-k8s.yaml
@@ -94,7 +94,7 @@ spec:
       resources:
         requests:
           cpu: 0.1
-          memory: 4Gi
+          memory: 8Gi
         limits:
           cpu: 4
           memory: 8Gi

--- a/banzai/tests/test_dbs.py
+++ b/banzai/tests/test_dbs.py
@@ -84,3 +84,10 @@ def test_not_removing_singlets():
     assert len(culled_list) == 2
     assert culled_list[0]['name'] == 'nres01'
     assert culled_list[1]['name'] == 'cam01'
+
+
+def test_standby_marked_schedulable():
+    instrument = dbs.query_for_instrument(db_address='sqlite:///test.db', site='coj', camera='kb98')
+    
+    assert instrument.name == 'kb98'
+    assert instrument.schedulable == True

--- a/banzai/tests/test_dbs.py
+++ b/banzai/tests/test_dbs.py
@@ -88,6 +88,5 @@ def test_not_removing_singlets():
 
 def test_standby_marked_schedulable():
     instrument = dbs.query_for_instrument(db_address='sqlite:///test.db', site='coj', camera='kb98')
-    
     assert instrument.name == 'kb98'
     assert instrument.schedulable == True

--- a/setup.cfg
+++ b/setup.cfg
@@ -84,7 +84,7 @@ edit_on_github = True
 github_project = lcogt/banzai
 
 # version should be PEP440 compatible (http://www.python.org/dev/peps/pep-0440)
-version = 0.26.7
+version = 0.26.8
 
 [options.entry_points]
 console_scripts =


### PR DESCRIPTION
This enables BANZAI to reduce data from cameras in `STANDBY` state. I also added a quick test to check that instruments in STANDBY are marked as SCHEDULABLE in the DB. Updated the ConfigDB test fixture to modify kb98's state from SCHEDULABLE->STANDBY for this purpose.