### PR TITLE
Add logic to munge data and trim sections for fs01 into correct form.

### DIFF
--- a/banzai/lco.py
+++ b/banzai/lco.py
@@ -400,7 +400,7 @@ class LCOFrameFactory(FrameFactory):
                         hdu_list += self._munge_data_cube(hdu)
                     # update datasec/trimsec for fs01
                     if hdu.header.get('INSTRUME') == 'fs01':
-                        self._update_spectral_sections(hdu)
+                        self._update_fs01_sections(hdu)
                     if hdu.data.dtype == np.uint16:
                         hdu.data = hdu.data.astype(np.float64)
                     # check if we need to propagate any header keywords from the primary header
@@ -489,16 +489,19 @@ class LCOFrameFactory(FrameFactory):
             raise MissingSaturate
 
     @staticmethod
-    def _update_spectral_sections(hdu):
+    def _update_fs01_sections(hdu):
         """
         Manually update data and trim sections for fs01 spectral camera
         :param hdu: Astropy ImageHDU
         """
-        section_keywords = {'TRIMSEC': '[2:2046,3:2015]',
-                            'DATASEC': '[10:2056,16:2032]'}
+        old_section_keywords = {'TRIMSEC': '[11:2055,19:2031]',
+                                'DATASEC': '[1:2048,1:2048]'}
+        new_section_keywords = {'TRIMSEC': '[2:2046,3:2015]',
+                                'DATASEC': '[10:2056,16:2032]'}
 
-        for key in section_keywords:
-            hdu.header[key] = section_keywords[key]
+        for key in old_section_keywords:
+            if hdu.header[key] == old_section_keywords[key]:
+                hdu.header[key] = new_section_keywords[key]
 
     @staticmethod
     def _init_detector_sections(image):

--- a/banzai/lco.py
+++ b/banzai/lco.py
@@ -398,6 +398,9 @@ class LCOFrameFactory(FrameFactory):
                             associated_data[associated_extension['NAME']] = None
                     if len(hdu.data.shape) > 2:
                         hdu_list += self._munge_data_cube(hdu)
+                    # update datasec/trimsec for fs01
+                    if hdu.meta['INSTRUME'] == 'fs01':
+                        self._update_spectral_sections(hdu)
                     if hdu.data.dtype == np.uint16:
                         hdu.data = hdu.data.astype(np.float64)
                     # check if we need to propagate any header keywords from the primary header
@@ -484,6 +487,18 @@ class LCOFrameFactory(FrameFactory):
             logger.error('The SATURATE keyword was not valid and there are no defaults in banzai for this camera.',
                          image=image)
             raise MissingSaturate
+
+    @staticmethod
+    def _update_spectral_sections(hdu):
+        """
+        Manually update data and trim sections for fs01 spectral camera
+        :param hdu: BANZAI CCDData object
+        """
+        section_keywords = {'TRIMSEC': '[2:2046,3:2015]',
+                            'DATASEC': '[10:2056,16:2032]'}
+
+        for key in section_keywords:
+            hdu.meta[key] = section_keywords[key]
 
     @staticmethod
     def _init_detector_sections(image):

--- a/banzai/lco.py
+++ b/banzai/lco.py
@@ -399,7 +399,7 @@ class LCOFrameFactory(FrameFactory):
                     if len(hdu.data.shape) > 2:
                         hdu_list += self._munge_data_cube(hdu)
                     # update datasec/trimsec for fs01
-                    if hdu.meta['INSTRUME'] == 'fs01':
+                    if hdu.header.get('INSTRUME') == 'fs01':
                         self._update_spectral_sections(hdu)
                     if hdu.data.dtype == np.uint16:
                         hdu.data = hdu.data.astype(np.float64)
@@ -492,13 +492,13 @@ class LCOFrameFactory(FrameFactory):
     def _update_spectral_sections(hdu):
         """
         Manually update data and trim sections for fs01 spectral camera
-        :param hdu: BANZAI CCDData object
+        :param hdu: Astropy ImageHDU
         """
         section_keywords = {'TRIMSEC': '[2:2046,3:2015]',
                             'DATASEC': '[10:2056,16:2032]'}
 
         for key in section_keywords:
