### PR TITLE
Fix/generalize hdu ordering

### DIFF
--- a/banzai/calibrations.py
+++ b/banzai/calibrations.py
@@ -58,7 +58,10 @@ class CalibrationStacker(CalibrationMaker):
 
         grouping = self.runtime_context.CALIBRATION_SET_CRITERIA.get(images[0].obstype, [])
         master_frame_class = import_utils.import_attribute(self.runtime_context.MASTER_CALIBRATION_FRAME_CLASS)
-        master_image = master_frame_class(images, master_calibration_filename, grouping_criteria=grouping)
+        hdu_order = self.runtime_context.MASTER_CALIBRATION_EXTENSION_ORDER.get(self.calibration_type)
+
+        master_image = master_frame_class.init_master_frame(images, master_calibration_filename,
+                                                            grouping_criteria=grouping, hdu_order=hdu_order)
 
         # turn off memory mapping for each segment
         for image in images:

--- a/banzai/calibrations.py
+++ b/banzai/calibrations.py
@@ -57,7 +57,7 @@ class CalibrationStacker(CalibrationMaker):
         master_calibration_filename = make_calibration_name(max(images, key=lambda x: datetime.strptime(x.epoch, '%Y%m%d') ))
 
         grouping = self.runtime_context.CALIBRATION_SET_CRITERIA.get(images[0].obstype, [])
