### PR TITLE
Add ability to coerce final data products into correct data type.

### DIFF
--- a/banzai/frames.py
+++ b/banzai/frames.py
@@ -174,6 +174,7 @@ class ObservationFrame(metaclass=abc.ABCMeta):
         fits_utils.reorder_hdus(hdu_list_to_write, self.hdu_order)
         if not isinstance(hdu_list_to_write[0], fits.PrimaryHDU):
             hdu_list_to_write[0] = fits.PrimaryHDU(data=hdu_list_to_write[0].data, header=hdu_list_to_write[0].header)
+        fits_utils.convert_extension_datatypes(hdu_list_to_write, context.REDUCED_DATA_EXTENSION_TYPES)
         if context.fpack:
             hdu_list_to_write = fits_utils.pack(hdu_list_to_write)
         return hdu_list_to_write

--- a/banzai/lco.py
+++ b/banzai/lco.py
@@ -399,7 +399,7 @@ class LCOFrameFactory(FrameFactory):
                     if len(hdu.data.shape) > 2:
                         hdu_list += self._munge_data_cube(hdu)
                     if hdu.data.dtype == np.uint16:
-                        hdu.data = hdu.data.astype(np.float32)
+                        hdu.data = hdu.data.astype(np.float64)
                     # check if we need to propagate any header keywords from the primary header
                     if primary_hdu is not None:
                         for keyword in self.primary_header_keys_to_propagate:

--- a/banzai/settings.py
+++ b/banzai/settings.py
@@ -125,6 +125,11 @@ REDUCED_DATA_EXTENSION_ORDERING = {'BIAS': ['SCI', 'BPM', 'ERR'],
                                    'SKYFLAT': ['SCI', 'BPM', 'ERR'],
                                    'EXPOSE': ['SCI', 'CAT', 'BPM', 'ERR'],
                                    'STANDARD': ['SCI', 'CAT', 'BPM', 'ERR']}
+
 MASTER_CALIBRATION_EXTENSION_ORDER = {'BIAS': ['SCI', 'BPM', 'ERR'],
                                       'DARK': ['SCI', 'BPM', 'ERR'],
                                       'SKYFLAT': ['SCI', 'BPM', 'ERR']}
+
+REDUCED_DATA_EXTENSION_TYPES = {'SCI': 'numpy.float32',
+                                'ERR': 'numpy.float32',
+                                'BPM': 'numpy.uint8'}

--- a/banzai/settings.py
+++ b/banzai/settings.py
@@ -130,6 +130,6 @@ MASTER_CALIBRATION_EXTENSION_ORDER = {'BIAS': ['SCI', 'BPM', 'ERR'],
                                       'DARK': ['SCI', 'BPM', 'ERR'],
                                       'SKYFLAT': ['SCI', 'BPM', 'ERR']}
 
-REDUCED_DATA_EXTENSION_TYPES = {'SCI': 'numpy.float32',
-                                'ERR': 'numpy.float32',
-                                'BPM': 'numpy.uint8'}
+REDUCED_DATA_EXTENSION_TYPES = {'SCI': 'float32',
+                                'ERR': 'float32',
+                                'BPM': 'uint8'}

--- a/banzai/tests/test_frames.py
+++ b/banzai/tests/test_frames.py
@@ -57,6 +57,21 @@ def test_calibration_to_fits_reorder_no_fpack():
     assert [hdu.header.get('EXTNAME') for hdu in test_frame.to_fits(context)] == ['SCI', 'BPM', 'ERR']
 
 
+def test_all_datatypes_wrong():
+    hdu_list = [FakeCCDData(data=np.ones((2,2), dtype=np.float64),meta={'EXTNAME':'SCI'}),
+                FakeCCDData(data=np.ones((2,2), dtype=np.float64), meta={'EXTNAME':'BPM'}),
+                FakeCCDData(data=np.ones((2,2), dtype=np.float64), meta={'EXTNAME':'ERR'})]
+    test_frame = FakeLCOObservationFrame(hdu_list=hdu_list)
+    test_frame.hdu_order = ['SCI', 'BPM', 'ERR']
+    context = FakeContext()
+    context.fpack = False
+    output_hdu_list = test_frame.to_fits(context)
+
+    assert output_hdu_list['SCI'].data.dtype == np.float32
+    assert output_hdu_list['BPM'].data.dtype == np.uint8
+    assert output_hdu_list['ERR'].data.dtype == np.float32
+
+
 def test_subtract():
     test_data = FakeCCDData(image_multiplier=4, uncertainty=3)
     test_data -= 1

--- a/banzai/utils/fits_utils.py
+++ b/banzai/utils/fits_utils.py
@@ -234,8 +234,8 @@ def reorder_hdus(hdu_list: fits.HDUList, extensions: list):
 def convert_extension_datatypes(hdu_list: fits.HDUList, extension_datatypes: dict):
     """
     Convert extensions' data types into desired form.
-    :param data: FITS HDUList
-    :param extension_datatypes: Dictionary of desired data types, keyed by exentension name
+    :param hdu_list: FITS HDUList
+    :param extension_datatypes: Dictionary of desired data types, keyed by extension name
     """
     for hdu in hdu_list:
         if hdu.name in extension_datatypes:

--- a/banzai/utils/fits_utils.py
+++ b/banzai/utils/fits_utils.py
@@ -3,7 +3,6 @@ from typing import Optional
 import requests
 
 from banzai import logs
-from banzai.utils import import_utils
 
 import numpy as np
 from astropy.io import fits
@@ -239,5 +238,4 @@ def convert_extension_datatypes(hdu_list: fits.HDUList, extension_datatypes: dic
     """
     for hdu in hdu_list:
         if hdu.name in extension_datatypes:
-            data_type_object = import_utils.import_attribute(extension_datatypes.get(hdu.name))
-            hdu.data = data_type_object(hdu.data)
+            hdu.data = hdu.data.astype(extension_datatypes[hdu.name])

--- a/banzai/utils/fits_utils.py
+++ b/banzai/utils/fits_utils.py
@@ -1,9 +1,9 @@
 import logging
-from typing import Optional, List
+from typing import Optional
 import requests
 
 from banzai import logs
-from banzai.context import Context
+from banzai.utils import import_utils
 
 import numpy as np
 from astropy.io import fits
@@ -229,3 +229,15 @@ def reorder_hdus(hdu_list: fits.HDUList, extensions: list):
             hdu = hdu_list[extension_name]
             hdu_list.remove(hdu)
             hdu_list.insert(idx, hdu)
+
+
+def convert_extension_datatypes(hdu_list: fits.HDUList, extension_datatypes: dict):
+    """
+    Convert extensions' data types into desired form.
+    :param data: FITS HDUList
+    :param extension_datatypes: Dictionary of desired data types, keyed by exentension name
+    """
+    for hdu in hdu_list:
+        if hdu.name in extension_datatypes:
+            data_type_object = import_utils.import_attribute(extension_datatypes.get(hdu.name))
+            hdu.data = data_type_object(hdu.data)


### PR DESCRIPTION
This adds the ability for users of the ObservationFrame class to define a set of datatypes they would wish to enforce upon their extensions' `data` attributes. 

We now also explicitly cast unsigned 16-bit integer data from the raw images into 64-bit floating point for processing. It is coerced at the final step, when the image is written out.