### PR TITLE
Improve and Document Public Helm Chart

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+1.1.1 (2020-12-17)
+-------------------
+- Add documentation and example configuration to helm chart
+- Fix bug where raw data settings would not properly default if 
+  environment variables were not set
+
 1.1.0 (2020-11-30)
 -------------------
 - Remove dependence on astropy-helpers for building and packaging

--- a/banzai/main.py
+++ b/banzai/main.py
@@ -324,8 +324,8 @@ def add_bpms_from_archive():
     add_settings_to_context(args, settings)
     # Query the archive for all bpm files
     url = f'{settings.ARCHIVE_FRAME_URL}/?OBSTYPE=BPM&limit=1000'
-    archive_auth_token = settings.ARCHIVE_AUTH_TOKEN
-    response = requests.get(url, headers=archive_auth_token)
+    archive_auth_header = settings.ARCHIVE_AUTH_HEADER
+    response = requests.get(url, headers=archive_auth_header)
     response.raise_for_status()
     results = response.json()['results']
 

--- a/banzai/settings.py
+++ b/banzai/settings.py
@@ -90,15 +90,19 @@ TELESCOPE_FILENAME_FUNCTION = 'banzai.utils.file_utils.telescope_to_filename'
 OBSERVATION_PORTAL_URL = os.getenv('OBSERVATION_PORTAL_URL',
                                    'http://internal-observation-portal.lco.gtn/api/observations/')
 
+# Specify different sources of raw and processed data, if needed.
 ARCHIVE_API_ROOT = os.getenv('API_ROOT')
+ARCHIVE_AUTH_TOKEN = os.getenv('AUTH_TOKEN')
 ARCHIVE_FRAME_URL = f'{ARCHIVE_API_ROOT}frames'
-ARCHIVE_AUTH_TOKEN = {'Authorization': f'Token {os.getenv("AUTH_TOKEN")}'}
-FITS_EXCHANGE = os.getenv('FITS_EXCHANGE', 'archived_fits')
+ARCHIVE_AUTH_HEADER = {'Authorization': f'Token {ARCHIVE_AUTH_TOKEN}'}
 
-RAW_DATA_FRAME_URL = os.getenv('RAW_DATA_FRAME_URL', ARCHIVE_FRAME_URL)
-RAW_DATA_AUTH_TOKEN = {'Authorization' : f'Token {os.getenv("RAW_DATA_AUTH_TOKEN", ARCHIVE_AUTH_TOKEN)}'}
+RAW_DATA_AUTH_TOKEN = os.getenv('RAW_DATA_AUTH_TOKEN', ARCHIVE_AUTH_TOKEN)
+RAW_DATA_API_ROOT = os.getenv('RAW_DATA_API_ROOT', ARCHIVE_API_ROOT)
+RAW_DATA_FRAME_URL = f'{ARCHIVE_API_ROOT}frames'
+RAW_DATA_AUTH_HEADER = {'Authorization' : f'Token {RAW_DATA_AUTH_TOKEN}'}
 
 CALIBRATE_PROPOSAL_ID = os.getenv('CALIBRATE_PROPOSAL_ID', 'calibrate')
+FITS_EXCHANGE = os.getenv('FITS_EXCHANGE', 'archived_fits')
 
 CONFIGDB_URL = os.getenv('CONFIGDB_URL', 'http://configdb.lco.gtn/sites/')
 

--- a/banzai/utils/fits_utils.py
+++ b/banzai/utils/fits_utils.py
@@ -99,11 +99,11 @@ def download_from_s3(file_info, context, is_raw_frame=False):
 
     if is_raw_frame:
         url = f'{context.RAW_DATA_FRAME_URL}/{frame_id}'
-        archive_auth_token = context.RAW_DATA_AUTH_TOKEN
+        archive_auth_header = context.RAW_DATA_AUTH_HEADER
     else:
         url = f'{context.ARCHIVE_FRAME_URL}/{frame_id}'
-        archive_auth_token = context.ARCHIVE_AUTH_TOKEN
-    response = requests.get(url, headers=archive_auth_token).json()
+        archive_auth_header = context.ARCHIVE_AUTH_HEADER
+    response = requests.get(url, headers=archive_auth_header).json()
     buffer = io.BytesIO()
     buffer.write(requests.get(response['url'], stream=True).content)
     buffer.seek(0)

--- a/helm-chart/banzai/Chart.yaml
+++ b/helm-chart/banzai/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: "1.0"
+appVersion: "1.1.1"
 description: A Helm chart to deploy the BANZAI pipeline
 name: banzai
-version: 1.0.0
+version: 1.1.0

