### PR TITLE
Add object to logging tags.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+1.7.3 (2022-01-28)
+------------------
+- Add OBJECT logging tag to pointing test so it can be filtered in Elasticsearch
+
 1.7.2 (2022-01-12)
 ------------------
 - Bugfix to read in non-fpacked files

--- a/banzai/qc/pointing.py
+++ b/banzai/qc/pointing.py
@@ -41,7 +41,8 @@ class PointingTest(Stage):
 
         angular_separation = solved_coords.separation(requested_coords).arcsec
 
-        logging_tags = {'PNTOFST': angular_separation}
+        logging_tags = {'PNTOFST': angular_separation,
+                        'OBJECT': image.meta['OBJECT']}
 
         pointing_severe = abs(angular_separation) > self.SEVERE_THRESHOLD
         pointing_warning = abs(angular_separation) > self.WARNING_THRESHOLD

--- a/banzai/qc/pointing.py
+++ b/banzai/qc/pointing.py
@@ -42,7 +42,7 @@ class PointingTest(Stage):
         angular_separation = solved_coords.separation(requested_coords).arcsec
 
         logging_tags = {'PNTOFST': angular_separation,
-                        'OBJECT': image.meta['OBJECT']}
+                        'OBJECT': image.meta.get('OBJECT', 'N/A')}
 
         pointing_severe = abs(angular_separation) > self.SEVERE_THRESHOLD
         pointing_warning = abs(angular_separation) > self.WARNING_THRESHOLD

--- a/banzai/tests/test_pointing.py
+++ b/banzai/tests/test_pointing.py
@@ -20,7 +20,8 @@ def test_no_offset():
     image_header = Header({'CRVAL1': '1.0',
                            'CRVAL2': '-1.0',
                            'OFST-RA': '0:04:00.00',
-                           'OFST-DEC': '-01:00:00.000'})
+                           'OFST-DEC': '-01:00:00.000',
+                           'OBJECT': 'testobj'})
 
     image = FakeLCOObservationFrame(hdu_list=[FakeCCDData(meta=image_header)])
     image = tester.do_stage(image)
@@ -34,7 +35,8 @@ def test_large_offset():
     image_header = Header({'CRVAL1': '00:00:00.000',
                            'CRVAL2': '-00:00:00.000',
                            'OFST-RA': '00:00:00.000',
-                           'OFST-DEC': '-00:00:10.000'})
+                           'OFST-DEC': '-00:00:10.000',
+                           'OBJECT': 'testobj'})
 
     image = FakeLCOObservationFrame(hdu_list=[FakeCCDData(meta=image_header)])
     image = tester.do_stage(image)


### PR DESCRIPTION
This way we can filter our pointing alerts by OBJECT name. See issue 1573 in redmine.