### PR TITLE
allow multiplying images where GAIN etc is not set

### DIFF
--- a/banzai/data.py
+++ b/banzai/data.py
@@ -150,9 +150,9 @@ class CCDData(Data):
         # TODO: Handle the case where this is an array. Add SATURATE and GAIN handling when array.
         self.data *= value
         self.uncertainty *= value
-        self.meta['SATURATE'] *= value
-        self.meta['GAIN'] /= value
-        self.meta['MAXLIN'] *= value
+        self.saturate *= value
+        self.gain /= value
+        self.max_linearity *= value
         return self
 
     def __itruediv__(self, value):


### PR DESCRIPTION
Multiplying an image by a constant crashes with a KeyError if GAIN, SATURATE, or MAXLIN are not set in the headers. This switches the multiplication method to using the gain, saturate, and max_linearity properties, which have an appropriate default set.