### PR TITLE
Set celery tasks to retry when a worker dies during their execution.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+1.5.5 (2021-10-05)
+------------------
+- Configure celery tasks to automatically retry in-progress tasks in the case of a container failure or scale-down
+
 1.5.4 (2021-09-21)
 ------------------
 - Add more granular error handling for fitting photometry

--- a/banzai/celery.py
+++ b/banzai/celery.py
@@ -57,7 +57,7 @@ app.log.setup()
 app.log.redirect_stdouts_to_logger(logger, 'INFO')
 
 
-@app.task(name='celery.schedule_calibration_stacking')
+@app.task(name='celery.schedule_calibration_stacking', reject_on_worker_lost=True)
 def schedule_calibration_stacking(site: str, runtime_context: dict, min_date=None, max_date=None, frame_types=None):
     logger.info('Scheduling when to stack frames.', extra_tags={'site': site})
     try:
@@ -126,7 +126,7 @@ def schedule_calibration_stacking(site: str, runtime_context: dict, min_date=Non
                      extra_tags={'site': site})
 
 
-@app.task(name='celery.stack_calibrations', bind=True, default_retry_delay=RETRY_DELAY)
+@app.task(name='celery.stack_calibrations', bind=True, default_retry_delay=RETRY_DELAY, reject_on_worker_lost=True)
 def stack_calibrations(self, min_date: str, max_date: str, instrument_id: int, frame_type: str,
                        runtime_context: dict, observations: list):
     try:
@@ -167,7 +167,7 @@ def stack_calibrations(self, min_date: str, max_date: str, instrument_id: int, f
         raise self.retry()
 
 
-@app.task(name='celery.process_image')
+@app.task(name='celery.process_image', reject_on_worker_lost=True)
 def process_image(file_info: dict, runtime_context: dict):
     """
     :param file_info: Body of queue message: dict

--- a/banzai/celery.py
+++ b/banzai/celery.py
@@ -57,7 +57,7 @@ app.log.setup()
 app.log.redirect_stdouts_to_logger(logger, 'INFO')
 
 
-@app.task(name='celery.schedule_calibration_stacking', reject_on_worker_lost=True)
+@app.task(name='celery.schedule_calibration_stacking', reject_on_worker_lost=True, max_retries=5)
 def schedule_calibration_stacking(site: str, runtime_context: dict, min_date=None, max_date=None, frame_types=None):
     logger.info('Scheduling when to stack frames.', extra_tags={'site': site})
     try:
@@ -167,7 +167,7 @@ def stack_calibrations(self, min_date: str, max_date: str, instrument_id: int, f
         raise self.retry()
 
 
-@app.task(name='celery.process_image', reject_on_worker_lost=True)
+@app.task(name='celery.process_image', reject_on_worker_lost=True, max_retries=5)
 def process_image(file_info: dict, runtime_context: dict):
     """
     :param file_info: Body of queue message: dict


### PR DESCRIPTION
When a worker pod is rescheduled or scaled-down, tasks will not be retried if the worker dies in the middle of execution. Alleviate this by having them retry when the worker is lost.