### PR TITLE
Fix/celery acks late

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+1.11.1 (2023-08-23)
+-------------------
+- Ack tasks late so that they may be re-queued in the event of a worker shutdown a la kubernetes
+
 1.11.0 (2023-08-10)
 -------------------
 - Added the process_by_group keyword to stages to fix a bug that wouldn't allow grouping only by instrument

--- a/banzai/celeryconfig.py
+++ b/banzai/celeryconfig.py
@@ -2,3 +2,4 @@ broker_url = 'redis://localhost:6379/0'
 imports = ('banzai.main', 'banzai.celery',)
 worker_prefetch_multiplier = 1
 worker_max_tasks_per_child = 100
+task_acks_late = True

--- a/helm-chart/banzai/values-prod.yaml
+++ b/helm-chart/banzai/values-prod.yaml
@@ -12,7 +12,7 @@ horizontalPodAutoscaler:
 
 image:
   repository: docker.lco.global/banzai
-  tag: "1.10.0"
+  tag: "1.11.0"
   pullPolicy: IfNotPresent
 
 # Values for the OCS Ingester library, used by BANZAI.
@@ -35,7 +35,7 @@ banzai:
   calibrateProposalId: calibrate
   banzaiWorkerLogLevel: info
   rawDataApiRoot: http://archiveapi-internal.prod/
-  fitsBroker: rabbitmq.lco.gtn
+  fitsBroker: rabbitmq-ha.prod.svc.cluster.local.
   fitsExchange: archived_fits
   queueName: banzai_pipeline
   celeryTaskQueueName: banzai_imaging


### PR DESCRIPTION
Ack tasks late so that they may be re-queued in the event of a worker shutdown a la kubernetes

I've actually been running this for quite some time and we're missing a lot fewer frames. We should probably do this for all BANZAI deployments.