-        master_frame_class = import_utils.import_attribute(self.runtime_context.MASTER_CALIBRATION_FRAME_CLASS)
+        master_frame_class = import_utils.import_attribute(self.runtime_context.CALIBRATION_FRAME_CLASS)
         hdu_order = self.runtime_context.MASTER_CALIBRATION_EXTENSION_ORDER.get(self.calibration_type)
 
         master_image = master_frame_class.init_master_frame(images, master_calibration_filename,

--- a/banzai/frames.py
+++ b/banzai/frames.py
@@ -14,12 +14,13 @@ logger = logging.getLogger('banzai')
 
 
 class ObservationFrame(metaclass=abc.ABCMeta):
-    def __init__(self, hdu_list: list, file_path: str, frame_id: int = None):
+    def __init__(self, hdu_list: list, file_path: str, frame_id: int = None, hdu_order: list = None):
         self._hdus = hdu_list
         self._file_path = file_path
         self.ra, self.dec = fits_utils.parse_ra_dec(hdu_list[0].meta)
         self.instrument = None
         self.frame_id = frame_id
+        self.hdu_order = hdu_order
 
     @property
     def primary_hdu(self):
@@ -170,7 +171,7 @@ class ObservationFrame(metaclass=abc.ABCMeta):
         hdu_list_to_write = fits.HDUList([])
         for hdu in self._hdus:
             hdu_list_to_write += hdu.to_fits(context)
-        fits_utils.reorder_hdus(hdu_list_to_write, context.REDUCED_DATA_EXTENSION_ORDERING.get(self.obstype))
+        fits_utils.reorder_hdus(hdu_list_to_write, self.hdu_order)
         if not isinstance(hdu_list_to_write[0], fits.PrimaryHDU):
             hdu_list_to_write[0] = fits.PrimaryHDU(data=hdu_list_to_write[0].data, header=hdu_list_to_write[0].header)
         if context.fpack:

--- a/banzai/frames.py
+++ b/banzai/frames.py
@@ -170,7 +170,7 @@ class ObservationFrame(metaclass=abc.ABCMeta):
         hdu_list_to_write = fits.HDUList([])
         for hdu in self._hdus:
             hdu_list_to_write += hdu.to_fits(context)
-        fits_utils.reorder_hdus(hdu_list_to_write, self.obstype, context.REDUCED_DATA_EXTENSION_ORDERING)
+        fits_utils.reorder_hdus(hdu_list_to_write, context.REDUCED_DATA_EXTENSION_ORDERING.get(self.obstype))
         if not isinstance(hdu_list_to_write[0], fits.PrimaryHDU):
             hdu_list_to_write[0] = fits.PrimaryHDU(data=hdu_list_to_write[0].data, header=hdu_list_to_write[0].header)
         if context.fpack:

--- a/banzai/frames.py
+++ b/banzai/frames.py
@@ -170,7 +170,7 @@ class ObservationFrame(metaclass=abc.ABCMeta):
         hdu_list_to_write = fits.HDUList([])
         for hdu in self._hdus:
             hdu_list_to_write += hdu.to_fits(context)
-        fits_utils.reorder_hdus(hdu_list_to_write, self.obstype, context)
+        fits_utils.reorder_hdus(hdu_list_to_write, self.obstype, context.REDUCED_DATA_EXTENSION_ORDERING)
         if not isinstance(hdu_list_to_write[0], fits.PrimaryHDU):
             hdu_list_to_write[0] = fits.PrimaryHDU(data=hdu_list_to_write[0].data, header=hdu_list_to_write[0].header)
         if context.fpack:

--- a/banzai/lco.py
+++ b/banzai/lco.py
@@ -150,8 +150,8 @@ class LCOCalibrationFrame(LCOObservationFrame, CalibrationFrame):
         data_class = type(images[0].primary_hdu)
         hdu_list = [data_class(data=np.zeros(images[0].data.shape, dtype=images[0].data.dtype),
                                meta=cls.init_master_header(images[0].meta, images))]
-        frame = cls.__init__(hdu_list=hdu_list, file_path=file_path, frame_id=frame_id,
-                             grouping_criteria=grouping_criteria, hdu_order=hdu_order)
+        frame = cls(hdu_list=hdu_list, file_path=file_path, frame_id=frame_id,
+                    grouping_criteria=grouping_criteria, hdu_order=hdu_order)
         frame.is_master = True
         frame.instrument = images[0].instrument
         return frame

--- a/banzai/settings.py
+++ b/banzai/settings.py
@@ -13,7 +13,7 @@ FRAME_SELECTION_CRITERIA = [('type', 'not contains', 'FLOYDS'), ('type', 'not co
 
 FRAME_FACTORY = 'banzai.lco.LCOFrameFactory'
 
-MASTER_CALIBRATION_FRAME_CLASS = 'banzai.lco.LCOMasterCalibrationFrame'
+CALIBRATION_FRAME_CLASS = 'banzai.lco.LCOCalibrationFrame'
 
 ORDERED_STAGES = ['banzai.bpm.BadPixelMaskLoader',
                   'banzai.bpm.SaturatedPixelFlagger',
@@ -124,4 +124,7 @@ REDUCED_DATA_EXTENSION_ORDERING = {'BIAS': ['SCI', 'BPM', 'ERR'],
                                    'DARK': ['SCI', 'BPM', 'ERR'],
                                    'SKYFLAT': ['SCI', 'BPM', 'ERR'],
                                    'EXPOSE': ['SCI', 'CAT', 'BPM', 'ERR'],
-                                   'STANDARD':['SCI', 'CAT', 'BPM', 'ERR']}
+                                   'STANDARD': ['SCI', 'CAT', 'BPM', 'ERR']}
+MASTER_CALIBRATION_EXTENSION_ORDER = {'BIAS': ['SCI', 'BPM', 'ERR'],
+                                      'DARK': ['SCI', 'BPM', 'ERR'],
+                                      'SKYFLAT': ['SCI', 'BPM', 'ERR']}

--- a/banzai/tests/test_calibration_stacker.py
+++ b/banzai/tests/test_calibration_stacker.py
@@ -14,8 +14,11 @@ header = {'DATASEC': f'[1:{nx},1:{ny}]', 'DETSEC': f'[1:{nx},1:{ny}]', 'CCDSUM':
 context = {'CALIBRATION_MIN_FRAMES': {'TEST': 1},
            'CALIBRATION_FILENAME_FUNCTIONS': {'TEST': ['banzai.utils.file_utils.ccdsum_to_filename']},
            'CALIBRATION_SET_CRITERIA': {'TEST': ['binning']},
-           'MASTER_CALIBRATION_FRAME_CLASS': 'banzai.lco.LCOMasterCalibrationFrame',
-           'TELESCOPE_FILENAME_FUNCTION': 'banzai.utils.file_utils.telescope_to_filename'}
+           'CALIBRATION_FRAME_CLASS': 'banzai.lco.LCOCalibrationFrame',
+           'TELESCOPE_FILENAME_FUNCTION': 'banzai.utils.file_utils.telescope_to_filename',
+           'MASTER_CALIBRATION_EXTENSION_ORDER': {'BIAS': ['SCI', 'BPM', 'ERR'],
+                                                  'DARK': ['SCI', 'BPM', 'ERR'],
+                                                  'SKYFLAT': ['SCI', 'BPM', 'ERR']}}
 context = Context(context)
 instrument = Instrument(site='cpt', camera='fa11', name='fa11')
 

--- a/banzai/tests/test_frames.py
+++ b/banzai/tests/test_frames.py
@@ -42,6 +42,7 @@ def test_exposure_to_fits_reorder_no_fpack():
 def test_calibration_to_fits_reorder_fpack():
     hdu_list = [FakeCCDData(meta={'EXTNAME': 'SCI', 'OBSTYPE': 'BIAS'})]
     test_frame = FakeLCOObservationFrame(hdu_list=hdu_list)
+    test_frame.hdu_order = ['SCI', 'BPM', 'ERR']
     context = FakeContext()
     context.fpack = True
     assert [hdu.header.get('EXTNAME') for hdu in test_frame.to_fits(context)] == [None, 'SCI', 'BPM', 'ERR']
@@ -50,6 +51,7 @@ def test_calibration_to_fits_reorder_fpack():
 def test_calibration_to_fits_reorder_no_fpack():
     hdu_list = [FakeCCDData(meta={'EXTNAME': 'SCI', 'OBSTYPE': 'BIAS'})]
     test_frame = FakeLCOObservationFrame(hdu_list=hdu_list)
+    test_frame.hdu_order = ['SCI', 'BPM', 'ERR']
     context = FakeContext()
     context.fpack = False
     assert [hdu.header.get('EXTNAME') for hdu in test_frame.to_fits(context)] == ['SCI', 'BPM', 'ERR']

--- a/banzai/tests/utils.py
+++ b/banzai/tests/utils.py
@@ -62,6 +62,7 @@ class FakeLCOObservationFrame(LCOObservationFrame):
         self.primary_hdu.meta['DAY-OBS'] = epoch
         self._file_path = file_path
         self.is_bad = False
+        self.hdu_order = ['SCI', 'CAT', 'BPM', 'ERR']
 
         for keyword in kwargs:
             setattr(self, keyword, kwargs[keyword])

--- a/banzai/utils/fits_utils.py
+++ b/banzai/utils/fits_utils.py
@@ -216,8 +216,15 @@ def to_fits_image_extension(data, master_extension_name, extension_name, context
     return fits.ImageHDU(data=data, header=header)
 
 
-def reorder_hdus(hdu_list: List,  obstype: str, context: Context):
-    for idx, extension_name in enumerate(context.REDUCED_DATA_EXTENSION_ORDERING.get(obstype)):
+def reorder_hdus(hdu_list: fits.HDUList,  obstype: str, ordering_dict: dict):
+    """
+    Re-order HDUs in an HDUList before writing to disk
+    :param hdu_list: Astropy fits.HDUList
+    :param obstype: Observation type from header
+    :param ordering_dict: A dictionary, keyed by OBSTYPE with the desired ordering of
+    extensions by EXTNAME
+    """
+    for idx, extension_name in enumerate(ordering_dict.get(obstype)):
         if hdu_list[idx].name != extension_name:
             hdu = hdu_list[extension_name]
             hdu_list.remove(hdu)

--- a/banzai/utils/fits_utils.py
+++ b/banzai/utils/fits_utils.py
@@ -222,6 +222,8 @@ def reorder_hdus(hdu_list: fits.HDUList, extensions: list):
     :param hdu_list: Astropy fits.HDUList
     :param extensions: Ordered list of extensions by EXTNAME
     """
+    if extensions is None:
+        extensions = []
     for idx, extension_name in enumerate(extensions):
         if hdu_list[idx].name != extension_name:
             hdu = hdu_list[extension_name]

--- a/banzai/utils/fits_utils.py
+++ b/banzai/utils/fits_utils.py
@@ -216,15 +216,13 @@ def to_fits_image_extension(data, master_extension_name, extension_name, context
     return fits.ImageHDU(data=data, header=header)
 
 
-def reorder_hdus(hdu_list: fits.HDUList,  obstype: str, ordering_dict: dict):
+def reorder_hdus(hdu_list: fits.HDUList, extensions: list):
     """
     Re-order HDUs in an HDUList before writing to disk
     :param hdu_list: Astropy fits.HDUList
-    :param obstype: Observation type from header
-    :param ordering_dict: A dictionary, keyed by OBSTYPE with the desired ordering of
-    extensions by EXTNAME
+    :param extensions: Ordered list of extensions by EXTNAME
     """
-    for idx, extension_name in enumerate(ordering_dict.get(obstype)):
+    for idx, extension_name in enumerate(extensions):
         if hdu_list[idx].name != extension_name:
             hdu = hdu_list[extension_name]
             hdu_list.remove(hdu)


### PR DESCRIPTION
Users of the LCOObservationFrame class can override its `to_fits()` method and use any OBSTYPE->extension ordering dict they like. This generalizes the HDU ordering behavior so that master calibrations can be treated differently from regular calibrations when re-ordering the HDUs.