### PR TITLE
Fix/failed wcs photometry

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+1.5.3 (2021-09-21)
+------------------
+- Additional fixes for photometric calibrations
+
 1.5.2 (2021-09-16)
 ------------------
 - Fix for photometric calibration for images with no WCS solution

--- a/banzai/photometry.py
+++ b/banzai/photometry.py
@@ -260,7 +260,7 @@ class PhotometricCalibrator(Stage):
             logger.warning("Not photometrically calibrating image because no catalog exists", image=image)
             return image
 
-        if image.meta['WCSERR'] == FAILED_WCS:
+        if image.meta['WCSERR'] == FAILED_WCS[0]:
             logger.warning("Not photometrically calibrating image because WCS solution failed", image=image)
             return image
 

--- a/banzai/photometry.py
+++ b/banzai/photometry.py
@@ -7,7 +7,6 @@ import sep
 from requests import HTTPError
 
 from banzai.utils import stats, array_utils
-from banzai.astrometry import FAILED_WCS
 from banzai.utils.photometry_utils import get_reference_sources, match_catalogs, to_magnitude, fit_photometry
 from banzai.stages import Stage
 from banzai.data import DataTable
@@ -260,7 +259,7 @@ class PhotometricCalibrator(Stage):
             logger.warning("Not photometrically calibrating image because no catalog exists", image=image)
             return image
 
-        if image.meta['WCSERR'] == FAILED_WCS[0]:
+        if image.meta['WCSERR'] > 0:
             logger.warning("Not photometrically calibrating image because WCS solution failed", image=image)
             return image
 

--- a/helm-chart/banzai/values-prod.yaml
+++ b/helm-chart/banzai/values-prod.yaml
@@ -6,8 +6,8 @@
 # will be started when the CPU usage rises above the configured threshold.
 horizontalPodAutoscaler:
   enabled: true
-  minReplicas: 6
-  maxReplicas: 6
+  minReplicas: 15
+  maxReplicas: 15
   targetCPUUtilizationPercentage: 50
 
 image:


### PR DESCRIPTION
Generalize our approach for checking for failed WCS - simply check that it's greater than zero and bail out.

Also increase the worker counts due to the introduction of the long-running photometric calibrator stage.