### PR TITLE
Fix/truncate exptime

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+0.28.7 (2020-03-05)
+-------------------
+- Explicitly truncate exposure time to 6 decimal places, since the Archive API will not accept EXPTIME values with more decimal places.
+
 0.28.6 (2020-03-02)
 -------------------
 - Update retrieving individual calibration image records to exclude master calibrations.

--- a/banzai/images.py
+++ b/banzai/images.py
@@ -179,6 +179,7 @@ class Image(object):
         image_hdu.header['BZERO'] = 0.0
         image_hdu.header['SIMPLE'] = True
         image_hdu.header['EXTEND'] = True
+        image_hdu.header['EXPTIME'] = '{:0.6f}'.format(self.exptime)
         image_hdu.name = 'SCI'
 
         hdu_list = [image_hdu]

--- a/setup.cfg
+++ b/setup.cfg
@@ -79,7 +79,7 @@ install_requires =
     celery[redis]==4.3.0
     apscheduler
     python-dateutil
-    lco_ingester>=2.1.11
+    lco_ingester>=2.1.13
     tenacity==6.0.0
 tests_require =
     pytest>=4.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -53,7 +53,7 @@ edit_on_github = True
 github_project = lcogt/banzai
 
 # version should be PEP440 compatible (http://www.python.org/dev/peps/pep-0440)
-version = 0.28.6
+version = 0.28.7
 
 [options]
 setup_requires =


### PR DESCRIPTION
Explicitly truncate exposure time to 6 decimal places, since the Archive API will not accept EXPTIME values with more decimal places.