### PR TITLE
Bugfix/fix multiple calibration stacking

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -96,7 +96,7 @@ matrix:
         # time.
 
         - os: linux
-          env: NUMPY_VERSION=1.16.0
+          env: NUMPY_VERSION=1.18.0
 
         # Try numpy pre-release
         - os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -96,7 +96,7 @@ matrix:
         # time.
 
         - os: linux
-          env: NUMPY_VERSION=1.18.0
+          env: NUMPY_VERSION=1.17.4
 
         # Try numpy pre-release
         - os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -96,7 +96,7 @@ matrix:
         # time.
 
         - os: linux
-          env: NUMPY_VERSION=1.13
+          env: NUMPY_VERSION=1.16.0
 
         # Try numpy pre-release
         - os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -107,6 +107,8 @@ matrix:
         - os: linux
           env: MAIN_CMD='pycodestyle banzai --count' RUN_TESTS=0
 
+before_install:
+    - pip uninstall -y numpy
 
 install:
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ env:
         - MAIN_CMD='python setup.py'
         - RUN_TESTS=1
         - SETUP_CMD=''
-        - PIP_DEPENDENCIES='lcogt_logging==0.3.2 requests mock kombu==4.4.0 sqlalchemy python-dateutil elasticsearch>=5.0.0,<6.0.0 celery[redis]==4.3.0 scipy'
+        - PIP_DEPENDENCIES='lcogt_logging==0.3.2 requests mock kombu==4.4.0 sqlalchemy python-dateutil elasticsearch>=5.0.0,<6.0.0 celery[redis]==4.3.0 scipy numpy==1.17.4'
         - EVENT_TYPE='pull_request push'
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,13 +30,13 @@ env:
         # The following versions are the 'default' for tests, unless
         # overridden underneath. They are defined here in order to save having
         # to repeat them for all configurations.
-        - PYTHON_VERSION=3.6
-        - NUMPY_VERSION=stable
+        - PYTHON_VERSION=3.7
+        - NUMPY_VERSION=1.17.4
         - ASTROPY_VERSION=stable
         - MAIN_CMD='python setup.py'
         - RUN_TESTS=1
         - SETUP_CMD=''
-        - PIP_DEPENDENCIES='lcogt_logging==0.3.2 requests mock kombu==4.4.0 sqlalchemy python-dateutil elasticsearch>=5.0.0,<6.0.0 celery[redis]==4.3.0 scipy numpy==1.17.4'
+        - PIP_DEPENDENCIES='lcogt_logging==0.3.2 requests mock kombu==4.4.0 sqlalchemy python-dateutil elasticsearch>=5.0.0,<6.0.0 celery[redis]==4.3.0 scipy'
         - EVENT_TYPE='pull_request push'
 
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+0.27.6 (2020-01-13)
+-------------------
+- Update celery task visibility timeout to 24h to avoid re-scheduling stacking tasks that do not complete within an hour. 
+  This addresses the issue of creating multiple calibration stacks within seconds of each other.
+- https://docs.celeryproject.org/en/latest/getting-started/brokers/redis.html#id1
+
 0.27.5 (2019-12-11)
 -------------------
 - Change ra, dec parsing to default to CRVAL header keywords. Ref. Redmine issue #1104.

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN yum -y install epel-release gcc mariadb-devel \
         && yum -y install fpack \
         && yum -y clean all
 
-RUN conda install -y numpy==1.16.0 pip scipy astropy pytest mock requests ipython coverage pyyaml\
+RUN conda install -y numpy==1.18.0 pip scipy astropy pytest mock requests ipython coverage pyyaml\
         && conda install -y -c conda-forge kombu=4.4.0 elasticsearch\<6.0.0,\>=5.0.0 pytest-astropy mysql-connector-python\
         && conda clean -y --all
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN yum -y install epel-release gcc mariadb-devel \
         && yum -y install fpack \
         && yum -y clean all
 
