### PR TITLE
add_bpm function updated to add_cal function

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 ------------------
 - Changed add_bpm function to take any calibration file, renamed to add_super_calibration
 
+1.9.7 (2022-04-07)
+------------------
+- Updates to use OpenSearch
+
 1.9.6 (2022-02-25)
 ------------------
 - Bugfix to propagate headers in data table objects

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+1.9.8 (2022-04-14)
+------------------
+- Changed add_bpm function to take any calibration file, renamed to add_super_calibration
+
 1.9.6 (2022-02-25)
 ------------------
 - Bugfix to propagate headers in data table objects

--- a/banzai/main.py
+++ b/banzai/main.py
@@ -301,22 +301,22 @@ def add_cal():
     logs.set_log_level(args.log_level)
     frame_factory = import_utils.import_attribute(settings.FRAME_FACTORY)()
     try:
-        bpm_image = frame_factory.open({'path': args.filepath}, args)
+        cal_image = frame_factory.open({'path': args.filepath}, args)
     except Exception:
         logger.error(f"Calibration file not able to be opened by BANZAI. Aborting... {logs.format_exception()}", extra_tags={'filename': args.filepath})
-        bpm_image = None
+        cal_image = None
 
     # upload BPM via ingester
     if bpm_image is not None:
         with open(args.filepath, 'rb') as f:
             logger.debug("Posting Calibration file to s3 archive")
-            ingester_response = file_utils.post_to_ingester(f, bpm_image, args.filepath)
+            ingester_response = file_utils.post_to_ingester(f, cal_image, args.filepath)
 
         logger.debug("File posted to s3 archive. Saving to database.", extra_tags={'frameid': ingester_response['frameid']})
-        bpm_image.frame_id = ingester_response['frameid']
-        bpm_image.is_bad = False
-        bpm_image.is_master = True
-        dbs.save_calibration_info(bpm_image.to_db_record(DataProduct(None, filename=os.path.basename(args.filepath),
+        cal_image.frame_id = ingester_response['frameid']
+        cal_image.is_bad = False
+        cal_image.is_master = True
+        dbs.save_calibration_info(cal_image.to_db_record(DataProduct(None, filename=os.path.basename(args.filepath),
                                                                      filepath=os.path.dirname(args.filepath))),
                                   args.db_address)
 

--- a/banzai/main.py
+++ b/banzai/main.py
@@ -289,13 +289,13 @@ def update_db():
 
 
 def add_cal():
-    parser = argparse.ArgumentParser(description="Add a bad pixel mask to the db.")
-    parser.add_argument('filepath', help='Full path to Bad Pixel Mask file')
+    parser = argparse.ArgumentParser(description="Add a calibration file (bad pixel mask, bias, dark, skyflat)to the db.")
+    parser.add_argument('filepath', help='Full path to calibration file')
     parser.add_argument("--log-level", default='debug', choices=['debug', 'info', 'warning',
                                                                  'critical', 'fatal', 'error'])
     parser.add_argument('--db-address', dest='db_address',
                         default='mysql://cmccully:password@localhost/test',
-                        help='Database address: Should be in SQLAlchemy form')
+                        help='Database address: Should be in SQLAlchemy form')#change to developer db
     args = parser.parse_args()
     add_settings_to_context(args, settings)
     logs.set_log_level(args.log_level)
@@ -303,13 +303,13 @@ def add_cal():
     try:
         bpm_image = frame_factory.open({'path': args.filepath}, args)
     except Exception:
-        logger.error(f"BPM not able to be opened by BANZAI. Aborting... {logs.format_exception()}", extra_tags={'filename': args.filepath})
+        logger.error(f"Calibration file not able to be opened by BANZAI. Aborting... {logs.format_exception()}", extra_tags={'filename': args.filepath})
         bpm_image = None
 
     # upload BPM via ingester
     if bpm_image is not None:
         with open(args.filepath, 'rb') as f:
-            logger.debug("Posting BPM to s3 archive")
+            logger.debug("Posting Calibration file to s3 archive")
             ingester_response = file_utils.post_to_ingester(f, bpm_image, args.filepath)
 
         logger.debug("File posted to s3 archive. Saving to database.", extra_tags={'frameid': ingester_response['frameid']})

--- a/banzai/main.py
+++ b/banzai/main.py
@@ -288,7 +288,7 @@ def update_db():
         logger.error('Could not populate instruments table: {error}'.format(error=logs.format_exception()))
 
 
-def add_bpm():
+def add_cal():
     parser = argparse.ArgumentParser(description="Add a bad pixel mask to the db.")
     parser.add_argument('filepath', help='Full path to Bad Pixel Mask file')
     parser.add_argument("--log-level", default='debug', choices=['debug', 'info', 'warning',

--- a/banzai/main.py
+++ b/banzai/main.py
@@ -289,7 +289,7 @@ def update_db():
 
 
 def add_cal():
-    parser = argparse.ArgumentParser(description="Add a calibration file (bad pixel mask, bias, dark, skyflat)to the db.")
+    parser = argparse.ArgumentParser(description="Add a calibration file (bad pixel mask, bias, dark, skyflat) to the db.")
     parser.add_argument('filepath', help='Full path to calibration file')
     parser.add_argument("--log-level", default='debug', choices=['debug', 'info', 'warning',
                                                                  'critical', 'fatal', 'error'])

--- a/banzai/main.py
+++ b/banzai/main.py
@@ -295,7 +295,7 @@ def add_cal():
                                                                  'critical', 'fatal', 'error'])
     parser.add_argument('--db-address', dest='db_address',
                         default='mysql://cmccully:password@localhost/test',
-                        help='Database address: Should be in SQLAlchemy form')#change to developer db for testing
+                        help='Database address: Should be in SQLAlchemy form')
     args = parser.parse_args()
     add_settings_to_context(args, settings)
     logs.set_log_level(args.log_level)

--- a/banzai/main.py
+++ b/banzai/main.py
@@ -295,7 +295,7 @@ def add_cal():
                                                                  'critical', 'fatal', 'error'])
     parser.add_argument('--db-address', dest='db_address',
                         default='mysql://cmccully:password@localhost/test',
-                        help='Database address: Should be in SQLAlchemy form')#change to developer db
+                        help='Database address: Should be in SQLAlchemy form')#change to developer db for testing
     args = parser.parse_args()
     add_settings_to_context(args, settings)
     logs.set_log_level(args.log_level)
