### PR TITLE
Add /image endpoint to base photometric catalog url

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,4 @@
-1.5.1 (2021-09-13)
+1.5.1 (2021-09-14)
 ------------------
 - Fix for photometric catalog service URL
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+1.5.1 (2021-09-13)
+------------------
+- Fix for photometric catalog service URL
+
 1.5.0 (2021-09-13)
 ------------------
 - Added ccd temperature as a matching criteria for super darks.

--- a/banzai/astrometry.py
+++ b/banzai/astrometry.py
@@ -29,16 +29,16 @@ class WCSSolver(Stage):
             image.meta['WCSERR'] = FAILED_WCS
             return image
 
-        try:
-            # Get the image catalog and sort in order of flux
-            # with the brightest objects first
-            image_catalog = image['CAT'].data
-            image_catalog.sort('flux')
-            image_catalog.reverse()
-        except KeyError:
+        if image['CAT'] is None:
             logger.warning('Not attempting WCS solve because no catalog exists', image=image)
             image.meta['WCSERR'] = FAILED_WCS
             return image
+
+        # Get the image catalog and sort in order of flux
+        # with the brightest objects first
+        image_catalog = image['CAT'].data
+        image_catalog.sort('flux')
+        image_catalog.reverse()
 
         catalog_payload = {'X': list(image_catalog['x'])[:SOURCE_LIMIT],
                            'Y': list(image_catalog['y'])[:SOURCE_LIMIT],

--- a/banzai/frames.py
+++ b/banzai/frames.py
@@ -222,7 +222,11 @@ class ObservationFrame(metaclass=abc.ABCMeta):
         return key in self._hdu_mapping
 
     def __getitem__(self, item):
-        return self._hdus[self._hdu_mapping[item]]
+        item_index = self._hdu_mapping.get(item)
+        if item_index is None:
+            return None
+        else:
+            return self._hdus[item_index]
 
 
 class CalibrationFrame(metaclass=abc.ABCMeta):

--- a/banzai/photometry.py
+++ b/banzai/photometry.py
@@ -256,6 +256,9 @@ class PhotometricCalibrator(Stage):
         if image.filter not in ['gp', 'rp', 'ip', 'zs']:
             return image
 
+        if image.get('CAT') is None:
+            logger.info("Not photometrically calibration image because no catalog exists")
+
         try:
             # Get the sources in the frame
             reference_catalog = get_reference_sources(image.meta, urljoin(self.runtime_context.REFERENCE_CATALOG_URL, '/image'))
@@ -278,6 +281,6 @@ class PhotometricCalibrator(Stage):
         image.meta['L1COLOR'] = color_coefficient, "Color coefficient [mag]"
         image.meta['L1COLERR'] = color_coefficient_error, "Error on color coefficient [mag]"
         # Calculate the mag of each of the items in the catalog (without the color term) saving them
-        image['CAT'].data['mag'], image['CAT'].data['magerr'] = to_magnitude(image['CAT'].data['flux'], image['CAT'].data['flux_error'],
+        image['CAT'].data['mag'], image['CAT'].data['magerr'] = to_magnitude(image['CAT'].data['flux'], image['CAT'].data['fluxerr'],
                                                                              zeropoint, image.exptime)
         return image

--- a/banzai/photometry.py
+++ b/banzai/photometry.py
@@ -264,7 +264,7 @@ class PhotometricCalibrator(Stage):
             return image
 
         # Match the catalog to the detected sources
-        matched_catalog = match_catalogs(image.catalog, reference_catalog)
+        matched_catalog = match_catalogs(image['CAT'].data, reference_catalog)
 
         # catalog_mag = instrumental_mag + zeropoint + color_coefficient * color
         # Fit the zeropoint and color_coefficient rejecting outliers
@@ -278,6 +278,6 @@ class PhotometricCalibrator(Stage):
         image.meta['L1COLOR'] = color_coefficient, "Color coefficient [mag]"
         image.meta['L1COLERR'] = color_coefficient_error, "Error on color coefficient [mag]"
         # Calculate the mag of each of the items in the catalog (without the color term) saving them
-        image.catalog['mag'], image.catalog['magerr'] = to_magnitude(image.catalog['flux'], image.catalog['flux_error'],
+        image.catalog['mag'], image.catalog['magerr'] = to_magnitude(image['CAT'].data['flux'], image['CAT'].data['flux_error'],
                                                                      zeropoint, image.exptime)
         return image

--- a/banzai/photometry.py
+++ b/banzai/photometry.py
@@ -1,4 +1,5 @@
 import logging
+from urllib.parse import urljoin
 
 import numpy as np
 from astropy.table import Table
@@ -257,7 +258,7 @@ class PhotometricCalibrator(Stage):
 
         try:
             # Get the sources in the frame
-            reference_catalog = get_reference_sources(image.meta, self.runtime_context.REFERENCE_CATALOG_URL)
+            reference_catalog = get_reference_sources(image.meta, urljoin(self.runtime_context.REFERENCE_CATALOG_URL, '/image/'))
         except HTTPError as e:
             logger.error(f'Error retrieving photometric reference catalog: {e}', image=image)
             return image

--- a/banzai/photometry.py
+++ b/banzai/photometry.py
@@ -256,8 +256,11 @@ class PhotometricCalibrator(Stage):
         if image.filter not in ['gp', 'rp', 'ip', 'zs']:
             return image
 
-        if image.get('CAT') is None:
-            logger.info("Not photometrically calibration image because no catalog exists")
+        try:
+            catalog = image['CAT']
+        except KeyError:
+            logger.warning("Not photometrically calibrating image because no catalog exists", image=image)
+            return image
 
         try:
             # Get the sources in the frame

--- a/banzai/photometry.py
+++ b/banzai/photometry.py
@@ -258,7 +258,7 @@ class PhotometricCalibrator(Stage):
 
         try:
             # Get the sources in the frame
-            reference_catalog = get_reference_sources(image.meta, urljoin(self.runtime_context.REFERENCE_CATALOG_URL, '/image/'))
+            reference_catalog = get_reference_sources(image.meta, urljoin(self.runtime_context.REFERENCE_CATALOG_URL, '/image'))
         except HTTPError as e:
             logger.error(f'Error retrieving photometric reference catalog: {e}', image=image)
             return image

--- a/banzai/photometry.py
+++ b/banzai/photometry.py
@@ -278,6 +278,6 @@ class PhotometricCalibrator(Stage):
         image.meta['L1COLOR'] = color_coefficient, "Color coefficient [mag]"
         image.meta['L1COLERR'] = color_coefficient_error, "Error on color coefficient [mag]"
         # Calculate the mag of each of the items in the catalog (without the color term) saving them
-        image.catalog['mag'], image.catalog['magerr'] = to_magnitude(image['CAT'].data['flux'], image['CAT'].data['flux_error'],
-                                                                     zeropoint, image.exptime)
+        image['CAT'].data['mag'], image['CAT'].data['magerr'] = to_magnitude(image['CAT'].data['flux'], image['CAT'].data['flux_error'],
+                                                                             zeropoint, image.exptime)
         return image

--- a/banzai/photometry.py
+++ b/banzai/photometry.py
@@ -256,9 +256,7 @@ class PhotometricCalibrator(Stage):
         if image.filter not in ['gp', 'rp', 'ip', 'zs']:
             return image
 
-        try:
-            catalog = image['CAT']
-        except KeyError:
+        if image['CAT'] is None:
             logger.warning("Not photometrically calibrating image because no catalog exists", image=image)
             return image
 

--- a/banzai/tests/test_end_to_end.py
+++ b/banzai/tests/test_end_to_end.py
@@ -18,6 +18,7 @@ from banzai.utils import fits_utils, file_utils
 from banzai.main import add_bpm
 from banzai.tests.utils import FakeResponse, get_min_and_max_dates, FakeContext
 from astropy.utils.data import get_pkg_data_filename
+from astropy.io import fits
 
 import logging
 
@@ -241,3 +242,6 @@ class TestScienceFileCreation:
         assert len(expected_files) > 0
         for expected_file in expected_files:
             assert expected_file in created_files
+
+        # check that one of our files was photometrically calibrated
+        assert fits.getheader(created_files[0]).get('L1PHOTZP') is not None

--- a/banzai/tests/test_end_to_end.py
+++ b/banzai/tests/test_end_to_end.py
@@ -243,5 +243,11 @@ class TestScienceFileCreation:
         for expected_file in expected_files:
             assert expected_file in created_files
 
-        # check that one of our files was photometrically calibrated
-        assert fits.getheader(created_files[0], 'SCI').get('L1ZP') is not None
+    def test_that_photometric_calibration_succeeded(self):
+        science_files = []
+        for day_obs in DAYS_OBS:
+            science_files += [filepath for filepath in glob(os.path.join(DATA_ROOT, day_obs, 
+                                                                         'processed', '*e91*'))]
+        zeropoints = [fits.open(file)['SCI'].header.get('L1ZP') for file in science_files]
+        # check that at least one of our images contains a zeropoint
+        assert zeropoints.count(None) != len(zeropoints)

--- a/banzai/tests/test_end_to_end.py
+++ b/banzai/tests/test_end_to_end.py
@@ -244,4 +244,4 @@ class TestScienceFileCreation:
             assert expected_file in created_files
 
         # check that one of our files was photometrically calibrated
-        assert fits.getheader(created_files[0]).get('L1PHOTZP') is not None
+        assert fits.getheader(created_files[0], 'SCI').get('L1ZP') is not None


### PR DESCRIPTION
Fixes photometric calibration and adds a test to check that _at least_ one of our produced science files contains the `L1ZP` keyword in its header