### PR TITLE
Track calibration frames by output product instead of input frames

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+1.16.0 (2023-04-18)
+-------------------
+- Calibration frames are now associated with output data products rather than frames
+  so that we have more than one calibration data product produced per frame.
+
 1.15.2 (2023-04-12)
 -------------------
 - Fix to fpacking data when the image data array is None

--- a/banzai/lco.py
+++ b/banzai/lco.py
@@ -141,7 +141,7 @@ class LCOObservationFrame(ObservationFrame):
             if runtime_context.post_to_archive:
                 archived_image_info = file_utils.post_to_ingester(data_product.file_buffer, self,
                                                                   data_product.filename, meta=data_product.meta)
-                self.frame_id = archived_image_info.get('frameid')
+                data_product.frame_id = archived_image_info.get('frameid')
 
             if not runtime_context.no_file_cache:
                 os.makedirs(self.get_output_directory(runtime_context), exist_ok=True)
@@ -170,7 +170,7 @@ class LCOCalibrationFrame(LCOObservationFrame, CalibrationFrame):
                              'instrument_id': self.instrument.id,
                              'is_master': self.is_master,
                              'is_bad': self.is_bad,
-                             'frameid': self.frame_id,
+                             'frameid': output_product.frame_id,
                              'attributes': {}}
         for attribute in self.grouping_criteria:
             record_attributes['attributes'][attribute] = str(getattr(self, attribute))

--- a/banzai/tests/test_frames.py
+++ b/banzai/tests/test_frames.py
@@ -63,9 +63,8 @@ def test_frame_to_db_record():
                                   'CONFMODE': 'full_frame'}, name='SCI')]
     test_frame = LCOCalibrationFrame(hdu_list=hdu_list, file_path='/foo/bar')
     test_frame.is_bad = False
-    test_frame.frame_id = 1234
     test_frame.instrument = MagicMock(id=7)
-    mock_data_product = MagicMock(filename='test.fits.fz', filepath='/path/to/test/test.fits.fz')
+    mock_data_product = MagicMock(filename='test.fits.fz', filepath='/path/to/test/test.fits.fz', frame_id=1234)
     db_record = test_frame.to_db_record(mock_data_product)
 
     assert type(db_record) == CalibrationImage


### PR DESCRIPTION
This branch fixes an issue associating frame ids in the database when more than one output product is created. This is specifically important for floyds which produces 1d and 2d standards. Previously we implicitly stored the frame id in the calimages table in the database of whatever product was produced last. This was an issue with floyds because that product was not the one we wanted to use in later processing.