@@ -306,8 +306,8 @@ def add_cal():
         logger.error(f"Calibration file not able to be opened by BANZAI. Aborting... {logs.format_exception()}", extra_tags={'filename': args.filepath})
         cal_image = None
 
-    # upload BPM via ingester
-    if bpm_image is not None:
+    # upload calibration file via ingester
+    if cal_image is not None:
         with open(args.filepath, 'rb') as f:
             logger.debug("Posting Calibration file to s3 archive")
             ingester_response = file_utils.post_to_ingester(f, cal_image, args.filepath)

--- a/banzai/main.py
+++ b/banzai/main.py
@@ -288,8 +288,8 @@ def update_db():
         logger.error('Could not populate instruments table: {error}'.format(error=logs.format_exception()))
 
 
-def add_cal():
-    parser = argparse.ArgumentParser(description="Add a calibration file (bad pixel mask, bias, dark, skyflat) to the db.")
+def add_super_calibration():
+    parser = argparse.ArgumentParser(description="Add a super calibration file to the db.")
     parser.add_argument('filepath', help='Full path to calibration file')
     parser.add_argument("--log-level", default='debug', choices=['debug', 'info', 'warning',
                                                                  'critical', 'fatal', 'error'])
@@ -309,7 +309,7 @@ def add_cal():
     # upload calibration file via ingester
     if cal_image is not None:
         with open(args.filepath, 'rb') as f:
-            logger.debug("Posting Calibration file to s3 archive")
+            logger.debug("Posting calibration file to s3 archive")
             ingester_response = file_utils.post_to_ingester(f, cal_image, args.filepath)
 
         logger.debug("File posted to s3 archive. Saving to database.", extra_tags={'frameid': ingester_response['frameid']})

--- a/banzai/tests/test_end_to_end.py
+++ b/banzai/tests/test_end_to_end.py
@@ -15,7 +15,7 @@ from banzai.celery import app, schedule_calibration_stacking
 from banzai.dbs import get_session, CalibrationImage, get_timezone, populate_instrument_tables
 from banzai.dbs import mark_frame
 from banzai.utils import fits_utils, file_utils
