### PR TITLE
Update ingester lib version to properly deal with frames that do not have RA/DEC defined.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -126,7 +126,7 @@ install_requires =
     celery[redis]==4.3.0
     apscheduler
     python-dateutil
-    lco_ingester>=2.1.14
+    lco_ingester>=2.1.15
     tenacity==6.0.0
 
 tests_require =


### PR DESCRIPTION
This is mainly to deal with BANZAI-NRES.