### PR TITLE
Update lco-ingester version

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+0.28.1 (2020-01-27)
+-------------------
+- Update lco-ingester to latest version (2.1.9)
+
 0.28.0 (2020-01-23)
 -------------------
 - Migrate BANZAI to be compatible with s3. Frames will now be downloaded from the LCO Archive, and posted

--- a/setup.cfg
+++ b/setup.cfg
@@ -53,7 +53,7 @@ edit_on_github = True
 github_project = lcogt/banzai
 
 # version should be PEP440 compatible (http://www.python.org/dev/peps/pep-0440)
-version = 0.28.0
+version = 0.28.1
 
 [options]
 setup_requires =
@@ -79,7 +79,7 @@ install_requires =
     celery[redis]==4.3.0
     apscheduler
     python-dateutil
-    lco_ingester>=2.1.7
+    lco_ingester>=2.1.9
 tests_require =
     pytest>=4.0
     mock


### PR DESCRIPTION
This updates BANZAI to explicitly use lco-ingester version >=2.1.9. The ingester was updated to better handle the DAY-OBS keyword, BPM files, and correctly create s3 keys in the classic "daydirs" structure.

I have tested ingestion of processed images into the dev archive via my local e2e tests with this version.