### PR TITLE
Add retry+exponential backoff to s3 download.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,10 @@
+0.28.3 (2020-02-11)
+-------------------
+- Fixes for ChunkedEncodingErrors when downloading files from s3:
+- Add retry and exponential backoff to s3 file downloading
+- Add `stream=True` flag to `requests.get()` call when downloading from s3
+- Adds dependency on tenacity==6.0.0 for retry logic
+
 0.28.2 (2020-02-06)
 -------------------
 - Fix for parsing RLEVEL from archived_fits message

--- a/banzai/utils/fits_utils.py
+++ b/banzai/utils/fits_utils.py
@@ -214,6 +214,8 @@ def get_basename(path):
     return basename
 
 
+# Stop after 4 attempts, and back off exponentially with a minimum wait time of 4 seconds, and a maximum of 10.
+# If it fails after 4 attempts, "reraise" the original exception back up to the caller.
 @retry(wait=wait_exponential(multiplier=2, min=4, max=10), stop=stop_after_attempt(4), reraise=True)
 def download_from_s3(file_info, output_directory, runtime_context):
     frame_id = file_info.get('frameid')

--- a/setup.cfg
+++ b/setup.cfg
@@ -53,7 +53,7 @@ edit_on_github = True
 github_project = lcogt/banzai
 
 # version should be PEP440 compatible (http://www.python.org/dev/peps/pep-0440)
-version = 0.28.2
+version = 0.28.3
 
 [options]
 setup_requires =

--- a/setup.cfg
+++ b/setup.cfg
@@ -80,6 +80,7 @@ install_requires =
     apscheduler
     python-dateutil
     lco_ingester>=2.1.9
+    tenacity==6.0.0
 tests_require =
     pytest>=4.0
     mock


### PR DESCRIPTION
We've been seeing some ChunkedEncodingErrors when pulling frames directly from s3, so I've added some basic retry logic with exponential backoff to the s3 downloading function. I found this cool library Tenacity (https://github.com/jd/tenacity) over the weekend that provides a nice, simple interface for setting up retry logic.

Also added the `stream=True` flag to the `requests.get()` call to s3.

For now, I have the parameters set in the decorator; there probably is a better place to put them?