### PR TITLE
Update ingester lib to 2.3.0. Increment version in helm chart. Update CHANGELOG

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+1.2.1 (2021-04-08)
+------------------
+- Upgrade to ocs-ingester 2.3.0, which adds the ability to ingest data products of 
+  arbitrary type to an OCS Science Archive
+
 1.2.0 (2021-04-04)
 ------------------
 - Added the option to losslessly compress fits extensions.

--- a/helm-chart/banzai/Chart.yaml
+++ b/helm-chart/banzai/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: "1.1.4"
+appVersion: "1.2.1"
 description: A Helm chart to deploy the BANZAI pipeline
 name: banzai
-version: 1.1.4
+version: 1.2.1

--- a/helm-chart/banzai/values-dev.yaml
+++ b/helm-chart/banzai/values-dev.yaml
@@ -3,7 +3,7 @@
 # Declare variables to be passed into your templates.
 image:
   repository: docker.lco.global/banzai
-  tag: "1.1.4"
+  tag: "1.2.1"
   pullPolicy: IfNotPresent
 
 # Values for the OCS Ingester library, used by BANZAI.

--- a/helm-chart/banzai/values-prod.yaml
+++ b/helm-chart/banzai/values-prod.yaml
@@ -12,7 +12,7 @@ horizontalPodAutoscaler:
 
 image:
   repository: docker.lco.global/banzai
-  tag: "1.1.4"
+  tag: "1.2.1"
   pullPolicy: IfNotPresent
 
 # Values for the OCS Ingester library, used by BANZAI.

--- a/setup.cfg
+++ b/setup.cfg
@@ -119,7 +119,7 @@ install_requires =
     celery[redis]==4.3.1
     apscheduler
     python-dateutil
-    ocs_ingester>=2.2.6
+    ocs_ingester>=2.3.0,<3
     tenacity==6.0.0
     python-dateutil
 setup_requires = setuptools_scm


### PR DESCRIPTION
Upgrade to ocs-ingester 2.3.0, which adds the ability to ingest data products of arbitrary type to an OCS Science Archive