### PR TITLE
Default Context

### DIFF
--- a/banzai/__init__.py
+++ b/banzai/__init__.py
@@ -30,3 +30,6 @@ logger = logging.getLogger('banzai')
 handler = logging.StreamHandler(stream=sys.stdout)
 handler.setFormatter(LCOGTFormatter())
 logger.addHandler(handler)
+
+sqlalchemy_logger = logging.getLogger('sqlalchemy')
+sqlalchemy_logger.setLevel(logging.WARN)

--- a/banzai/__init__.py
+++ b/banzai/__init__.py
@@ -31,5 +31,5 @@ handler = logging.StreamHandler(stream=sys.stdout)
 handler.setFormatter(LCOGTFormatter())
 logger.addHandler(handler)
 
-sqlalchemy_logger = logging.getLogger('sqlalchemy')
-sqlalchemy_logger.setLevel(logging.WARN)
+# Default the logger to INFO so that we actually get messages by default.
+logger.setLevel('INFO')

--- a/banzai/logs.py
+++ b/banzai/logs.py
@@ -8,7 +8,7 @@ from banzai.utils import date_utils
 
 
 class BanzaiLogger(logging.getLoggerClass()):
-    def __init__(self, name, level='INFO'):
+    def __init__(self, name, level='NOTSET'):
         super(BanzaiLogger, self).__init__(name, level)
 
     def _log(self, level, msg, *args, **kwargs):

--- a/banzai/logs.py
+++ b/banzai/logs.py
@@ -8,7 +8,7 @@ from banzai.utils import date_utils
 
 
 class BanzaiLogger(logging.getLoggerClass()):
-    def __init__(self, name, level='NOTSET'):
+    def __init__(self, name, level='INFO'):
         super(BanzaiLogger, self).__init__(name, level)
 
     def _log(self, level, msg, *args, **kwargs):

--- a/banzai/main.py
+++ b/banzai/main.py
@@ -54,9 +54,17 @@ def add_settings_to_context(args, settings):
             setattr(args, setting, getattr(settings, setting))
 
 
-def parse_args(settings, extra_console_arguments=None, parser_description='Process LCO data.'):
-    """Parse arguments, including default command line argument, and set the overall log level"""
-
+def parse_args(settings, extra_console_arguments=None, parser_description='Process LCO data.',
+               parse_system_args=True):
+    """
+    Create a context object from the given arguments
+    :param settings: settings object/module that has defaults for the context object
+    :param extra_console_arguments: Non default arguments to add to the command line
+    :param parser_description: Help str printed to the console
+    :param parse_system_args: Actually parse command line parameters. Setting this False is
+        useful to create a context object with defaults to be used for testing.
+    :return:
+    """
     parser = argparse.ArgumentParser(description=parser_description)
 
     parser.add_argument("--processed-path", default='/archive/engineering',
@@ -97,8 +105,11 @@ def parse_args(settings, extra_console_arguments=None, parser_description='Proce
         extra_console_arguments = []
     for argument in extra_console_arguments:
         parser.add_argument(*argument['args'], **argument['kwargs'])
-    args = parser.parse_args()
 
+    if parse_system_args:
+        args = parser.parse_args()
+    else:
+        args = parser.parse_args([])
     logs.set_log_level(args.log_level)
 
     add_settings_to_context(args, settings)


### PR DESCRIPTION
Added the ability to make a context object without actually parsing command line args. This is useful for testing or running things manually.