### PR TITLE
Uprevv ingester version. Update changelog.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+1.1.4 (2020-03-23)
+-------------------
+- Update to use OCS Ingester 2.2.6, with fixes for NRES data products.
+
 1.1.3 (2020-02-23)
 -------------------
 - Move public CI from Travis to GitHub Actions

--- a/helm-chart/banzai/Chart.yaml
+++ b/helm-chart/banzai/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: "1.1.2"
+appVersion: "1.1.4"
 description: A Helm chart to deploy the BANZAI pipeline
 name: banzai
-version: 1.1.2
+version: 1.1.4

--- a/helm-chart/banzai/values-dev.yaml
+++ b/helm-chart/banzai/values-dev.yaml
@@ -3,7 +3,7 @@
 # Declare variables to be passed into your templates.
 image:
   repository: docker.lco.global/banzai
-  tag: "1.1.2"
+  tag: "1.1.4"
   pullPolicy: IfNotPresent
 
 # Values for the OCS Ingester library, used by BANZAI.

--- a/helm-chart/banzai/values-prod.yaml
+++ b/helm-chart/banzai/values-prod.yaml
@@ -12,7 +12,7 @@ horizontalPodAutoscaler:
 
 image:
   repository: docker.lco.global/banzai
-  tag: "1.1.2"
+  tag: "1.1.4"
   pullPolicy: IfNotPresent
 
 # Values for the OCS Ingester library, used by BANZAI.

--- a/setup.cfg
+++ b/setup.cfg
@@ -97,7 +97,7 @@ edit_on_github = True
 github_project = lcogt/banzai
 
 # version should be PEP440 compatible (http://www.python.org/dev/peps/pep-0440)
-version = 1.1.3
+version = 1.1.4
 
 [options]
 zip_safe = False
@@ -122,7 +122,7 @@ install_requires =
     celery[redis]==4.3.1
     apscheduler
     python-dateutil
-    ocs_ingester>=2.2.5
+    ocs_ingester>=2.2.6
     tenacity==6.0.0
     python-dateutil
 setup_requires = setuptools_scm


### PR DESCRIPTION
This is a fix for downstream BANZAI-NRES so that frames with sexagesimal RA/Dec can be properly ingested.