### PR TITLE
Simplify Processed Path for Steward Images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,6 @@ distribute-*.tar.gz
 *.iml
 
 .coverage.subprocess
+
+# Docker environment file
+.env

--- a/banzai/astrometry.py
+++ b/banzai/astrometry.py
@@ -8,10 +8,10 @@ from astropy import units
 import numpy as np
 
 from banzai.stages import Stage
+from banzai import settings
 
 logger = logging.getLogger('banzai')
 
-SOURCE_LIMIT = 50
 FAILED_WCS = (4, 'Error status of WCS fit. 0 for no error')
 SUCCESSFUL_WCS = (0, 'Error status of WCS fit. 0 for no error')
 
@@ -40,9 +40,11 @@ class WCSSolver(Stage):
         image_catalog.sort('flux')
         image_catalog.reverse()
 
-        catalog_payload = {'X': list(image_catalog['x'])[:SOURCE_LIMIT],
-                           'Y': list(image_catalog['y'])[:SOURCE_LIMIT],
-                           'FLUX': list(image_catalog['flux'])[:SOURCE_LIMIT],
+        catalog_payload = {'X': list(image_catalog['x'])[:settings.WCS_SOURCE_LIMIT],
+                           'Y': list(image_catalog['y'])[:settings.WCS_SOURCE_LIMIT],
+                           'FLUX': list(image_catalog['flux'])[:settings.WCS_SOURCE_LIMIT],
+                           'radius': settings.WCS_RADIUS,
+                           'tolerance': settings.WCS_TOLERANCE,
                            'pixel_scale': image.pixel_scale,
                            'naxis': 2,
                            'naxis1': image.shape[1],

--- a/banzai/frames.py
+++ b/banzai/frames.py
@@ -282,5 +282,5 @@ class FrameFactory:
 
     @staticmethod
     @abc.abstractmethod
-    def get_instrument_from_header(header, db_address):
+    def get_instrument_from_header(header, db_address=None):
         pass

--- a/banzai/lco.py
+++ b/banzai/lco.py
@@ -490,15 +490,15 @@ class LCOFrameFactory(FrameFactory):
             return None
 
     @staticmethod
-    def get_instrument_from_header(header, db_address):
+    def get_instrument_from_header(header, db_address=None):
         site = header.get('SITEID')
         camera = header.get('INSTRUME')
-        instrument = dbs.query_for_instrument(db_address, site, camera)
+        instrument = dbs.query_for_instrument(site, camera, db_address=db_address)
         name = camera
         if instrument is None:
             # if instrument is missing, assume it is an NRES frame and check for the instrument again.
             name = header.get('TELESCOP')
-            instrument = dbs.query_for_instrument(db_address, site, camera, name=name)
+            instrument = dbs.query_for_instrument(site, camera, name=name, db_address=db_address)
         if instrument is None:
             msg = 'Instrument is not in the database, Please add it before reducing this data.'
             tags = {'site': site, 'camera': camera, 'telescop': name}

--- a/banzai/main.py
+++ b/banzai/main.py
@@ -86,7 +86,6 @@ def parse_args(settings, extra_console_arguments=None, parser_description='Proce
                         help='Continue processing a file even if a master calibration does not exist?')
     parser.add_argument('--rlevel', dest='reduction_level', default=91, type=int, help='Reduction level')
     parser.add_argument('--db-address', dest='db_address',
-                        default='mysql://cmccully:password@localhost/test',
                         help='Database address: Should be in SQLAlchemy form')
     parser.add_argument('--elasticsearch-url', dest='elasticsearch_url',
                         default='http://elasticsearch.lco.gtn:9200')
@@ -154,7 +153,8 @@ def make_master_calibrations():
                                                    'Must be in the format "YYYY-MM-DDThh:mm:ss".'}}]
 
     runtime_context = parse_args(settings, extra_console_arguments=extra_console_arguments)
-    instrument = dbs.query_for_instrument(runtime_context.db_address, runtime_context.site, runtime_context.camera)
+    instrument = dbs.query_for_instrument(runtime_context.site, runtime_context.camera,
+                                          db_address=runtime_context.db_address)
     calibrations.make_master_calibrations(instrument,  runtime_context.frame_type.upper(),
                                           runtime_context.min_date, runtime_context.max_date, runtime_context)
 
@@ -211,7 +211,6 @@ def mark_frame(mark_as):
     parser.add_argument('--filename', dest='filename', required=True,
                         help='Name of calibration file to be marked')
     parser.add_argument('--db-address', dest='db_address',
-                        default='mysql://cmccully:password@localhost/test',
                         help='Database address: Should be in SQLAlchemy form')
     parser.add_argument("--log-level", default='debug', choices=['debug', 'info', 'warning',
                                                                  'critical', 'fatal', 'error'])
@@ -231,7 +230,7 @@ def add_instrument():
     parser.add_argument("--name", help='Instrument name (e.g kb05, nres03)', required=True)
     parser.add_argument("--instrument-type", dest='instrument_type',
                         help="Instrument type (e.g. 1m0-SciCam-Sinistro)", required=True)
