### PR TITLE
Update calibration image retrieval from db to exclude masters.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+0.28.6 (2020-03-02)
+-------------------
+- Update retrieving individual calibration image records to exclude master calibrations.
+  In some cases, manual stacking of masters was picking up old master calibrations and including
+  them in new master cals.
+
 0.28.5 (2020-02-18)
 -------------------
 - Update lco-ingester version to 2.1.11 to add extra metrics tag.

--- a/banzai/dbs.py
+++ b/banzai/dbs.py
@@ -490,6 +490,7 @@ def get_individual_calibration_image_records(instrument, calibration_type, min_d
     calibration_criteria &= CalibrationImage.type == calibration_type.upper()
     calibration_criteria &= CalibrationImage.dateobs >= parse(min_date).replace(tzinfo=None)
     calibration_criteria &= CalibrationImage.dateobs <= parse(max_date).replace(tzinfo=None)
+    calibration_criteria &= CalibrationImage.is_master == False
 
     if not include_bad_frames:
         calibration_criteria &= CalibrationImage.is_bad == False

--- a/setup.cfg
+++ b/setup.cfg
@@ -53,7 +53,7 @@ edit_on_github = True
 github_project = lcogt/banzai
 
 # version should be PEP440 compatible (http://www.python.org/dev/peps/pep-0440)
-version = 0.28.5
+version = 0.28.6
 
 [options]
 setup_requires =


### PR DESCRIPTION
In the case when manually stacking masters using BANZAI-Web, operator error may cause old masters that lie within the stacking time range to be included in new masters, which is incorrect behavior.

Thank you to @drhaz for identifying the problem.