### PR TITLE
Bugfix/fix instrument name configdb

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+0.27.4 (2019-11-13)
+-------------------
+- Fix for parsing instruments with empty string codes from ConfigDB
+
 0.27.3 (2019-11-04)
 -------------------
 - Fix for retrieving correct number of calibration blocks from observation portal.

--- a/banzai/dbs.py
+++ b/banzai/dbs.py
@@ -179,7 +179,7 @@ def parse_configdb(configdb_address=_CONFIGDB_ADDRESS):
                                       'type': sci_cam['camera_type']['code'],
                                       'schedulable': ins['state'] in INSTRUMENT_STATES_TO_REDUCE}
                         # hotfix for configdb
-                        if instrument['name'] is None:
+                        if not instrument['name']:
                             instrument['name'] = instrument['camera']
                         if instrument['name'] in CAMERAS_FOR_INSTRUMENTS:
                             instrument['camera'] = CAMERAS_FOR_INSTRUMENTS[instrument['name']]

--- a/setup.cfg
+++ b/setup.cfg
@@ -53,7 +53,7 @@ edit_on_github = True
 github_project = lcogt/banzai
 
 # version should be PEP440 compatible (http://www.python.org/dev/peps/pep-0440)
-version = 0.27.3
+version = 0.27.4
 
 [options]
 setup_requires =


### PR DESCRIPTION
When parsing instrument entries from ConfigDB, the instrument code can sometimes be a blank string. If this occurs, then the instrument name would remain an empty string, as `'' is None` evaluates to false.