### PR TITLE
Fix/celery beat

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+1.18.2 (2024-08-28)
+-------------------
+- Fix call to start celery beat for celery 5
+
 1.18.1 (2024-08-28)
 -------------------
 - Update celery config to turn off gossip and mingle as workers were missing lots of heartbeats and were throwing errors. See https://www.cloudamqp.com/docs/celery.html#commandline-arguments for details

--- a/banzai/main.py
+++ b/banzai/main.py
@@ -174,10 +174,8 @@ def start_stacking_scheduler():
                               schedule_calibration_stacking.s(site=site, runtime_context=vars(runtime_context)),
                               queue=runtime_context.CELERY_TASK_QUEUE_NAME)
 
-    beat = celery.bin.beat.beat(app=app)
+    app.Beat(schedule='/tmp/celerybeat-schedule', pidfile='/tmp/celerybeat.pid', working_directory='/tmp').run()
     logger.info('Starting celery beat')
-    beat.run(schedule='/tmp/celerybeat-schedule', pidfile='/tmp/celerybeat.pid', working_directory='/tmp')
-
 
 def run_realtime_pipeline():
     extra_console_arguments = [{'args': ['--n-processes'],

--- a/setup.cfg
+++ b/setup.cfg
@@ -61,7 +61,7 @@ install_requires =
     pytest>=4.0
     pyyaml
     psycopg2-binary
-    celery[redis]>5
+    celery[redis]>5,<6
     apscheduler
     python-dateutil
     ocs_ingester>=3.0.4,<4.0.0


### PR DESCRIPTION
The docs are here https://docs.celeryq.dev/en/stable/reference/celery.apps.beat.html

This was breaking in production as we were using an outdated call to the celery beat binary. Help from this stack overflow comment: https://stackoverflow.com/a/65213590