### PR TITLE
Update to use e2e data 1.3.0 which includes MuSCAT data

### DIFF
--- a/banzai/tests/e2e-k8s.yaml
+++ b/banzai/tests/e2e-k8s.yaml
@@ -16,7 +16,7 @@ spec:
     # When the Pod is initialized, copy all files within the container at path
     # /archive/engineering into the empty data volume mounted at /data
     - name: banzai-data
-      image: docker.lco.global/banzai-e2e-data:1.2.4
+      image: docker.lco.global/banzai-e2e-data:1.3.0
       imagePullPolicy: IfNotPresent
       securityContext:
         runAsUser: 10087

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2'
 services:
   banzai-e2e:
-    image: docker.lco.global/banzai-e2e-data:1.2.4
+    image: docker.lco.global/banzai-e2e-data:1.3.0
     container_name: banzai-e2e
     network_mode: "bridge"
     entrypoint:


### PR DESCRIPTION
With this, we'll test all new PRs against MuSCAT data. Yay!