-    parser.add_argument('--db-address', dest='db_address', default='sqlite:///test.db',
+    parser.add_argument('--db-address', dest='db_address',
                         help='Database address: Should be in SQLAlchemy format')
     args = parser.parse_args()
     instrument = {'site': args.site,
@@ -248,7 +247,7 @@ def add_site():
     parser.add_argument("--latitude", help='Latitude (deg)', required=True)
     parser.add_argument("--timezone", help="Time zone relative to UTC", required=True)
     parser.add_argument("--elevation", help="Elevation of site (m)", required=True)
-    parser.add_argument('--db-address', dest='db_address', default='sqlite:///test.db',
+    parser.add_argument('--db-address', dest='db_address',
                         help='Database address: Should be in SQLAlchemy format')
     args = parser.parse_args()
     site = {'code': args.site,
@@ -277,7 +276,6 @@ def update_db():
                         default='http://configdb.lco.gtn/sites/',
                         help='URL of the configdb with instrument information')
     parser.add_argument('--db-address', dest='db_address',
-                        default='mysql://cmccully:password@localhost/test',
                         help='Database address: Should be in SQLAlchemy form')
     args = parser.parse_args()
     logs.set_log_level(args.log_level)
@@ -294,7 +292,6 @@ def add_bpm():
     parser.add_argument("--log-level", default='debug', choices=['debug', 'info', 'warning',
                                                                  'critical', 'fatal', 'error'])
     parser.add_argument('--db-address', dest='db_address',
-                        default='mysql://cmccully:password@localhost/test',
                         help='Database address: Should be in SQLAlchemy form')
     args = parser.parse_args()
     add_settings_to_context(args, settings)
@@ -324,7 +321,6 @@ def add_bpm():
 def add_bpms_from_archive():
     parser = argparse.ArgumentParser(description="Add bad pixel mask from a given archive api")
     parser.add_argument('--db-address', dest='db_address',
-                        default='mysql://cmccully:password@localhost/test',
                         help='Database address: Should be in SQLAlchemy form')
     args = parser.parse_args()
     add_settings_to_context(args, settings)
@@ -362,7 +358,6 @@ def create_db():
     parser.add_argument("--log-level", default='debug', choices=['debug', 'info', 'warning',
                                                                  'critical', 'fatal', 'error'])
     parser.add_argument('--db-address', dest='db_address',
-                        default='sqlite3:///test.db',
                         help='Database address: Should be in SQLAlchemy form')
     args = parser.parse_args()
     logs.set_log_level(args.log_level)

--- a/banzai/mosaic.py
+++ b/banzai/mosaic.py
@@ -31,9 +31,9 @@ class MosaicCreator(Stage):
         mosaiced_data.meta['L1STATOV'] = '1' if any([data.meta.get('L1STATOV', '0') == '1' for data in image.ccd_hdus]) \
                                          else '0', 'Status flag for overscan correction'
 
+        kwd = 'OVERSCN' if len(image.ccd_hdus) < 10 else 'OVRSCN'
         for i, data in enumerate(image.ccd_hdus):
             mosaiced_data.copy_in(data)
-            kwd = 'OVERSCN' if len(image.ccd_hdus) < 10 else 'OVRSCN'
             mosaiced_data.meta[f'{kwd}{i + 1}'] = '{:0.2f}'.format(data.meta.get('OVERSCAN', 0.0)), \
                                                     'Overscan value that was subtracted'
             image.remove(data)

--- a/banzai/mosaic.py
+++ b/banzai/mosaic.py
@@ -33,7 +33,8 @@ class MosaicCreator(Stage):
 
         for i, data in enumerate(image.ccd_hdus):
             mosaiced_data.copy_in(data)
-            mosaiced_data.meta[f'OVERSCN{i + 1}'] = '{:0.2f}'.format(data.meta.get('OVERSCAN', 0.0)), \
+            kwd = 'OVERSCN' if len(image.ccd_hdus) < 10 else 'OVRSCN'
+            mosaiced_data.meta[f'{kwd}{i + 1}'] = '{:0.2f}'.format(data.meta.get('OVERSCAN', 0.0)), \
                                                     'Overscan value that was subtracted'
             image.remove(data)
 

--- a/banzai/photometry.py
+++ b/banzai/photometry.py
@@ -274,13 +274,13 @@ class SourceDetector(Stage):
 
 
 class PhotometricCalibrator(Stage):
-    color_to_fit = {'gp': 'g-r', 'rp': 'r-i', 'ip': 'r-i', 'zs': 'i-z'}
+    color_to_fit = {'g': 'g-r', 'r': 'r-i', 'i': 'r-i', 'z': 'i-z'}
 
     def __init__(self, runtime_context):
         super(PhotometricCalibrator, self).__init__(runtime_context)
 
     def do_stage(self, image):
-        if image.filter not in ['gp', 'rp', 'ip', 'zs']:
+        if image.filter[0] not in ['g', 'r', 'i', 'z']:
             logger.info("Not photometrically calibrating because of filter", image=image)
             return image
 
@@ -317,7 +317,7 @@ class PhotometricCalibrator(Stage):
         # Note the zero index here in the filter name is because we only store teh first letter of the filter name
         try:
             zeropoint, zeropoint_error, color_coefficient, color_coefficient_error = \
-                fit_photometry(matched_catalog, image.filter[0], self.color_to_fit[image.filter], image.exptime)
+                fit_photometry(matched_catalog, image.filter[0], self.color_to_fit[image.filter[0]], image.exptime)
         except:
             logger.error(f"Error fitting photometry: {logs.format_exception()}", image=image)
             return image
@@ -325,7 +325,7 @@ class PhotometricCalibrator(Stage):
         # Save the zeropoint, color coefficient and errors to header
         image.meta['L1ZP'] = zeropoint, "Instrumental zeropoint [mag]"
         image.meta['L1ZPERR'] = zeropoint_error, "Error on Instrumental zeropoint [mag]"
-        image.meta['L1COLORU'] = self.color_to_fit[image.filter], "Color used for calibration"
+        image.meta['L1COLORU'] = self.color_to_fit[image.filter[0]], "Color used for calibration"
         image.meta['L1COLOR'] = color_coefficient, "Color coefficient [mag]"
         image.meta['L1COLERR'] = color_coefficient_error, "Error on color coefficient [mag]"
         # Calculate the mag of each of the items in the catalog (without the color term) saving them

--- a/banzai/settings.py
+++ b/banzai/settings.py
@@ -9,6 +9,8 @@ settings.py: Settings script for banzai.
 import os
 import banzai
 
+DB_ADDRESS = os.getenv('DB_ADDRESS', 'sqlite:///banzai.db')
+
 FRAME_SELECTION_CRITERIA = [('type', 'not contains', 'FLOYDS'), ('type', 'not contains', 'NRES')]
 
 FRAME_FACTORY = 'banzai.steward.StewardFrameFactory'

--- a/banzai/settings.py
+++ b/banzai/settings.py
@@ -11,30 +11,31 @@ import banzai
 
 FRAME_SELECTION_CRITERIA = [('type', 'not contains', 'FLOYDS'), ('type', 'not contains', 'NRES')]
 
-FRAME_FACTORY = 'banzai.lco.LCOFrameFactory'
+FRAME_FACTORY = 'banzai.steward.StewardFrameFactory'
 
-CALIBRATION_FRAME_CLASS = 'banzai.lco.LCOCalibrationFrame'
+CALIBRATION_FRAME_CLASS = 'banzai.steward.StewardCalibrationFrame'
 
 ORDERED_STAGES = ['banzai.bpm.BadPixelMaskLoader',
                   'banzai.bpm.SaturatedPixelFlagger',
-                  'banzai.qc.header_checker.HeaderChecker',
-                  'banzai.qc.sinistro_1000s.ThousandsTest',
+                  # 'banzai.qc.header_checker.HeaderChecker',
+                  # 'banzai.qc.sinistro_1000s.ThousandsTest',
                   'banzai.qc.saturation.SaturationTest',
                   'banzai.bias.OverscanSubtractor',
-                  'banzai.crosstalk.CrosstalkCorrector',
+                  # 'banzai.crosstalk.CrosstalkCorrector',
                   'banzai.gain.GainNormalizer',
                   'banzai.mosaic.MosaicCreator',
-                  'banzai.trim.Trimmer',
+                  # 'banzai.trim.Trimmer',
                   'banzai.bias.BiasSubtractor',
                   'banzai.uncertainty.PoissonInitializer',
-                  'banzai.dark.DarkSubtractor',
+                  # 'banzai.dark.DarkSubtractor',
                   'banzai.flats.FlatDivider',
                   'banzai.qc.pattern_noise.PatternNoiseDetector',
                   'banzai.cosmic.CosmicRayDetector',
                   'banzai.photometry.SourceDetector',
-                  'banzai.astrometry.WCSSolver',
-                  'banzai.qc.pointing.PointingTest',
-                  'banzai.photometry.PhotometricCalibrator']
+                  # 'banzai.astrometry.WCSSolver',
+                  # 'banzai.qc.pointing.PointingTest',
+                  # 'banzai.photometry.PhotometricCalibrator',
+                  ]
 
 CALIBRATION_MIN_FRAMES = {'BIAS': 5,
                           'DARK': 5,
@@ -45,8 +46,8 @@ CALIBRATION_SET_CRITERIA = {'BIAS': ['configuration_mode', 'binning'],
                             'SKYFLAT': ['configuration_mode', 'binning', 'filter'],
                             'BPM': ['configuration_mode', 'binning']}
 
-LAST_STAGE = {'BIAS': 'banzai.trim.Trimmer',
-              'DARK': 'banzai.uncertainty.PoissonInitializer', 'SKYFLAT': 'banzai.dark.DarkSubtractor',
+LAST_STAGE = {'BIAS': 'banzai.mosaic.MosaicCreator',
+              'DARK': 'banzai.uncertainty.PoissonInitializer', 'SKYFLAT': 'banzai.uncertainty.PoissonInitializer',
               'SINISTRO': 'banzai.mosaic.MosaicCreator', 'STANDARD': None, 'EXPOSE': None, 'EXPERIMENTAL': None}
 
 EXTRA_STAGES = {'BIAS': ['banzai.bias.BiasMasterLevelSubtractor', 'banzai.bias.BiasComparer'],
@@ -69,8 +70,6 @@ CALIBRATION_STACK_DELAYS = {'BIAS': 300,
                             'DARK': 300,
                             'SKYFLAT': 300}
 
-SINISTRO_IMAGE_TYPES = ['BIAS', 'DARK', 'SKYFLAT', 'EXPOSE', 'STANDARD', 'TRAILED', 'EXPERIMENTAL']
-
 SCHEDULE_STACKING_CRON_ENTRIES = {'coj': {'minute': 30, 'hour': 6},
                                   'cpt': {'minute': 0, 'hour': 15},
                                   'tfn': {'minute': 30, 'hour': 17},
@@ -88,7 +87,7 @@ CALIBRATION_FILENAME_FUNCTIONS = {'BIAS': ('banzai.utils.file_utils.config_to_fi
                                               'banzai.utils.file_utils.ccdsum_to_filename',
                                               'banzai.utils.file_utils.filter_to_filename')}
 
-TELESCOPE_FILENAME_FUNCTION = 'banzai.utils.file_utils.telescope_to_filename'
+TELESCOPE_FILENAME_FUNCTION = 'steward.telescope_to_filename'
 
 OBSERVATION_PORTAL_URL = os.getenv('OBSERVATION_PORTAL_URL',
                                    'http://internal-observation-portal.lco.gtn/api/observations/')

--- a/banzai/settings.py
+++ b/banzai/settings.py
@@ -80,6 +80,9 @@ SCHEDULE_STACKING_CRON_ENTRIES = {'coj': {'minute': 30, 'hour': 6},
                                   'ogg': {'minute': 0, 'hour': 3}}
 
 ASTROMETRY_SERVICE_URL = os.getenv('ASTROMETRY_SERVICE_URL', 'http://localhost:5000/catalog/')
+WCS_SOURCE_LIMIT = 500  # use N brightest stars in image
+WCS_RADIUS = 2.  # degrees
+WCS_TOLERANCE = 0.01
 
 CALIBRATION_FILENAME_FUNCTIONS = {'BIAS': ('banzai.utils.file_utils.config_to_filename',
                                            'banzai.utils.file_utils.ccdsum_to_filename'),

--- a/banzai/settings.py
+++ b/banzai/settings.py
@@ -34,7 +34,7 @@ ORDERED_STAGES = ['banzai.bpm.BadPixelMaskLoader',
                   'banzai.qc.pattern_noise.PatternNoiseDetector',
                   'banzai.cosmic.CosmicRayDetector',
                   'banzai.photometry.SourceDetector',
-                  # 'banzai.astrometry.WCSSolver',
+                  'banzai.astrometry.WCSSolver',
                   # 'banzai.qc.pointing.PointingTest',
                   'banzai.photometry.PhotometricCalibrator',
                   ]

--- a/banzai/settings.py
+++ b/banzai/settings.py
@@ -89,7 +89,7 @@ CALIBRATION_FILENAME_FUNCTIONS = {'BIAS': ('banzai.utils.file_utils.config_to_fi
                                               'banzai.utils.file_utils.ccdsum_to_filename',
                                               'banzai.utils.file_utils.filter_to_filename')}
 
-TELESCOPE_FILENAME_FUNCTION = 'steward.telescope_to_filename'
+TELESCOPE_FILENAME_FUNCTION = 'banzai.steward.telescope_to_filename'
 
 OBSERVATION_PORTAL_URL = os.getenv('OBSERVATION_PORTAL_URL',
                                    'http://internal-observation-portal.lco.gtn/api/observations/')

--- a/banzai/split_chips.py
+++ b/banzai/split_chips.py
@@ -1,0 +1,37 @@
+from astropy.io import fits
+import string
+
+
+def split_chips(filename):
+    """
+    Splits a multiextension FITS file into separate files for each physical chip.
+
+    The number of amps per chip is determined using N-AMPS-X * N-AMPS-Y / N-DET-X / N-DET-Y from the header. The
+    original primary header is copied into each new file. A new keyword CHIP is added to the header, containing a
+    single letter a-z. This is also appended to the filename.
+
+    Parameters
+    ----------
+    filename : str
+        The filename or path to the original multiextension FITS file.
+
+    Returns
+    -------
+    image_paths : list
+        A list of dictionaries: [{'path': 'chipa.fits'}, {'path': 'chipb.fits'}, ...]
+    """
+    hdulist = fits.open(filename)
+    hdr = hdulist[0].header
+    namps_per_chip = hdr['N-AMPS-X'] * hdr['N-AMPS-Y'] // hdr['N-DET-X'] // hdr['N-DET-Y']
+    ext1 = 1
+    image_paths = []
+    while ext1 < len(hdulist):
+        primary_hdu = hdulist[0].copy()
+        chip_letter = string.ascii_lowercase[ext1 // namps_per_chip]
+        primary_hdu.header['CHIP'] = chip_letter
+        new_hdulist = fits.HDUList([primary_hdu, *hdulist[ext1:ext1+namps_per_chip]])
+        new_filename = filename.replace('.fits', f'{chip_letter}.fits')
+        new_hdulist.writeto(new_filename, overwrite=True)
+        ext1 += namps_per_chip
+        image_paths.append({'path': new_filename})
+    return image_paths

--- a/banzai/steward.py
+++ b/banzai/steward.py
@@ -340,14 +340,9 @@ class StewardFrameFactory(FrameFactory):
         site = 'kpno'
         camera = header.get('INSTRUME')
         instrument = dbs.query_for_instrument(db_address, site, camera)
-        name = camera
-        if instrument is None:
-            # if instrument is missing, assume it is an NRES frame and check for the instrument again.
-            name = header.get('TELESCOP')
-            instrument = dbs.query_for_instrument(db_address, site, camera, name=name)
         if instrument is None:
             msg = 'Instrument is not in the database, Please add it before reducing this data.'
-            tags = {'site': site, 'camera': camera, 'telescop': name}
+            tags = {'site': site, 'camera': camera}
             logger.debug(msg, extra_tags=tags)
         return instrument
 
@@ -382,5 +377,5 @@ class StewardFrameFactory(FrameFactory):
 def telescope_to_filename(image):
     telescope = image.meta.get('TELESCOP', '')
     if telescope == 'Steward 2.3 m (bok)':
-        telescope = 'Bok'
+        telescope = '2m3bok'
     return telescope

--- a/banzai/steward.py
+++ b/banzai/steward.py
@@ -1,0 +1,386 @@
+import datetime
+import os
+from fnmatch import fnmatch
+from typing import Optional
+from io import BytesIO
+
+import numpy as np
+from astropy.io import fits
+
+from astropy.time import Time
+from astropy.table import Table
+import hashlib
+
+from banzai import dbs
+from banzai.data import CCDData, HeaderOnly, DataTable, ArrayData, DataProduct
+from banzai.frames import ObservationFrame, CalibrationFrame, logger, FrameFactory
+from banzai.utils import date_utils, fits_utils, image_utils, file_utils
+from banzai.utils.image_utils import Section
+
+IMAGETYP_TO_OBSTYPE = {
+    'zero': 'BIAS',
+    'flat': 'SKYFLAT',
+    'object': 'EXPOSE',
+}
+
+
+class StewardObservationFrame(ObservationFrame):
+    def get_output_directory(self, runtime_context) -> str:
+        return os.path.join(runtime_context.processed_path, self.instrument.camera, self.epoch, 'processed')
+
+    @property
+    def obstype(self):
+        imagetyp = self.primary_hdu.meta.get('IMAGETYP')
+        return IMAGETYP_TO_OBSTYPE.get(imagetyp, imagetyp)
+
+    @property
+    def epoch(self):
+        return date_utils.epoch_date_to_string(self.primary_hdu.meta.get('DATE-OBS'))
+
+    @property
+    def request_number(self):
+        return
+
+    @property
+    def block_start(self):
+        return
+
+    @property
+    def site(self):
+        return 'kpno'
+
+    @property
+    def camera(self):
+        return self.primary_hdu.meta.get('INSTRUME')
+
+    @property
+    def filter(self):
+        return self.primary_hdu.meta.get('FILTER')
+
+    @property
+    def dateobs(self):
+        return Time(self.primary_hdu.meta.get('DATE-OBS'), scale='utc').datetime
+
+    @property
+    def datecreated(self):
+        return Time(self.primary_hdu.meta.get('DATE'), scale='utc').datetime
+
+    @property
+    def configuration_mode(self):
+        return 'default'
+
+    @property
+    def bias_level(self):
+        return self.primary_hdu.meta.get('BIASLVL')
+
+    @bias_level.setter
+    def bias_level(self, value):
+        self.primary_hdu.meta['BIASLVL'] = value
+
+    @property
+    def read_noise(self):
+        return self.primary_hdu.meta.get('RDNOISE')
+
+    @read_noise.setter
+    def read_noise(self, value):
+        self.primary_hdu.meta['RDNOISE'] = value
+
+    @property
+    def pixel_scale(self):
+        return float(self.primary_hdu.meta.get('PIXSCAL1'))
+
+    @property
+    def exptime(self):
+        return self.primary_hdu.meta.get('EXPTIME', 0.0)
+
+    @property
+    def ccd_temperature(self):
+        return int(self.primary_hdu.meta.get('CAMTEMP', 0.0))
+
+    @property
+    def requested_ccd_temperature(self):
+        return self.primary_hdu.meta.get('CAMTEMP', 0.0)
+
+    @property
+    def measured_ccd_temperature(self):
+        return self.primary_hdu.meta.get('CAMTEMP', 0.0)
+
+    def save_processing_metadata(self, context):
+        datecreated = datetime.datetime.utcnow()
+        self.meta['DATE'] = (date_utils.date_obs_to_string(datecreated), '[UTC] Date this FITS file was written')
+        self.meta['RLEVEL'] = (context.reduction_level, 'Reduction level')
+
+        self.meta['PIPEVER'] = (context.PIPELINE_VERSION, 'Pipeline version')
+
+    def get_output_filename(self, runtime_context):
+        output_filename = self.filename.replace('.fits', '.banzai.fits')
+        if runtime_context.fpack and not output_filename.endswith('.fz'):
+            output_filename += '.fz'
+        if not runtime_context.fpack and output_filename.endswith('.fz'):
+            output_filename = output_filename[:-3]
+        return output_filename
+
+    def get_output_data_products(self, runtime_context):
+        output_filename = self.get_output_filename(runtime_context)
+        output_fits = self.to_fits(runtime_context)
+        output_product = DataProduct.from_fits(output_fits, output_filename, self.get_output_directory(runtime_context))
+        return [output_product]
+
+    def write(self, runtime_context):
+        self.save_processing_metadata(runtime_context)
+        output_products = self.get_output_data_products(runtime_context)
+        for data_product in output_products:
+            if runtime_context.post_to_archive:
+                archived_image_info = file_utils.post_to_ingester(data_product.file_buffer, self,
+                                                                  data_product.filename, meta=data_product.meta)
+                self.frame_id = archived_image_info.get('frameid')
+
+            if not runtime_context.no_file_cache:
+                os.makedirs(self.get_output_directory(runtime_context), exist_ok=True)
+                data_product.file_buffer.seek(0)
+                with open(os.path.join(data_product.filepath, data_product.filename), 'wb') as f:
+                    f.write(data_product.file_buffer.read())
+                logger.info(f'Wrote processed image to {data_product.filename}')
+
+            data_product.file_buffer.seek(0)
+            md5 = hashlib.md5(data_product.file_buffer.read()).hexdigest()
+            dbs.save_processed_image(data_product.filename, md5, db_address=runtime_context.db_address)
+        return output_products
+
+
+class StewardCalibrationFrame(StewardObservationFrame, CalibrationFrame):
+    def __init__(self, hdu_list: list, file_path: str, frame_id: int = None, grouping_criteria: list = None,
+                 hdu_order: list = None):
+        CalibrationFrame.__init__(self, grouping_criteria=grouping_criteria)
+        StewardObservationFrame.__init__(self, hdu_list, file_path, frame_id=frame_id, hdu_order=hdu_order)
+
+    def to_db_record(self, output_product):
+        record_attributes = {'type': self.obstype.upper(),
+                             'filename': output_product.filename,
+                             'filepath': output_product.filepath,
+                             'dateobs': self.dateobs,
+                             'datecreated': self.datecreated,
+                             'instrument_id': self.instrument.id,
+                             'is_master': self.is_master,
+                             'is_bad': self.is_bad,
+                             'frameid': self.frame_id,
+                             'attributes': {}}
+        for attribute in self.grouping_criteria:
+            record_attributes['attributes'][attribute] = str(getattr(self, attribute))
+        return dbs.CalibrationImage(**record_attributes)
+
+    @property
+    def is_master(self):
+        return self.meta.get('ISMASTER', False)
+
+    @is_master.setter
+    def is_master(self, value):
+        self.meta['ISMASTER'] = value
+
+    def write(self, runtime_context):
+        output_products = StewardObservationFrame.write(self, runtime_context)
+        CalibrationFrame.write(self, output_products, runtime_context)
+
+    @classmethod
+    def init_master_frame(cls, images: list, file_path: str, frame_id: int = None,
+                          grouping_criteria: list = None, hdu_order: list = None):
+        data_class = type(images[0].primary_hdu)
+        hdu_list = [data_class(data=np.zeros(images[0].data.shape, dtype=images[0].data.dtype),
+                               meta=cls.init_master_header(images[0].meta, images))]
+        frame = cls(hdu_list=hdu_list, file_path=file_path, frame_id=frame_id,
+                    grouping_criteria=grouping_criteria, hdu_order=hdu_order)
+        frame.is_master = True
+        frame.instrument = images[0].instrument
+        return frame
+
+    @staticmethod
+    def init_master_header(old_header, images):
+        header = fits.Header()
+        for key in old_header.keys():
+            try:
+                # Dump empty header keywords and ignore old histories.
+                if len(key) > 0 and key != 'HISTORY':
+                    for i in range(old_header.count(key)):
+                        header[key] = (old_header[(key, i)], old_header.comments[(key, i)])
+            except ValueError as e:
+                logger.error('Could not add keyword {key}: {error}'.format(key=key, error=e))
+                continue
+        header = fits_utils.sanitize_header(header)
+        observation_dates = [image.dateobs for image in images]
+        mean_dateobs = date_utils.mean_date(observation_dates)
+
+        date_obs, time_obs = date_utils.date_obs_to_string(mean_dateobs).split('T')
+        header['DATE-OBS'] = (date_obs, '[UTC] Mean observation start time')
+        header['TIME-OBS'] = (time_obs, '[UTC] Mean observation start time')
+        header['DAY-OBS'] = (max(images, key=lambda x: datetime.datetime.strptime(x.epoch, '%Y%m%d')).epoch, '[UTC] Date at start of local observing night')
+        header['ISMASTER'] = (True, 'Is this a master calibration frame')
+
+        header.add_history("Images combined to create master calibration image:")
+        for i, image in enumerate(images):
+            header[f'IMCOM{i+1:03d}'] = (image.filename, 'Image combined to create master')
+        return header
+
+
+class StewardFrameFactory(FrameFactory):
+    @property
+    def observation_frame_class(self):
+        return StewardObservationFrame
+
+    @property
+    def calibration_frame_class(self):
+        return StewardCalibrationFrame
+
+    @property
+    def data_class(self):
+        return CCDData
+
+    @property
+    def primary_header_keys_to_propagate(self):
+        """
+        These are keys that may exist in the PrimaryHDU's header, but
+        do not exist in the ImageHDUs.
+        """
+        return [('RDNOISE', 'RDNOIS{:d}'), ('GAIN', 'GAIN{:d}')]
+
+    @property
+    def associated_extensions(self):
+        return [{'FITS_NAME': 'BPM', 'NAME': 'mask'}, {'FITS_NAME': 'ERR', 'NAME': 'uncertainty'}]
+
+    def open(self, file_info, runtime_context) -> Optional[ObservationFrame]:
+        if file_info.get('RLEVEL') is not None:
+            is_raw = file_info.get('RLEVEL', 0) == 0
+        else:
+            is_raw = False
+        fits_hdu_list, filename, frame_id = fits_utils.open_fits_file(file_info, runtime_context, is_raw_frame=is_raw)
+        hdu_list = []
+        associated_fits_extensions = [associated_extension['FITS_NAME']
+                                      for associated_extension in self.associated_extensions]
+        # If all of the extensions are arrays we would normally associate with a CCDData object (e.g. BPMs)
+        # treat the extensions as normal data
+        imagetyp = fits_hdu_list[0].header['IMAGETYP']
+        obstype = IMAGETYP_TO_OBSTYPE.get(imagetyp, imagetyp)
+        if obstype in associated_fits_extensions or \
+                all(hdu.header.get('EXTNAME', '') in associated_fits_extensions
+                    for hdu in fits_hdu_list if hdu.data is not None):
+            for hdu in fits_hdu_list:
+                if hdu.data is None or hdu.data.size == 0:
+                    hdu_list.append(HeaderOnly(meta=hdu.header))
+                else:
+                    hdu_list.append(self.data_class(data=hdu.data, meta=hdu.header, name=hdu.header.get('EXTNAME')))
+        else:
+            primary_hdu = None
+            for i, hdu in enumerate(fits_hdu_list):
+                # Move on from any associated arrays like BPM or ERR
+                if any(associated_extension['FITS_NAME'] in hdu.header.get('EXTNAME', '')
+                       for associated_extension in self.associated_extensions):
+                    continue
+                # Otherwise parse the fits file into a frame object and the corresponding data objects
+                if hdu.data is None or hdu.data.size == 0:
+                    hdu_list.append(HeaderOnly(meta=hdu.header))
+                    primary_hdu = hdu
+                elif isinstance(hdu, fits.BinTableHDU):
+                    hdu_list.append(DataTable(data=Table(hdu.data), meta=hdu.header, name=hdu.header.get('EXTNAME')))
+                # Assume we are looking at a CCD extension
+                else:
+                    associated_data = {}
+                    condensed_name = hdu.header.get('EXTNAME', '')
+                    for extension_name_to_condense in runtime_context.EXTENSION_NAMES_TO_CONDENSE:
+                        condensed_name = condensed_name.replace(extension_name_to_condense, '')
+                    for associated_extension in self.associated_extensions:
+                        associated_fits_extension_name = condensed_name + associated_extension['FITS_NAME']
+                        if associated_fits_extension_name in fits_hdu_list:
+                            if hdu.header.get('EXTVER') == 0:
+                                extension_version = None
+                            else:
+                                extension_version = hdu.header.get('EXTVER')
+                            associated_data[associated_extension['NAME']] = fits_hdu_list[associated_fits_extension_name,
+                                                                                          extension_version].data
+                        else:
+                            associated_data[associated_extension['NAME']] = None
+
+                    if hdu.data.dtype == np.uint16:
+                        hdu.data = hdu.data.astype(np.float64)
+                    # check if we need to propagate any header keywords from the primary header
+                    if primary_hdu is not None:
+                        for keyword, primary_keyword in self.primary_header_keys_to_propagate:
+                            primary_keyword = primary_keyword.format(i)
+                            if primary_keyword in primary_hdu.header and keyword not in hdu.header:
+                                hdu.header[keyword] = float(primary_hdu.header[primary_keyword])
+                    # For master frames without uncertainties, set to all zeros
+                    if hdu.header.get('ISMASTER', False) and associated_data['uncertainty'] is None:
+                        associated_data['uncertainty'] = np.zeros(hdu.data.shape, dtype=hdu.data.dtype)
+                    hdu_list.append(self.data_class(data=hdu.data, meta=hdu.header, name=hdu.header.get('EXTNAME'),
+                                                    **associated_data))
+
+        # Either use the calibration frame type or normal frame type depending on the IMAGETYP keyword
+        imagetyp = hdu_list[0].meta.get('IMAGETYP')
+        obstype = IMAGETYP_TO_OBSTYPE.get(imagetyp, imagetyp)
+        hdu_order = runtime_context.REDUCED_DATA_EXTENSION_ORDERING.get(obstype)
+
+        if obstype in runtime_context.CALIBRATION_IMAGE_TYPES:
+            grouping = runtime_context.CALIBRATION_SET_CRITERIA.get(obstype, [])
+            image = self.calibration_frame_class(hdu_list, filename, frame_id=frame_id, grouping_criteria=grouping,
+                                                 hdu_order=hdu_order)
+        else:
+            image = self.observation_frame_class(hdu_list, filename, frame_id=frame_id, hdu_order=hdu_order)
+        image.instrument = self.get_instrument_from_header(image.primary_hdu.meta, runtime_context.db_address)
+        if image.instrument is None:
+            return None
+
+        self._init_saturate(image)
+
+        # If the frame cannot be processed for some reason return None instead of the new image object
+        if image_utils.image_can_be_processed(image, runtime_context):
+            return image
+        else:
+            return None
+
+    @staticmethod
+    def get_instrument_from_header(header, db_address):
+        site = 'kpno'
+        camera = header.get('INSTRUME')
+        instrument = dbs.query_for_instrument(db_address, site, camera)
+        name = camera
+        if instrument is None:
+            # if instrument is missing, assume it is an NRES frame and check for the instrument again.
+            name = header.get('TELESCOP')
+            instrument = dbs.query_for_instrument(db_address, site, camera, name=name)
+        if instrument is None:
+            msg = 'Instrument is not in the database, Please add it before reducing this data.'
+            tags = {'site': site, 'camera': camera, 'telescop': name}
+            logger.debug(msg, extra_tags=tags)
+        return instrument
+
+    @staticmethod
+    def _init_saturate(image):
+        defaults = {'90prime': 65565.}
+
+        default_unbinned_saturation = None
+        for instrument_type in defaults:
+            if instrument_type in image.instrument.type.lower():
+                default_unbinned_saturation = defaults[instrument_type]
+                break
+
+        for hdu in image.ccd_hdus:
+            # Pull from the primary extension by default
+            if hdu.meta.get('SATURATE', 0.0) == 0.0:
+                hdu.meta['SATURATE'] = image.meta.get('SATURATE', 0.0)
+                hdu.meta['MAXLIN'] = image.meta.get('MAXLIN', 0.0)
+            # If still nothing, use hard coded defaults
+            if hdu.meta.get('SATURATE', 0.0) == 0.0 and default_unbinned_saturation is not None:
+                n_binned_pixels = hdu.binning[0] * hdu.binning[1]
+                default = default_unbinned_saturation * n_binned_pixels / hdu.gain
+                image.meta['SATURATE'] = (default, '[ADU] Saturation level used')
+                hdu.meta['SATURATE'] = (default, '[ADU] Saturation level used')
+                hdu.meta['MAXLIN'] = (default, '[ADU] Non-linearity level')
+
+        if 0.0 in [hdu.meta.get('SATURATE', 0.0) for hdu in image.ccd_hdus]:
+            logger.error('The SATURATE keyword was not valid and there are no defaults in banzai for this camera.',
+                         image=image)
+
+
+def telescope_to_filename(image):
+    telescope = image.meta.get('TELESCOP', '')
+    if telescope == 'Steward 2.3 m (bok)':
+        telescope = 'Bok'
+    return telescope

--- a/banzai/steward.py
+++ b/banzai/steward.py
@@ -336,10 +336,10 @@ class StewardFrameFactory(FrameFactory):
             return None
 
     @staticmethod
-    def get_instrument_from_header(header, db_address):
+    def get_instrument_from_header(header, db_address=None):
         site = 'kpno'
         camera = header.get('INSTRUME')
-        instrument = dbs.query_for_instrument(db_address, site, camera)
+        instrument = dbs.query_for_instrument(site, camera, db_address=db_address)
         if instrument is None:
             msg = 'Instrument is not in the database, Please add it before reducing this data.'
             tags = {'site': site, 'camera': camera}

--- a/banzai/steward.py
+++ b/banzai/steward.py
@@ -51,7 +51,7 @@ class StewardObservationFrame(ObservationFrame):
 
     @property
     def camera(self):
-        return self.primary_hdu.meta.get('INSTRUME')
+        return self.primary_hdu.meta.get('INSTRUME')[:3] + self.primary_hdu.meta.get('CHIP')
 
     @property
     def filter(self):
@@ -338,7 +338,7 @@ class StewardFrameFactory(FrameFactory):
     @staticmethod
     def get_instrument_from_header(header, db_address=None):
         site = 'kpno'
-        camera = header.get('INSTRUME')
+        camera = header.get('INSTRUME')[:3] + header.get('CHIP')
         instrument = dbs.query_for_instrument(site, camera, db_address=db_address)
         if instrument is None:
             msg = 'Instrument is not in the database, Please add it before reducing this data.'

--- a/banzai/steward.py
+++ b/banzai/steward.py
@@ -348,7 +348,7 @@ class StewardFrameFactory(FrameFactory):
 
     @staticmethod
     def _init_saturate(image):
-        defaults = {'90prime': 65565.}
+        defaults = {'90prime': 65535.}  # ADU (before gain)
 
         default_unbinned_saturation = None
         for instrument_type in defaults:
@@ -364,7 +364,7 @@ class StewardFrameFactory(FrameFactory):
             # If still nothing, use hard coded defaults
             if hdu.meta.get('SATURATE', 0.0) == 0.0 and default_unbinned_saturation is not None:
                 n_binned_pixels = hdu.binning[0] * hdu.binning[1]
-                default = default_unbinned_saturation * n_binned_pixels / hdu.gain
+                default = default_unbinned_saturation * n_binned_pixels
                 image.meta['SATURATE'] = (default, '[ADU] Saturation level used')
                 hdu.meta['SATURATE'] = (default, '[ADU] Saturation level used')
                 hdu.meta['MAXLIN'] = (default, '[ADU] Non-linearity level')

--- a/banzai/steward.py
+++ b/banzai/steward.py
@@ -376,6 +376,6 @@ class StewardFrameFactory(FrameFactory):
 
 def telescope_to_filename(image):
     telescope = image.meta.get('TELESCOP', '')
-    if telescope == 'Steward 2.3 m (bok)':
+    if 'bok' in telescope.lower():
         telescope = '2m3bok'
     return telescope

--- a/banzai/utils/db_migration.py
+++ b/banzai/utils/db_migration.py
@@ -59,7 +59,7 @@ class PreviewImage(Base):
     tries = Column(Integer, default=0)
 
 
-def create_new_db(db_address):
+def create_new_db(db_address=None):
     engine = create_engine(db_address)
     dbs.Base.metadata.create_all(engine)
 

--- a/banzai/utils/realtime_utils.py
+++ b/banzai/utils/realtime_utils.py
@@ -8,14 +8,14 @@ from banzai import logs
 logger = logging.getLogger('banzai')
 
 
-def set_file_as_processed(path, db_address):
+def set_file_as_processed(path, db_address=None):
     image = dbs.get_processed_image(path, db_address=db_address)
     if image is not None:
         image.success = True
         dbs.commit_processed_image(image, db_address=db_address)
 
 
-def increment_try_number(path, db_address):
+def increment_try_number(path, db_address=None):
     image = dbs.get_processed_image(path, db_address=db_address)
     # Otherwise increment the number of tries
     image.tries += 1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,97 +1,36 @@
-version: '2'
+version: '0'
 services:
-  banzai-e2e:
-    image: docker.lco.global/banzai-e2e-data:1.3.0
-    container_name: banzai-e2e
-    network_mode: "bridge"
-    entrypoint:
-    - /bin/true
-    labels:
-      io.rancher.container.pull_image: always
-      io.rancher.container.start_once: 'true'
+  database:
+    image: postgis/postgis
+    container_name: banzai_database
+    ports:
+      - ${PGPORT}:5432
+    user: 1024:100
     volumes:
-    - banzaie2e:/archive
-    logging:
-      options:
-        max-size: '100m'
-        max-file: '3'
-  banzai-fits-exchange:
-    image: rabbitmq:3.7.9
-    network_mode: "bridge"
-    container_name: banzai-fits-exchange
-    mem_limit: '1g'
-    logging:
-      options:
-        max-size: '100m'
-        max-file: '3'
-  banzai-redis:
-    image: redis:5.0.3
-    network_mode: "bridge"
-    container_name: banzai-redis
-    labels:
-      io.rancher.container.pull_image: always
-    mem_limit: '1g'
-  banzai-celery-workers:
-    image: ${DOCKER_IMG}
-    network_mode: "bridge"
-    container_name: banzai-celery-workers
-    entrypoint: ["celery", "-A", "banzai", "worker",
-                 "--hostname", "banzai-celery-worker",
-                 "-l", "debug", "-c", "4"]
-    mem_limit: '8g'
-    depends_on:
-      - banzai-redis
-      - banzai-fits-exchange
-      - banzai-e2e
-    links:
-      - banzai-redis:redis
-    volumes_from:
-      - banzai-e2e
+      - /nfs/data/primefocus/pgdata:/var/lib/postgresql/data
     environment:
-      RETRY_DELAY: "0"
-      TASK_HOST: "redis://redis:6379/0"
-      OBSERVATION_PORTAL_URL: "http://internal-observation-portal.lco.gtn/api/observations/"
-      OMP_NUM_THREADS: "2"
-      OPENTSDB_PYTHON_METRICS_TEST_MODE: "1"
-    labels:
-      io.rancher.container.pull_image: always
-      io.rancher.sidekicks: banzai-e2e
-    logging:
-      options:
-        max-size: '100m'
-        max-file: '3'
-  banzai-listener:
-    image: ${DOCKER_IMG}
-    network_mode: "bridge"
-    container_name: banzai-listener
-    mem_limit: '1g'
-    depends_on:
-      - banzai-redis
-      - banzai-fits-exchange
-      - banzai-e2e
-    links:
-      - banzai-fits-exchange:broker
-      - banzai-redis:redis
-    entrypoint: ["banzai_run_realtime_pipeline", "--fpack",
-                 "--db-address=sqlite:////archive/engineering/test.db",
-                 "--broker-url=broker"]
+      POSTGRES_DB: ${PGNAME}
+      POSTGRES_USER: ${PGUSER}
+      POSTGRES_PASSWORD: ${PGPASSWORD}
+  astrometry:
+    build: /home/primefocus/gaia-astrometry.net-service
+    container_name: banzai_astrometry
+    ports:
+      - 5000:80
+    volumes:
+      - /nfs/data/primefocus/gaia-astrometry.net-indices:/index
     environment:
-      DB_ADDRESS: sqlite:////archive/engineering/test.db
-      TASK_HOST: "redis://redis:6379/0"
-      FITS_BROKER_URL: "broker"
-      OBSERVATION_PORTAL_URL:  "http://internal-observation-portal.lco.gtn/api/observations/"
-      FITS_EXCHANGE: fits_files
-      FITS_BROKER: broker
-      OPENTSDB_PYTHON_METRICS_TEST_MODE: "1"
-    volumes_from:
-    - banzai-e2e
-    labels:
-      io.rancher.container.pull_image: always
-      io.rancher.sidekicks: banzai-e2e
-    logging:
-      options:
-        max-size: '100m'
-        max-file: '3'
-volumes:
-  banzaie2e:
-    driver: local
+      MAX_REQUESTS: 5
+      INDEX_FILE_PATH: /index
+      GUNICORN_WORKERS: 3
+      WORKER_TIMEOUT_SECONDS: 120
+      GRACEFUL_TIMEOUT: 120
+  photometry:
+    build: /home/primefocus/photometric-catalog-service
+    container_name: banzai_photometry
+    ports:
+      - 5005:80
+    extra_hosts:
+      - host.docker.internal:host-gateway
+    environment:
+      CATALOG_DB_URL: postgresql://${PGUSER}:${PGPASSWORD}@host.docker.internal:${PGPORT}/${PGNAME}

--- a/setup.cfg
+++ b/setup.cfg
@@ -144,6 +144,7 @@ banzai.tests = data/*
 [options.entry_points]
 console_scripts =
     banzai_reduce_individual_frame = banzai.main:reduce_single_frame
+    banzai_reduce_multichip_frame = banzai.main:reduce_multichip_frame
     banzai_reduce_directory = banzai.main:reduce_directory
     banzai_make_master_calibrations = banzai.main:make_master_calibrations
     banzai_automate_stack_calibrations = banzai.main:start_stacking_scheduler


### PR DESCRIPTION
This removes the directory structure for saving Steward images, so that the four 90prime chips are not stored separately. Now the data goes directly to `processed_path/dayobs/` directories.

To do this, I had to define `dayobs` for Steward images. I adopted a convention of using the previous local date if images are taken before local noon