### PR TITLE
Update ra, dec parsing to use CRVAL keywords

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+0.27.5 (2019-12-11)
+-------------------
+- Change ra, dec parsing to default to CRVAL header keywords. Ref. Redmine issue #1104.
+
 0.27.4 (2019-11-13)
 -------------------
 - Fix for parsing instruments with empty string codes from ConfigDB

--- a/banzai/utils/fits_utils.py
+++ b/banzai/utils/fits_utils.py
@@ -80,13 +80,13 @@ def table_to_fits(table):
 
 def parse_ra_dec(header):
     try:
-        coord = SkyCoord(header.get('RA'), header.get('DEC'), unit=(units.hourangle, units.degree))
+        coord = SkyCoord(header.get('CRVAl1'), header.get('CRVAL2'), unit=(units.degree, units.degree))
         ra = coord.ra.deg
         dec = coord.dec.deg
     except (ValueError, TypeError):
-        # Fallback to CRVAL1 and CRVAL2
+        # Fallback to RA and DEC
         try:
-            coord = SkyCoord(header.get('CRVAl1'), header.get('CRVAL2'), unit=(units.degree, units.degree))
+            coord = SkyCoord(header.get('RA'), header.get('DEC'), unit=(units.hourangle, units.degree))
             ra = coord.ra.deg
             dec = coord.dec.deg
         except (ValueError, TypeError):

--- a/setup.cfg
+++ b/setup.cfg
@@ -53,7 +53,7 @@ edit_on_github = True
 github_project = lcogt/banzai
 
 # version should be PEP440 compatible (http://www.python.org/dev/peps/pep-0440)
-version = 0.27.4
+version = 0.27.5
 
 [options]
 setup_requires =


### PR DESCRIPTION
Issue 1104 describes astrometry solves failing due to erroneous RA, DEC header values. https://lcoglobal.redmineup.com/issues/1104

This change prioritizes CRVAL1, CRVAL2 to be used when getting the ra, dec for an image.