### PR TITLE
Add semver pattern back in for tagged releases

### DIFF
--- a/.github/workflows/docker_image.yml
+++ b/.github/workflows/docker_image.yml
@@ -47,6 +47,7 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
             type=sha,event=pr
+            type=semver,pattern={{version}}
 
       - name: Build and also push Dockerimage
         id: build-and-push


### PR DESCRIPTION
In updating the PR behavior for docker builds, I neglected to also specify that we should build images tagged with their version when we create a new tag, so make sure we do that.