-            hdu.meta[key] = section_keywords[key]
+            hdu.header[key] = section_keywords[key]
 
     @staticmethod
     def _init_detector_sections(image):

--- a/banzai/tests/test_frames.py
+++ b/banzai/tests/test_frames.py
@@ -1,6 +1,7 @@
 import pytest
 import numpy as np
 from astropy.table import Table
+from astropy.io.fits import ImageHDU, Header
 
 from banzai.utils.image_utils import Section
 from banzai.data import CCDData, DataTable
@@ -16,13 +17,14 @@ def set_random_seed():
 
 
 def test_update_trimsec_fs01():
-    test_hdu = FakeCCDData(meta={'TRIMSEC': '[11:2055,19:2031]',
-                                 'DATASEC': '[1:2048,1:2048]',
-                                 'INSTRUME': 'fs01'})
+    test_header = Header({'TRIMSEC': '[11:2055,19:2031]',
+                          'DATASEC': '[1:2048,1:2048]',
+                          'INSTRUME': 'fs01'})
+    test_hdu = ImageHDU(data=np.ones(10), header=test_header)
     LCOFrameFactory._update_spectral_sections(test_hdu)
 
-    assert test_hdu.meta.get('TRIMSEC') == '[2:2046,3:2015]'
-    assert test_hdu.meta.get('DATASEC') == '[10:2056,16:2032]'
+    assert test_hdu.header.get('TRIMSEC') == '[2:2046,3:2015]'
+    assert test_hdu.header.get('DATASEC') == '[10:2056,16:2032]'
 
 
 def test_ccd_data_to_fits():

--- a/banzai/tests/test_frames.py
+++ b/banzai/tests/test_frames.py
@@ -21,7 +21,7 @@ def test_update_trimsec_fs01():
                           'DATASEC': '[1:2048,1:2048]',
                           'INSTRUME': 'fs01'})
     test_hdu = ImageHDU(data=np.ones(10), header=test_header)
-    LCOFrameFactory._update_spectral_sections(test_hdu)
+    LCOFrameFactory._update_fs01_sections(test_hdu)
 
     assert test_hdu.header.get('TRIMSEC') == '[2:2046,3:2015]'
     assert test_hdu.header.get('DATASEC') == '[10:2056,16:2032]'

--- a/banzai/tests/test_frames.py
+++ b/banzai/tests/test_frames.py
@@ -5,6 +5,7 @@ from astropy.table import Table
 from banzai.utils.image_utils import Section
 from banzai.data import CCDData, DataTable
 from banzai.tests.utils import FakeCCDData, FakeLCOObservationFrame, FakeContext
+from banzai.lco import LCOFrameFactory
 
 pytestmark = pytest.mark.frames
 
@@ -12,6 +13,16 @@ pytestmark = pytest.mark.frames
 @pytest.fixture(scope='module')
 def set_random_seed():
     np.random.seed(10031312)
+
+
+def test_update_trimsec_fs01():
+    test_hdu = FakeCCDData(meta={'TRIMSEC': '[11:2055,19:2031]',
+                                 'DATASEC': '[1:2048,1:2048]',
+                                 'INSTRUME': 'fs01'})
+    LCOFrameFactory._update_spectral_sections(test_hdu)
+
+    assert test_hdu.meta.get('TRIMSEC') == '[2:2046,3:2015]'
+    assert test_hdu.meta.get('DATASEC') == '[10:2056,16:2032]'
 
 
 def test_ccd_data_to_fits():


### PR DESCRIPTION
This is to deal with the fact that fs01 has pre-scan turned on, and its detector and data sections are incorrect. Turning off pre-scan and appropriately adjusting the header keywords requires a great deal of data validation and effort in low-level software.

This logic should be removed when the fs01 spectral camera is retired.