### PR TITLE
Fix Kubernetes Security Warnings

### DIFF
--- a/banzai/main.py
+++ b/banzai/main.py
@@ -165,7 +165,7 @@ def start_stacking_scheduler():
 
     beat = celery.bin.beat.beat(app=app)
     logger.info('Starting celery beat')
-    beat.run()
+    beat.run(schedule='/tmp/celerybeat-schedule', pidfile='/tmp/celerybeat.pid')
 
 
 def run_realtime_pipeline():

--- a/helm-chart/banzai/templates/listener.yaml
+++ b/helm-chart/banzai/templates/listener.yaml
@@ -20,6 +20,8 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
     {{- end }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
     {{ if .Values.useDockerizedDatabase }}
       initContainers:
         # Create the db if it doesn't exist
@@ -27,8 +29,7 @@ spec:
           image:  "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy}}
           securityContext:
-            runAsUser: 10087
-            runAsGroup: 10000
+            {{- toYaml .Values.securityContext | nindent 12 }}
           command:
             - "banzai_create_db"
             - "--db-address=$(DB_ADDRESS)"
@@ -47,8 +48,7 @@ spec:
           image:  "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy}}
           securityContext:
-            runAsUser: 10087
-            runAsGroup: 10000
+            {{- toYaml .Values.securityContext | nindent 12 }}
           command:
             - "banzai_update_db"
             - "--db-address=$(DB_ADDRESS)"
@@ -67,8 +67,7 @@ spec:
           image:  "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy}}
           securityContext:
-            runAsUser: 10087
-            runAsGroup: 10000
+            {{- toYaml .Values.securityContext | nindent 12 }}
           command:
             - "banzai_populate_bpms"
             - "--db-address=$(DB_ADDRESS)"
@@ -88,8 +87,7 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           securityContext:
-            runAsUser: 10087
-            runAsGroup: 10000
+            {{- toYaml .Values.securityContext | nindent 12 }}
           command:
             - "banzai_run_realtime_pipeline"
             - "--post-to-archive"
@@ -109,12 +107,16 @@ spec:
             limits:
               cpu: "1"
               memory: "1Gi"
+          volumeMounts:
+            - name: listener-tmp
+              mountPath: /tmp
+              readOnly: false
+
         - name: 'banzai-calibration-scheduler'
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           securityContext:
-            runAsUser: 10087
-            runAsGroup: 10000
+            {{- toYaml .Values.securityContext | nindent 12 }}
           command:
             - "banzai_automate_stack_calibrations"
             - "--post-to-archive"
@@ -133,6 +135,19 @@ spec:
             limits:
               cpu: "1"
               memory: "1Gi"
+          volumeMounts:
+            - name: scheduler-tmp
+              mountPath: /tmp
+              readOnly: false
+
+      volumes:
+        - name: listener-tmp
+          emptyDir:
+            sizeLimit: 1Gi
+        - name: scheduler-tmp
+          emptyDir:
+            sizeLimit: 1Gi
+
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/helm-chart/banzai/templates/workers.yaml
+++ b/helm-chart/banzai/templates/workers.yaml
@@ -19,14 +19,15 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
     {{- end }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
 
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           securityContext:
-            runAsUser: 10087
-            runAsGroup: 10000
+            {{- toYaml .Values.securityContext | nindent 12 }}
           command:
             - "celery"
             - "-A"
@@ -47,6 +48,16 @@ spec:
             limits:
               cpu: "3"
               memory: "4Gi"
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+              readOnly: false
+
+      volumes:
+        - name: tmp
+          emptyDir:
+            sizeLimit: 4Gi
+
     {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/helm-chart/banzai/values-dev.yaml
+++ b/helm-chart/banzai/values-dev.yaml
@@ -15,6 +15,21 @@ image:
   tag: latest
   pullPolicy: IfNotPresent
 
+podSecurityContext:
+  fsGroup: 10000
+
+securityContext:
+  capabilities:
+    drop:
+    - ALL
+  readOnlyRootFilesystem: true
+  runAsNonRoot: true
+  # Preserve compatibility with archive.lco.gtn uid/gid
+  # LCO SBA LDAP uid/username: 10087/archive
+  # LCO SBA LDAP gid/group: 10000/Domain Users
+  runAsUser: 10087
+  runAsGroup: 10000
+
 nodeSelector: {}
 
 tolerations: []


### PR DESCRIPTION
Fix various security warnings found by the FairWindsOps Polaris tool, installed in our cluster at http://polaris.lco.gtn/. I have deployed this version as `banzai-dev` and everything starts and appears to run correctly (after a bit of debugging and the one fix to put a temporary file into `/tmp`).

Not urgent. Please let me know if this breaks anything, and I can help debug it.