--- a/helm-chart/banzai/README.md
+++ b/helm-chart/banzai/README.md
@@ -1,0 +1,146 @@
+# BANZAI Imaging Pipeline
+
+This chart installs the following applications into a Kubernetes cluster.
+
+- [BANZAI-Imaging](https://github.com/lcogt/banzai)
+
+## Installing the Chart
+
+To install the chart with the release name `banzai`:
+
+```
+$ helm install --name banzai banzai/
+```
+
+## Uninstalling the Chart
+
+To uninstall/delete the `banzai` deployment:
+
+```
+$ helm delete --purge banzai
+```
+
+## Configuration
+
+You can customize the resources created by this chart by setting your desired
+configuration values. Please read the chart and associated templates to find
+all values which can be customized. Default values listed in the table represent 
+what is present in the chart's default values file.
+
+### image
+Configuration parameters relating to the docker image that is being deployed.
+
+Parameter | Description | Default
+--- | --- | ---
+`image.repository` | Docker image repository | `docker.lco.global/banzai`
+`image.tag` | Docker image tag | **_Not set (required)_**
+`image.pullPolicy` | [Kubernetes image pull policy](https://kubernetes.io/docs/concepts/configuration/overview/#container-images) | `IfNotPresent`
+
+### ingester
+Configuration parameters for the [OCS Ingester Library](https://github.com/observatorycontrolsystem/ingester)
+
+#### Required values configuration
+Parameter | Description | Default
+--- | --- | ---
+`ingester.apiRoot` | Ingester API root (API_ROOT environment variable)| **_Not set (required)_**
+`ingester.s3Bucket` | Science Archive AWS S3 bucket (BUCKET environment variable) | **_Not set (required)_**
+`ingester.noMetrics` | Do not submit metrics to an OpenTSDB server (see optional OpenTSDB configuration below) | `true`
+`ingester.postProcessFiles` | Optionally submit files to fits queue | `false` 
+
+#### Required secrets configuration
+For sensitive keys, this helm chart will pull from the kubernetes secret `banzai-secrets` in your kubernetes namespace.
+
+Environment Variable | Description | Secret | Key
+--- | --- | --- | ---
+`AUTH_TOKEN` | Authorization token for Science Archive. | `banzai-secrets` | `archive-auth-token`
+`AWS_ACCESS_KEY_ID` | AWS access key ID for Archive S3 bucket. | `banzai-secrets` | `aws-access-key-id`
+`AWS_SECRET_ACCESS_KEY` | AWS secret access key for Archive S3 bucket. | `banzai-secrets` | `aws-secret-access-key`
+
+#### Optional OpenTSDB configuration
+If you would like ingestion metrics posted to an [OpenTSDB](http://opentsdb.net/) server, set these values accordingly.
+
+Parameter | Description | Default
+--- | --- | ---
+`ingester.ingesterProcessName` | A tag set with the collected metrics to identify where the metrics are coming from (INGESTER_PROCESS_NAME environment variable) | **_Not set_**
+`ingester.opentsdbHostname` | OpenTSDB Host to send metrics to (OPENTSDB_HOSTNAME environment variable) | **_Not set_**
+`ingester.opentsdbPort` | OpenTSDB erver port used to receive metrics (OPENTSDB_PORT environment variable) | **_Not set_**
+
+
+### banzai
+BANZAI-specific configuration
+
+Parameter | Description | Default
+--- | --- | ---
+`banzai.astrometryServiceUrl` | URL for LCO GAIA-Astrometry service | **_Not set (required)_**
+`banzai.configdbUrl` | URL for Configuration Database. | **_Not set (required)_**
+`banzai.observationPortalUrl` | URL for LCO Observation Portal | **_Not set (required)_**
+`banzai.calibrateProposalId` | Proposal ID for LCO Calibration requests | **_Not set (required)_**
+`banzai.banzaiWorkerLogLevel` | Log level for BANZAI worker processes | **_Not set (required)_**
+`fitsBroker` | Hostname for FITS files queue | **_Not set (required)_**
+`fitsExchange` | Exchange name for FITS files queue | **_Not set (required)_**
+`queueName` | BANZAI file queue name (fanout from fitsExchange) | **_Not set (required)_**
+
+#### Optional separate raw and processed archive sources
+During development, it is sometimes necessary to pull raw data from a "production" science archive, and push/pull processed
+data to/from a "development" science archive running independently in a separate namespace.
+
+By default, BANZAI will push/pull to and from the same science archive. If separate archive sources are desired, a raw data
+source may be specified. Please note that the processed data source is assumed always to be the source configured in the 
+science archive section.
+
+Parameter | Description | Default
+--- | --- | ---
+`banzai.useDifferentArchiveSources` | Use different archives for raw and processed data. If set to true, optional raw data source configuration must be specified. | `false`
+`banzai.rawDataApiRoot` | API root URL for raw data source | **_Not set_**
+
+The authorization token for the raw data source is pulled from the `banzai-secrets` kubernetes secret
+
+Environment Variable | Description | Secret | Key
+--- | --- | --- | ---
+`RAW_DATA_AUTH_TOKEN` | Authorization token for raw data source | `banzai-secrets` | `raw-data-auth-token`
+
+### PostgreSQL Database Configuration
+
+This helm chart configures BANZAI to use a Postgresql backend. It can be configured to use an existing database, or spin up its
+own.
+
+#### Existing DB Configuration
+
+When using an existing database (`.Values.useDockerizedDatabase = false`), set the following values:
+
+Parameter | Description | Default
+--- | --- | ---
+`postgresql.hostname` | Hostname for postgresql server | **_Not set_**
+`postgresql.postgresqlUsername` | Username for postgresql DB | **_Not set_**
+`postgresql.postgresqlDatabase` | Database name for BANZAI DB | **_Not set_**
+
+Additionally, specify the DB password associated with the username you set via a kubernetes secret
+
+Environment Variable | Description | Secret | Key
+--- | --- | --- | ---
+`DB_PASSWORD` | Password for BANZAI DB | `banzai-secrets` | `postgresql-password`
+
+
+#### Using a Dockerized database
+
+See values-dev for a working example of using a dockerized database.
+
+### RabbitMQ Configuration
+
+#### Existing RabbitMQ Configuration
+
+When using an existing RabbitMQ server (`.Values.useDockerizedRabbitMQ = false`), set the following values:
+
+Parameter | Description | Default
+--- | --- | ---
+`rabbitmq.hostname` | Hostname for RabbitMQ server | **_Not set_**
+`rabbitmq.rabbitmq.username` | Username for RabbitMQ instance | **_Not set_**
+`rabbitmq.vhost` | RabbitMQ Vhost | **_Not set_**
+
+Environment Variable | Description | Secret | Key
+--- | --- | --- | ---
+`RABBITMQ_PASSWORD` | Password for RabbitMQ instance | `banzai-secrets` | `rabbitmq-password`
+
+#### Using a Dockerized RabbitMQ
+
+See values-dev for a working example of using a dockerized RabbitMQ

--- a/helm-chart/banzai/README.md
+++ b/helm-chart/banzai/README.md
@@ -9,7 +9,7 @@ This chart installs the following applications into a Kubernetes cluster.
 To install the chart with the release name `banzai`:
 
 ```
-$ helm install --name banzai banzai/
+$ helm install --name banzai banzai/ -f /path/to/values.yaml
 ```
 
 ## Uninstalling the Chart
@@ -144,3 +144,53 @@ Environment Variable | Description | Secret | Key
 #### Using a Dockerized RabbitMQ
 
 See values-dev for a working example of using a dockerized RabbitMQ
+
+## Appendix: Secrets
+
+Below is an example YAML file, which specifies a Kubernetes secret, `banzai-secrets`.
+See Kubernetes secrets documentation [here](https://kubernetes.io/docs/concepts/configuration/secret/) 
+
+```yaml
+apiVersion: v1
+data:
+  archive-auth-token:
+  # raw-data-auth-token key only needed if .Values.useDifferentArchiveSources is true
+  raw-data-auth-token:
+  aws-access-key-id:
+  aws-secret-access-key:
+  postgresql-password:
+  rabbitmq-password:
+kind: Secret
+metadata:
+  name: banzai-secrets
+  namespace: 
+type: Opaque
+```
+
+Data stored in a Kubernetes secret is usually stored as a base64-encoded string. To properly store a secret value, 
+first encode it as base64.
+
+If my `postgresql-password` is `secret_password`, I will need to encode it before creating the secret.
+
+```bash
+echo -n secret_password | base64
+c2VjcmV0X3Bhc3N3b3Jk
+```
+
+Enter the base64-encoded string into the proper place in the above template.
+
+```yaml
+data:
+...
+  postgresql-password: c2VjcmV0X3Bhc3N3b3Jk
+...
+```
+
+Finally, be sure to set the kubernetes namespace name inside the `metadata` section. The secret will exist only in
+that namespace. This is the namespace you intend to deploy the application.
+
+Once all required values have been set, create the secret in your namespace by:
+
+```bash
+kubectl apply -f banzai-secrets.yaml
+```

--- a/helm-chart/banzai/templates/_helpers.tpl
+++ b/helm-chart/banzai/templates/_helpers.tpl
@@ -91,15 +91,16 @@ Ingester environment variables
   value: {{ .Values.ingester.apiRoot | quote }}
 - name: BUCKET
   value: {{ .Values.ingester.s3Bucket | quote }}
-- name: INGESTER_PROCESS_NAME
-  value: {{ .Values.ingester.ingesterProcessName | quote }}
-- name: OPENTSDB_HOSTNAME
-  value: {{ .Values.ingester.opentsdbHostname | quote }}
-- name: OPENTSDB_PORT
-  value: {{ .Values.ingester.opentsdbPort | quote }}
 {{- if .Values.ingester.noMetrics }}
 - name: OPENTSDB_PYTHON_METRICS_TEST_MODE
   value: "1"
+{{- else }}
+- name: INGESTER_PROCESS_NAME
+  value: {{ required "ingester.ingesterProcessName must be defined if noMetrics is false" .Values.ingester.ingesterProcessName | quote }}
+- name: OPENTSDB_HOSTNAME
+  value: {{ required "ingester.opentsdbHostname must be defined if noMetrics is false" .Values.ingester.opentsdbHostname | quote }}
+- name: OPENTSDB_PORT
+  value: {{ required "ingester.opentsdbPort must be defined if noMetrics is false" .Values.ingester.opentsdbPort | quote }}
 {{- end }}
 - name: POSTPROCESS_FILES
 {{- if .Values.ingester.postProcessFiles }}

--- a/helm-chart/banzai/templates/_helpers.tpl
+++ b/helm-chart/banzai/templates/_helpers.tpl
@@ -58,6 +58,9 @@ Generate the PostgreSQL DB hostname
 {{- end -}}
 {{- end -}}
 
+{{/*
+Generate the RabbitMQ queue hostname
+*/}}
 {{- define "banzai.rabbitmq" -}}
 {{- if .Values.rabbitmq.fullnameOverride -}}
 {{- .Values.rabbitmq.fullnameOverride | trunc 63 | trimSuffix "-" -}}
@@ -72,29 +75,84 @@ Generate the PostgreSQL DB hostname
 Define shared environment variables
 */}}
 {{- define "banzai.Env" -}}
+{{/*
+External service URLS
+*/ -}}
 - name: ASTROMETRY_SERVICE_URL
-  value: {{ .Values.astrometryServiceUrl | quote }}
+  value: {{ .Values.banzai.astrometryServiceUrl | quote }}
 - name: CONFIGDB_URL
-  value: {{ .Values.configDbUrl | quote }}
-{{- if .Values.useDockerizedDatabase -}}
+  value: {{ .Values.banzai.configdbUrl | quote }}
+- name: OBSERVATION_PORTAL_URL
+  value: {{ .Values.banzai.observationPortalUrl | quote }}
+{{/*
+Ingester environment variables
+*/ -}}
+- name: API_ROOT
+  value: {{ .Values.ingester.apiRoot | quote }}
+- name: BUCKET
+  value: {{ .Values.ingester.s3Bucket | quote }}
+- name: INGESTER_PROCESS_NAME
+  value: {{ .Values.ingester.ingesterProcessName | quote }}
+- name: OPENTSDB_HOSTNAME
+  value: {{ .Values.ingester.opentsdbHostname | quote }}
+- name: OPENTSDB_PORT
+  value: {{ .Values.ingester.opentsdbPort | quote }}
+{{- if .Values.ingester.noMetrics }}
+- name: OPENTSDB_PYTHON_METRICS_TEST_MODE
+  value: "1"
+{{- end }}
+- name: POSTPROCESS_FILES
+{{- if .Values.ingester.postProcessFiles }}
+  value: "True"
+{{- else }}
+  value: "False"
+{{- end }}
+- name: AUTH_TOKEN
+  valueFrom:
+    secretKeyRef:
+      name: banzai-secrets
+      key: archive-auth-token
+- name: AWS_ACCESS_KEY_ID
+  valueFrom:
+    secretKeyRef:
+      name: banzai-secrets
+      key: aws-access-key-id
+- name: AWS_SECRET_ACCESS_KEY
+  valueFrom:
+    secretKeyRef:
+      name: banzai-secrets
+      key: aws-secret-access-key
+{{- /*
+Optional raw data source environment variables
+*/}}
+{{- if .Values.banzai.useDifferentArchiveSources }}
+- name: RAW_DATA_API_ROOT
+  value: {{ required "banzai.rawDataApiRoot is required if banzai.useDifferentArchiveSources is specified." .Values.banzai.rawDataApiRoot | quote }}
+- name: RAW_DATA_AUTH_TOKEN
+  valueFrom:
+    secretKeyRef:
+      name: banzai-secrets
+      key: raw-data-auth-token
+{{- end -}}
+{{/*
+BANZAI DB Configuration
+*/}}
 - name: DB_HOST
   value: {{ include "banzai.dbhost" . | quote }}
 - name: DB_PASSWORD
   valueFrom:
     secretKeyRef:
       name: banzai-secrets
-      key: postgresqlPassword
+      key: postgresql-password
 - name: DB_USER
   value: {{ .Values.postgresql.postgresqlUsername | quote }}
 - name: DB_NAME
   value: {{ .Values.postgresql.postgresqlDatabase | quote }}
 - name: DB_ADDRESS
   value: postgres://$(DB_USER):$(DB_PASSWORD)@$(DB_HOST)/$(DB_NAME)
-{{ else }}
-- name: DB_ADDRESS
-  value: {{ .Values.databaseUrl | quote }}
-{{- end }}
-{{- if .Values.useDockerizedRabbitMQ }}
+{{/*
+Celery task queue configuration
+*/ -}}
 - name: RABBITMQ_HOST
   value: {{ include "banzai.rabbitmq" . | quote }}
 - name: RABBITMQ_PASSWORD
@@ -104,51 +162,18 @@ Define shared environment variables
       key: rabbitmq-password
 - name: TASK_HOST
   value: amqp://{{ .Values.rabbitmq.rabbitmq.username }}:$(RABBITMQ_PASSWORD)@$(RABBITMQ_HOST)/{{ .Values.rabbitmq.vhost }}
-{{- else }}
-- name: TASK_HOST
-  value: {{ .Values.taskHost | quote}}
-{{- end }}
 - name: RETRY_DELAY
   value: "600"
-- name: OPENTSDB_PORT
-  value: "80"
 - name: CALIBRATE_PROPOSAL_ID
-  value: {{ .Values.calibrateProposalId | quote }}
-- name: OBSERVATION_PORTAL_URL
-  value: {{ .Values.observationPortalUrl | quote }}
-- name: API_ROOT
-  value: {{ .Values.apiRoot | quote }}
-- name: AUTH_TOKEN
-  value: {{ .Values.archiveAuthToken | quote }}
-- name: RAW_DATA_FRAME_URL
-  value: {{ .Values.rawDataFrameUrl | quote }}
-- name: RAW_DATA_AUTH_TOKEN
-  value: {{ .Values.rawDataAuthToken | quote }}
-- name: BUCKET
-  value: {{ .Values.s3Bucket | quote }}
-- name: AWS_ACCESS_KEY_ID
-  value: {{ .Values.awsAccessKeyId | quote }}
-- name: AWS_SECRET_ACCESS_KEY
-  value: {{ .Values.awsSecretAccessKey | quote }}
-- name: OPENTSDB_HOSTNAME
-  value: {{ .Values.opentsdbHostname | quote }}
+  value: {{ .Values.banzai.calibrateProposalId | quote }}
 - name: BOSUN_HOSTNAME
-  value: {{ .Values.bosunHostname | quote }}
+  value: {{ .Values.banzai.bosunHostname | quote }}
 - name: FITS_BROKER
-  value: {{ .Values.fitsBroker | quote }}
+  value: {{ .Values.banzai.fitsBroker | quote }}
 - name: FITS_EXCHANGE
-  value: {{ .Values.fitsExchange | quote }}
+  value: {{ .Values.banzai.fitsExchange | quote }}
 - name: QUEUE_NAME
-  value: {{ .Values.queueName | quote }}
-- name: INGESTER_PROCESS_NAME
-  value: {{ .Values.ingesterProcessName | quote }}
-- name: POSTPROCESS_FILES
-  value: "False"
+  value: {{ .Values.banzai.queueName | quote }}
 - name: BANZAI_WORKER_LOGLEVEL
-  value: {{ .Values.banzaiWorkerLogLevel | quote }}
-{{- if .Values.noMetrics }}
-- name: OPENTSDB_PYTHON_METRICS_TEST_MODE
-  value: "1"
-{{- end -}}
-
+  value: {{ .Values.banzai.banzaiWorkerLogLevel | quote }}
 {{- end -}}

--- a/helm-chart/banzai/templates/_helpers.tpl
+++ b/helm-chart/banzai/templates/_helpers.tpl
@@ -167,8 +167,6 @@ Celery task queue configuration
   value: "600"
 - name: CALIBRATE_PROPOSAL_ID
   value: {{ .Values.banzai.calibrateProposalId | quote }}
-- name: BOSUN_HOSTNAME
-  value: {{ .Values.banzai.bosunHostname | quote }}
 - name: FITS_BROKER
   value: {{ .Values.banzai.fitsBroker | quote }}
 - name: FITS_EXCHANGE

--- a/helm-chart/banzai/templates/_helpers.tpl
+++ b/helm-chart/banzai/templates/_helpers.tpl
@@ -150,7 +150,7 @@ BANZAI DB Configuration
 - name: DB_NAME
   value: {{ .Values.postgresql.postgresqlDatabase | quote }}
 - name: DB_ADDRESS
-  value: postgres://$(DB_USER):$(DB_PASSWORD)@$(DB_HOST)/$(DB_NAME)
+  value: postgresql://$(DB_USER):$(DB_PASSWORD)@$(DB_HOST)/$(DB_NAME)
 {{/*
 Celery task queue configuration
 */ -}}

--- a/helm-chart/banzai/templates/db-instrument-update.yaml
+++ b/helm-chart/banzai/templates/db-instrument-update.yaml
@@ -10,7 +10,7 @@ spec:
   failedJobsHistoryLimit: 1
   successfulJobsHistoryLimit: 3
   startingDeadlineSeconds: 120
-  schedule: "{{ .Values.cronjob.schedule }}"
+  schedule: "{{ .Values.instrumentTableCronjob.schedule }}"
   jobTemplate:
     metadata:
       labels:

--- a/helm-chart/banzai/values-dev.yaml
+++ b/helm-chart/banzai/values-dev.yaml
@@ -14,7 +14,7 @@ ingester:
   opentsdbHostname: opentsdb.lco.gtn
   opentsdbPort: 80
   postProcessFiles: false
-  noMetrics: false
+  noMetrics: true
 
 # Values specific to the BANZAI pipeline
 banzai:
@@ -28,7 +28,6 @@ banzai:
   fitsBroker: rabbitmq.lco.gtn
   fitsExchange: archived_fits
   queueName: banzai_dev_pipeline
-  useDockerizedDatabase: true
 
 # CronJob configuration to periodically update instrument table in BANZAI DB
 instrumentTableCronjob:

--- a/helm-chart/banzai/values-dev.yaml
+++ b/helm-chart/banzai/values-dev.yaml
@@ -1,73 +1,41 @@
-# Default values for banzai.
+# Development deployment values for banzai.
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
-
-# Automatically manage worker count within the configured limits. More workers
-# will be started when the CPU usage rises above the configured threshold.
-horizontalPodAutoscaler:
-  enabled: true
-  minReplicas: 1
-  maxReplicas: 4
-  targetCPUUtilizationPercentage: 50
-
 image:
   repository: docker.lco.global/banzai
-  tag: latest
+  tag: ""
   pullPolicy: IfNotPresent
 
-podSecurityContext:
-  fsGroup: 10000
+# Values for the OCS Ingester library, used by BANZAI.
+ingester:
+  apiRoot: http://archiveapi-dev.dev/
+  s3Bucket: archivetest2.lco.global
+  ingesterProcessName: banzai-dev
+  opentsdbHostname: opentsdb.lco.gtn
+  opentsdbPort: 80
+  postProcessFiles: false
+  noMetrics: true
 
-securityContext:
-  capabilities:
-    drop:
-    - ALL
-  readOnlyRootFilesystem: true
-  runAsNonRoot: true
-  # Preserve compatibility with archive.lco.gtn uid/gid
-  # LCO SBA LDAP uid/username: 10087/archive
-  # LCO SBA LDAP gid/group: 10000/Domain Users
-  runAsUser: 10087
-  runAsGroup: 10000
+# Values specific to the BANZAI pipeline
+banzai:
+  astrometryServiceUrl: http://astrometry.lco.gtn/catalog
+  useDifferentArchiveSources: false
+  calibrateProposalId: calibrate
+  observationPortalUrl: http://internal-observation-portal.lco.gtn/api/observations/
+  configdbUrl: http://configdb.lco.gtn/sites/
+  banzaiWorkerLogLevel: debug
+  rawDataApiRoot: http://archiveapi-internal.prod/
+  bosunHostname: alerts.lco.gtn
+  fitsBroker: rabbitmq.lco.gtn
+  fitsExchange: archived_fits
+  queueName: banzai_dev_pipeline
+  useDockerizedDatabase: true
 
-nodeSelector: {}
-
-tolerations: []
-
-affinity: {}
-
-calibrateProposalId: calibrate
-
-observationPortalUrl: http://internal-observation-portal.lco.gtn/api/observations/
-
-apiRoot: "http://archiveapi-dev.dev/"
-
-s3Bucket: archivetest2.lco.global
-
-banzaiWorkerLogLevel: "debug"
-
-rawDataFrameUrl: "http://archiveapi-internal.prod/frames"
-
-ingesterProcessName: "banzai-dev"
-
-noMetrics: true
-
-opentsdbHostname: opentsdb.lco.gtn
-
-bosunHostname: alerts.lco.gtn
-
-fitsBroker: rabbitmq.lco.gtn
-
-fitsExchange: archived_fits
-
-queueName: banzai_dev_pipeline
-
-useDockerizedDatabase: true
-
-# cron job to periodically update instrument table in BANZAI DB
-cronjob:
+# CronJob configuration to periodically update instrument table in BANZAI DB
+instrumentTableCronjob:
   schedule: "*/5 * * * *"
 
+useDockerizedDatabase: true
 postgresql:
   hostname: "db.example.com"
   postgresqlUsername: "banzai"
@@ -84,7 +52,6 @@ postgresql:
       memory: 512Mi
 
 useDockerizedRabbitMQ: true
-
 rabbitmq:
   rabbitmq:
     username: "user"
@@ -97,6 +64,3 @@ rabbitmq:
     limits:
       cpu: 1
       memory: 1Gi
-
-
-configdb_url: "http://configdb.lco.gtn/sites/"

--- a/helm-chart/banzai/values-dev.yaml
+++ b/helm-chart/banzai/values-dev.yaml
@@ -3,7 +3,7 @@
 # Declare variables to be passed into your templates.
 image:
   repository: docker.lco.global/banzai
-  tag: "1.1.0"
+  tag: "1.1.1"
   pullPolicy: IfNotPresent
 
 # Values for the OCS Ingester library, used by BANZAI.

--- a/helm-chart/banzai/values-dev.yaml
+++ b/helm-chart/banzai/values-dev.yaml
@@ -3,7 +3,7 @@
 # Declare variables to be passed into your templates.
 image:
   repository: docker.lco.global/banzai
-  tag: ""
+  tag: "1.1.0"
   pullPolicy: IfNotPresent
 
 # Values for the OCS Ingester library, used by BANZAI.

--- a/helm-chart/banzai/values-dev.yaml
+++ b/helm-chart/banzai/values-dev.yaml
@@ -14,18 +14,17 @@ ingester:
   opentsdbHostname: opentsdb.lco.gtn
   opentsdbPort: 80
   postProcessFiles: false
-  noMetrics: true
+  noMetrics: false
 
 # Values specific to the BANZAI pipeline
 banzai:
   astrometryServiceUrl: http://astrometry.lco.gtn/catalog
-  useDifferentArchiveSources: false
-  calibrateProposalId: calibrate
-  observationPortalUrl: http://internal-observation-portal.lco.gtn/api/observations/
   configdbUrl: http://configdb.lco.gtn/sites/
+  observationPortalUrl: http://internal-observation-portal.lco.gtn/api/observations/
+  useDifferentArchiveSources: true
+  calibrateProposalId: calibrate
   banzaiWorkerLogLevel: debug
   rawDataApiRoot: http://archiveapi-internal.prod/
-  bosunHostname: alerts.lco.gtn
   fitsBroker: rabbitmq.lco.gtn
   fitsExchange: archived_fits
   queueName: banzai_dev_pipeline
@@ -37,9 +36,9 @@ instrumentTableCronjob:
 
 useDockerizedDatabase: true
 postgresql:
-  hostname: "db.example.com"
   postgresqlUsername: "banzai"
   postgresqlDatabase: "banzai"
+  # pull password from postgresql-password in banzai-secrets
   existingSecret: "banzai-secrets"
   service:
     port: "5432"

--- a/helm-chart/banzai/values-prod.yaml
+++ b/helm-chart/banzai/values-prod.yaml
@@ -12,7 +12,7 @@ horizontalPodAutoscaler:
 
 image:
   repository: docker.lco.global/banzai
-  tag: "1.1.0"
+  tag: "1.1.1"
   pullPolicy: IfNotPresent
 
 # Values for the OCS Ingester library, used by BANZAI.

--- a/helm-chart/banzai/values-prod.yaml
+++ b/helm-chart/banzai/values-prod.yaml
@@ -1,0 +1,57 @@
+# Production deployment values for banzai.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+# Automatically manage worker count within the configured limits. More workers
+# will be started when the CPU usage rises above the configured threshold.
+horizontalPodAutoscaler:
+  enabled: true
+  minReplicas: 5
+  maxReplicas: 10
+  targetCPUUtilizationPercentage: 50
+
+image:
+  repository: docker.lco.global/banzai
+  tag: "1.1.0"
+  pullPolicy: IfNotPresent
+
+# Values for the OCS Ingester library, used by BANZAI.
+ingester:
+  apiRoot: http://archiveapi-internal.prod/
+  s3Bucket: archive-lco-global
+  ingesterProcessName: banzai_imaging
+  opentsdbHostname: opentsdb.lco.gtn
+  opentsdbPort: 80
+  postProcessFiles: false
+  noMetrics: false
+
+# Values specific to the BANZAI pipeline
+banzai:
+  astrometryServiceUrl: http://astrometry.lco.gtn/catalog
+  configdbUrl: http://configdb.lco.gtn/sites/
+  observationPortalUrl: http://internal-observation-portal.lco.gtn/api/observations/
+  useDifferentArchiveSources: false
+  calibrateProposalId: calibrate
+  banzaiWorkerLogLevel: info
+  rawDataApiRoot: http://archiveapi-internal.prod/
+  fitsBroker: rabbitmq.lco.gtn
+  fitsExchange: archived_fits
+  queueName: banzai_pipeline
+
+# CronJob configuration to periodically update instrument table in BANZAI DB
+instrumentTableCronjob:
+  schedule: "*/5 * * * *"
+
+useDockerizedDatabase: false
+useDockerizedRabbitMQ: false
+
+postgresql:
+  hostname: postgres1-cluster.cluster-cple9sjsskrf.us-west-2.rds.amazonaws.com
+  postgresqlUsername: banzai
+  postgresqlDatabase: banzai
+
+rabbitmq:
+  hostname: rabbitmq-ha.prod.svc.cluster.local.
+  rabbitmq:
+    username: banzai
+  vhost: banzai

--- a/helm-chart/banzai/values.yaml
+++ b/helm-chart/banzai/values.yaml
@@ -17,16 +17,6 @@ horizontalPodAutoscaler:
 podSecurityContext:
   fsGroup: 10000
 
-ingester:
-  noMetrics: true
-  postProcessFiles: false
-
-banzai:
-  useDifferentArchiveSources: false
-
-useDockerizedDatabase: false
-useDockerizedRabbitMQ: false
-
 securityContext:
   capabilities:
     drop:
@@ -38,6 +28,16 @@ securityContext:
   # LCO SBA LDAP gid/group: 10000/Domain Users
   runAsUser: 10087
   runAsGroup: 10000
+
+ingester:
+  noMetrics: true
+  postProcessFiles: false
+
+banzai:
+  useDifferentArchiveSources: false
+
+useDockerizedDatabase: false
+useDockerizedRabbitMQ: false
 
 nodeSelector: {}
 tolerations: []

--- a/helm-chart/banzai/values.yaml
+++ b/helm-chart/banzai/values.yaml
@@ -1,6 +1,10 @@
 # Default values for banzai.
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
+image:
+  repository: docker.lco.global/banzai
+  tag: ""
+  pullPolicy: IfNotPresent
 
 # Automatically manage worker count within the configured limits. More workers
 # will be started when the CPU usage rises above the configured threshold.
@@ -12,6 +16,16 @@ horizontalPodAutoscaler:
 
 podSecurityContext:
   fsGroup: 10000
+
+ingester:
+  noMetrics: true
+  postProcessFiles: false
+
+banzai:
+  useDifferentArchiveSources: false
+
+useDockerizedDatabase: false
+useDockerizedRabbitMQ: false
 
 securityContext:
   capabilities:

--- a/helm-chart/banzai/values.yaml
+++ b/helm-chart/banzai/values.yaml
@@ -1,0 +1,31 @@
+# Default values for banzai.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+# Automatically manage worker count within the configured limits. More workers
+# will be started when the CPU usage rises above the configured threshold.
+horizontalPodAutoscaler:
+  enabled: true
+  minReplicas: 1
+  maxReplicas: 4
+  targetCPUUtilizationPercentage: 50
+
+podSecurityContext:
+  fsGroup: 10000
+
+securityContext:
+  capabilities:
+    drop:
+    - ALL
+  readOnlyRootFilesystem: true
+  runAsNonRoot: true
+  # Preserve compatibility with archive.lco.gtn uid/gid
+  # LCO SBA LDAP uid/username: 10087/archive
+  # LCO SBA LDAP gid/group: 10000/Domain Users
+  runAsUser: 10087
+  runAsGroup: 10000
+
+nodeSelector: {}
+tolerations: []
+affinity: {}
+

--- a/setup.cfg
+++ b/setup.cfg
@@ -97,7 +97,7 @@ edit_on_github = True
 github_project = lcogt/banzai
 
 # version should be PEP440 compatible (http://www.python.org/dev/peps/pep-0440)
-version = 1.1.0
+version = 1.1.1
 
 [options]
 zip_safe = False


### PR DESCRIPTION
This PR updates and documents BANZAI-imaging's helm chart.

* Pull sensitive values (API keys, passwords, etc...) from kubernetes secrets
* Provide examples of development and production values files.
* Provide deployment instructions, secret creation instructions, and documentation on every configurable value.
* Fixes a bug where the `RAW_DATA_AUTH_TOKEN` would not initialize properly if not explicitly set. Rename some settings variables for clarity. 
