### PR TITLE
Temporarily disable worker autoscaling

### DIFF
--- a/helm-chart/banzai/values-prod.yaml
+++ b/helm-chart/banzai/values-prod.yaml
@@ -6,8 +6,8 @@
 # will be started when the CPU usage rises above the configured threshold.
 horizontalPodAutoscaler:
   enabled: true
-  minReplicas: 5
-  maxReplicas: 10
+  minReplicas: 6
+  maxReplicas: 6
   targetCPUUtilizationPercentage: 50
 
 image:


### PR DESCRIPTION
Keep using the autoscaling controller, but simply limit the workers min and max to 6. There is an issue where a task will not be retried if a worker is brought down while executing it.