### PR TITLE
Make sure we handle exceptions when fitting photometry.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+1.5.4 (2021-09-21)
+------------------
+- Add more granular error handling for fitting photometry
+
 1.5.3 (2021-09-21)
 ------------------
 - Additional fixes for photometric calibrations

--- a/banzai/photometry.py
+++ b/banzai/photometry.py
@@ -279,8 +279,13 @@ class PhotometricCalibrator(Stage):
         # catalog_mag = instrumental_mag + zeropoint + color_coefficient * color
         # Fit the zeropoint and color_coefficient rejecting outliers
         # Note the zero index here in the filter name is because we only store teh first letter of the filter name
-        zeropoint, zeropoint_error, color_coefficient, color_coefficient_error = \
-            fit_photometry(matched_catalog, image.filter[0], self.color_to_fit[image.filter], image.exptime)
+        try:
+            zeropoint, zeropoint_error, color_coefficient, color_coefficient_error = \
+                fit_photometry(matched_catalog, image.filter[0], self.color_to_fit[image.filter], image.exptime)
+        except:
+            logger.error(f"Error fitting photometry: {logs.format_exception()}", image=image)
+            return image
+
         # Save the zeropoint, color coefficient and errors to header
         image.meta['L1ZP'] = zeropoint, "Instrumental zeropoint [mag]"
         image.meta['L1ZPERR'] = zeropoint_error, "Error on Instrumental zeropoint [mag]"


### PR DESCRIPTION
Log them properly but move on with reduction - we don't want missing frames over this.