### PR TITLE
Update to use OCS Ingester 2.2.5

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+1.1.2 (2020-01-14)
+-------------------
+- Update to use OCS Ingester version 2.2.5
+
 1.1.1 (2020-12-17)
 -------------------
 - Add documentation and example configuration to helm chart

--- a/banzai/utils/file_utils.py
+++ b/banzai/utils/file_utils.py
@@ -2,8 +2,8 @@ import hashlib
 import logging
 from time import sleep
 
-from lco_ingester import ingester
-from lco_ingester.exceptions import RetryError, DoNotRetryError, BackoffRetryError, NonFatalDoNotRetryError
+from ocs_ingester import ingester
+from ocs_ingester.exceptions import RetryError, DoNotRetryError, BackoffRetryError, NonFatalDoNotRetryError
 
 from kombu import Connection, Exchange
 from banzai.utils import import_utils

--- a/helm-chart/banzai/Chart.yaml
+++ b/helm-chart/banzai/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: "1.1.1"
+appVersion: "1.1.2"
 description: A Helm chart to deploy the BANZAI pipeline
 name: banzai
-version: 1.1.0
+version: 1.1.1

--- a/helm-chart/banzai/values-dev.yaml
+++ b/helm-chart/banzai/values-dev.yaml
@@ -3,7 +3,7 @@
 # Declare variables to be passed into your templates.
 image:
   repository: docker.lco.global/banzai
-  tag: "1.1.1"
+  tag: "1.1.2"
   pullPolicy: IfNotPresent
 
 # Values for the OCS Ingester library, used by BANZAI.

--- a/helm-chart/banzai/values-prod.yaml
+++ b/helm-chart/banzai/values-prod.yaml
@@ -12,7 +12,7 @@ horizontalPodAutoscaler:
 
 image:
   repository: docker.lco.global/banzai
-  tag: "1.1.1"
+  tag: "1.1.2"
   pullPolicy: IfNotPresent
 
 # Values for the OCS Ingester library, used by BANZAI.

--- a/setup.cfg
+++ b/setup.cfg
@@ -97,7 +97,7 @@ edit_on_github = True
 github_project = lcogt/banzai
 
 # version should be PEP440 compatible (http://www.python.org/dev/peps/pep-0440)
-version = 1.1.1
+version = 1.1.2
 
 [options]
 zip_safe = False
@@ -122,7 +122,7 @@ install_requires =
     celery[redis]==4.3.1
     apscheduler
     python-dateutil
-    lco_ingester>=2.1.15
+    ocs_ingester>=2.2.5
     tenacity==6.0.0
     python-dateutil
 setup_requires = setuptools_scm


### PR DESCRIPTION
This ingester version includes updates related to the deletion of the "old" LCO s3 bucket. No functional changes.