### PR TITLE
Update lco-ingester dependency version

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+0.28.8 (2020-03-09)
+-------------------
+- Upgrade ingester lib version to address OpenTSDB default HTTP port issue.
+- Fix EXPTIME to be a float, rounded to 6 digits.
+
 0.28.7 (2020-03-05)
 -------------------
 - Explicitly truncate exposure time to 6 decimal places, since the Archive API will not accept EXPTIME values with more decimal places.

--- a/banzai/images.py
+++ b/banzai/images.py
@@ -179,7 +179,7 @@ class Image(object):
         image_hdu.header['BZERO'] = 0.0
         image_hdu.header['SIMPLE'] = True
         image_hdu.header['EXTEND'] = True
-        image_hdu.header['EXPTIME'] = '{:0.6f}'.format(self.exptime)
+        image_hdu.header['EXPTIME'] = np.around(self.exptime, decimals=6)
         image_hdu.name = 'SCI'
 
         hdu_list = [image_hdu]

--- a/setup.cfg
+++ b/setup.cfg
@@ -53,7 +53,7 @@ edit_on_github = True
 github_project = lcogt/banzai
 
 # version should be PEP440 compatible (http://www.python.org/dev/peps/pep-0440)
-version = 0.28.7
+version = 0.28.8
 
 [options]
 setup_requires =

--- a/setup.cfg
+++ b/setup.cfg
@@ -79,7 +79,7 @@ install_requires =
     celery[redis]==4.3.0
     apscheduler
     python-dateutil
-    lco_ingester>=2.1.13
+    lco_ingester>=2.1.14
     tenacity==6.0.0
 tests_require =
     pytest>=4.0


### PR DESCRIPTION
The lco-ingester library has been updated to version 2.1.14, which
itself contains an update to one of its dependencies,
opentsdb-python-metrics, which publishes metrics data on the standard
HTTP port 80 by default, rather than using a custom port number.

This behavior is also now configurable, rather than being hard-coded
into the library.

With this change, the LCO IT staff will be able to migrate the OpenTSDB
server to our newer hardware platform.