### PR TITLE
Update lco-ingester to 2.1.11 to add extra metrics tag.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+0.28.5 (2020-02-18)
+-------------------
+- Update lco-ingester version to 2.1.11 to add extra metrics tag.
+
 0.28.4 (2020-02-12)
 -------------------
 - Add initial crosstalk coefficients for fa19

--- a/setup.cfg
+++ b/setup.cfg
@@ -53,7 +53,7 @@ edit_on_github = True
 github_project = lcogt/banzai
 
 # version should be PEP440 compatible (http://www.python.org/dev/peps/pep-0440)
-version = 0.28.4
+version = 0.28.5
 
 [options]
 setup_requires =
@@ -79,7 +79,7 @@ install_requires =
     celery[redis]==4.3.0
     apscheduler
     python-dateutil
-    lco_ingester>=2.1.9
+    lco_ingester>=2.1.11
     tenacity==6.0.0
 tests_require =
     pytest>=4.0


### PR DESCRIPTION
We will need to set `INGESTER_PROCESS_NAME=banzai_imaging` in the Rancher deployment.