-from banzai.main import add_bpm
+from banzai.main import add_cal
 from banzai.tests.utils import FakeResponse, get_min_and_max_dates, FakeContext
 from astropy.io import fits
 import pkg_resources
@@ -166,7 +166,7 @@ def init(configdb, mock_ingester, mock_args):
     for instrument in INSTRUMENTS:
         for bpm_filepath in glob(os.path.join(DATA_ROOT, instrument, 'bpm/*bpm*')):
             mock_args.return_value = argparse.Namespace(filepath=bpm_filepath, db_address=os.environ['DB_ADDRESS'], log_level='debug')
-            add_bpm()
+            add_cal()
 
 
 @pytest.mark.e2e

--- a/banzai/tests/test_end_to_end.py
+++ b/banzai/tests/test_end_to_end.py
@@ -15,7 +15,7 @@ from banzai.celery import app, schedule_calibration_stacking
 from banzai.dbs import get_session, CalibrationImage, get_timezone, populate_instrument_tables
 from banzai.dbs import mark_frame
 from banzai.utils import fits_utils, file_utils
-from banzai.main import add_cal
+from banzai.main import add_super_calibration
 from banzai.tests.utils import FakeResponse, get_min_and_max_dates, FakeContext
 from astropy.io import fits
 import pkg_resources
@@ -166,7 +166,7 @@ def init(configdb, mock_ingester, mock_args):
     for instrument in INSTRUMENTS:
         for bpm_filepath in glob(os.path.join(DATA_ROOT, instrument, 'bpm/*bpm*')):
             mock_args.return_value = argparse.Namespace(filepath=bpm_filepath, db_address=os.environ['DB_ADDRESS'], log_level='debug')
-            add_cal()
+            add_super_calibration()
 
 
 @pytest.mark.e2e

--- a/setup.cfg
+++ b/setup.cfg
@@ -154,7 +154,7 @@ console_scripts =
     banzai_migrate_db = banzai.utils.db_migration:migrate_db
     banzai_add_instrument = banzai.main:add_instrument
     banzai_add_site = banzai.main:add_site
-    banzai_add_bpm = banzai.main:add_bpm
+    banzai_add_cal = banzai.main:add_cal
     banzai_populate_bpms = banzai.main:add_bpms_from_archive
     banzai_create_db = banzai.main:create_db
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -154,7 +154,7 @@ console_scripts =
     banzai_migrate_db = banzai.utils.db_migration:migrate_db
     banzai_add_instrument = banzai.main:add_instrument
     banzai_add_site = banzai.main:add_site
-    banzai_add_cal = banzai.main:add_cal
+    banzai_add__super_calibration = banzai.main:add_super_calibration
     banzai_populate_bpms = banzai.main:add_bpms_from_archive
     banzai_create_db = banzai.main:create_db
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -154,7 +154,7 @@ console_scripts =
     banzai_migrate_db = banzai.utils.db_migration:migrate_db
     banzai_add_instrument = banzai.main:add_instrument
     banzai_add_site = banzai.main:add_site
-    banzai_add__super_calibration = banzai.main:add_super_calibration
+    banzai_add_super_calibration = banzai.main:add_super_calibration
     banzai_populate_bpms = banzai.main:add_bpms_from_archive
     banzai_create_db = banzai.main:create_db
 


### PR DESCRIPTION
Updated to add_bpm function to reflect the fact that the function can take any kind of calibration file: dark, bias, sky flat, and bad pixel mask.

- Changed the function name to add_cal, and updated the command line function to read in the function.
- The command line function is now `banzai_add_cal`
- Updated the test_end_to_end.py script to use the new function name
- Updated the command line descriptions and error messages to apply to general calibration files rather than just BPM files

Tested the change using the development archive and a local database, and using a bias, dark and skyflat file. All three uploads were successful, as reflected by the database and the archive:
**Database**
![image](https://user-images.githubusercontent.com/30590837/162505822-727dfb4b-3027-4cd4-a9fc-0a719c133190.png)
**Archive**
http://archive-api-dev.lco.gtn/frames/