-RUN conda install -y numpy==1.18.0 pip scipy astropy pytest mock requests ipython coverage pyyaml\
+RUN conda install -y numpy==1.17.4 pip scipy astropy pytest mock requests ipython coverage pyyaml\
         && conda install -y -c conda-forge kombu=4.4.0 elasticsearch\<6.0.0,\>=5.0.0 pytest-astropy mysql-connector-python\
         && conda clean -y --all
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN yum -y install epel-release gcc mariadb-devel \
         && yum -y install fpack \
         && yum -y clean all
 
-RUN conda install -y numpy==1.15.4 pip scipy astropy pytest mock requests ipython coverage pyyaml\
+RUN conda install -y numpy==1.16.0 pip scipy astropy pytest mock requests ipython coverage pyyaml\
         && conda install -y -c conda-forge kombu=4.4.0 elasticsearch\<6.0.0,\>=5.0.0 pytest-astropy mysql-connector-python\
         && conda clean -y --all
 

--- a/banzai/celery.py
+++ b/banzai/celery.py
@@ -14,6 +14,8 @@ from banzai.context import Context
 app = Celery('banzai')
 app.config_from_object('banzai.celeryconfig')
 app.conf.update(broker_url=os.getenv('REDIS_HOST', 'redis://localhost:6379/0'))
+# Increase broker timeout to avoid re-scheduling tasks that aren't completed within an hour
+app.conf.broker_transport_options = {'visibility_timeout': 86400}
 
 logger = logging.getLogger('banzai')
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -58,7 +58,7 @@ version = 0.27.6
 [options]
 setup_requires =
     cython
-    numpy>=1.13
+    numpy>=1.16
 install_requires =
     astropy>=3.0
     scipy

--- a/setup.cfg
+++ b/setup.cfg
@@ -79,7 +79,6 @@ install_requires =
     celery[redis]==4.3.0
     apscheduler
     python-dateutil
-    # astrometry.net>=0.72
 tests_require =
     pytest>=4.0
     mock

--- a/setup.cfg
+++ b/setup.cfg
@@ -53,7 +53,7 @@ edit_on_github = True
 github_project = lcogt/banzai
 
 # version should be PEP440 compatible (http://www.python.org/dev/peps/pep-0440)
-version = 0.27.5
+version = 0.27.6
 
 [options]
 setup_requires =

--- a/setup.cfg
+++ b/setup.cfg
@@ -58,13 +58,13 @@ version = 0.27.6
 [options]
 setup_requires =
     cython
-    numpy>=1.16
+    numpy>=1.18
 install_requires =
     astropy>=3.0
     scipy
     sqlalchemy>=1.3.0b1
     logutils
-    numpy>=1.16
+    numpy>=1.18
     cython
     mysql-connector-python
     lcogt_logging==0.3.2

--- a/setup.cfg
+++ b/setup.cfg
@@ -58,13 +58,13 @@ version = 0.27.6
 [options]
 setup_requires =
     cython
-    numpy>=1.18
+    numpy==1.17.4
 install_requires =
     astropy>=3.0
     scipy
     sqlalchemy>=1.3.0b1
     logutils
-    numpy>=1.18
+    numpy==1.17.4
     cython
     mysql-connector-python
     lcogt_logging==0.3.2

--- a/setup.cfg
+++ b/setup.cfg
@@ -64,7 +64,7 @@ install_requires =
     scipy
     sqlalchemy>=1.3.0b1
     logutils
-    numpy>=1.12
+    numpy>=1.16
     cython
     mysql-connector-python
     lcogt_logging==0.3.2


### PR DESCRIPTION
When the calibration stacking tasks are scheduled, they are often completed >3 hours later. However, when using redis as the celery backend, the default task visibility timeout is 1 hour. This means that if the scheduled task is not completed within an hour, it will be re-scheduled. This is a possible culprit as to why multiple copies of the same task are being executed at once.

https://docs.celeryproject.org/en/latest/getting-started/brokers/redis.html#id1 