### PR TITLE
Explicitly filter out bad masters when selecting master calibration images.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+0.28.9 (2020-03-18)
+-------------------
+- Fix master calibration image selection to not use frames marked as bad.
+
 0.28.8 (2020-03-09)
 -------------------
 - Upgrade ingester lib version to address OpenTSDB default HTTP port issue.

--- a/banzai/dbs.py
+++ b/banzai/dbs.py
@@ -452,6 +452,7 @@ def get_master_calibration_image_record(image, calibration_type, master_selectio
     calibration_criteria = CalibrationImage.type == calibration_type.upper()
     calibration_criteria &= CalibrationImage.instrument_id == image.instrument.id
     calibration_criteria &= CalibrationImage.is_master.is_(True)
+    calibration_criteria &= CalibrationImage.is_bad.is_(False)
 
     for criterion in master_selection_criteria:
         # We have to cast to strings according to the sqlalchemy docs for version 1.3:

--- a/setup.cfg
+++ b/setup.cfg
@@ -53,7 +53,7 @@ edit_on_github = True
 github_project = lcogt/banzai
 
 # version should be PEP440 compatible (http://www.python.org/dev/peps/pep-0440)
-version = 0.28.8
+version = 0.28.9
 
 [options]
 setup_requires =


### PR DESCRIPTION
Nikolaus noticed that even though he had marked some masters as bad in the BANZAI DB and re-processed the affected images, they were still being processed with the same masters. I confirmed this, and found that we never explicitly enforce the `is_bad=False` criteria in the selection logic.