### PR TITLE
Added delay to trigger after block end and to prefer public/same block/same proposal calibrations.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+1.20.0 (2024-12-11)
+-------------------
+- Added functionality to delay processing until after the end of the observing block
+- Added the ability to only use public calibrations
+- Added the ability to prefer calibrations taken within the same block or with the same proposal
+
 1.19.1 (2024-11-05)
 -------------------
 - Added extra logging and try excepts to catch frames that bypass silently

--- a/banzai/calibrations.py
+++ b/banzai/calibrations.py
@@ -137,9 +137,14 @@ class CalibrationUser(Stage):
         pass
 
     def get_calibration_file_info(self, image):
-        return dbs.get_master_cal(image, self.calibration_type, self.master_selection_criteria,
-                                  use_only_older_calibrations=self.runtime_context.use_only_older_calibrations,
-                                  db_address=self.runtime_context.db_address)
+        return dbs.cal_record_to_file_info(
+            dbs.get_master_cal_record(image, self.calibration_type, self.master_selection_criteria,
+                                      self.runtime_context.db_address, 
+                                      use_only_older_calibrations=self.runtime_context.use_only_older_calibrations,
+                                      prefer_same_block=self.runtime_context.same_block_cals,
+                                      prefer_same_proposal=self.runtime_context.prefer_same_proposal,
+                                      check_public=self.runtime_context.check_public_cals)
+        )
 
 
 class CalibrationComparer(CalibrationUser):

--- a/banzai/dbs.py
+++ b/banzai/dbs.py
@@ -10,9 +10,8 @@ October 2015
 import os.path
 import datetime
 from dateutil.parser import parse
-import numpy as np
 import requests
-from sqlalchemy import create_engine, pool, type_coerce, cast
+from sqlalchemy import create_engine, pool, type_coerce, cast, func
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy import Column, Integer, String, DateTime, ForeignKey, Boolean, CHAR, JSON, UniqueConstraint, Float
 from sqlalchemy.ext.declarative import declarative_base
@@ -74,6 +73,9 @@ class CalibrationImage(Base):
     good_until = Column(DateTime, default=datetime.datetime(3000, 1, 1))
     good_after = Column(DateTime, default=datetime.datetime(1000, 1, 1))
     attributes = Column(JSON)
+    blockid = Column(Integer, nullable=True)
+    proposal = Column(String(50), nullable=True)
+    public_date = Column(DateTime, nullable=True)
 
 
 class Instrument(Base):
@@ -336,7 +338,8 @@ def cal_record_to_file_info(record):
 
 
 def get_master_cal_record(image, calibration_type, master_selection_criteria, db_address,
-                          use_only_older_calibrations=False):
+                          use_only_older_calibrations=False, prefer_same_block=False, check_public=False,
+                          prefer_same_proposal=False):
     calibration_criteria = CalibrationImage.type == calibration_type.upper()
     calibration_criteria &= CalibrationImage.instrument_id == image.instrument.id
     calibration_criteria &= CalibrationImage.is_master.is_(True)
@@ -356,24 +359,22 @@ def get_master_cal_record(image, calibration_type, master_selection_criteria, db
     calibration_criteria &= CalibrationImage.good_after <= image.dateobs
     calibration_criteria &= CalibrationImage.good_until >= image.dateobs
 
+    calibration_image = None
     with get_session(db_address=db_address) as db_session:
-        calibration_images = db_session.query(CalibrationImage).filter(calibration_criteria).all()
-
-    # Exit if no calibration file found
-    if len(calibration_images) == 0:
-        return None
-
-    # Find the closest date
-    date_deltas = np.abs(np.array([i.dateobs - image.dateobs for i in calibration_images]))
-    closest_calibration_image = calibration_images[np.argmin(date_deltas)]
-
-    return closest_calibration_image
-
-
-def get_master_cal(image, calibration_type, master_selection_criteria, db_address,
-                   use_only_older_calibrations=False):
-    return cal_record_to_file_info(get_master_cal_record(image, calibration_type, master_selection_criteria, db_address,
-                                                         use_only_older_calibrations=use_only_older_calibrations))
+        if prefer_same_block:
+            block_criteria = CalibrationImage.blockid == image.blockid
+            image_filter = db_session.query(CalibrationImage).filter(calibration_criteria & block_criteria)
+            calibration_image = image_filter.order_by(func.abs(CalibrationImage.dateobs - image.dateobs)).first()
+        if calibration_image is None and prefer_same_proposal:
+            proposal_criteria = CalibrationImage.proposal == image.proposal
+            image_filter = db_session.query(CalibrationImage).filter(calibration_criteria & proposal_criteria)
+            calibration_image = image_filter.order_by(func.abs(CalibrationImage.dateobs - image.dateobs)).first()
+        if check_public:
+            calibration_criteria &= CalibrationImage.public_date <= datetime.datetime.utcnow()
+        if calibration_image is None:
+            image_filter = db_session.query(CalibrationImage).filter(calibration_criteria)
+            calibration_image = image_filter.order_by(func.abs(CalibrationImage.dateobs - image.dateobs)).first()
+    return calibration_image
 
 
 def get_individual_cal_records(instrument, calibration_type, min_date: str, max_date: str, db_address: str,

--- a/banzai/frames.py
+++ b/banzai/frames.py
@@ -166,6 +166,31 @@ class ObservationFrame(metaclass=abc.ABCMeta):
         pass
 
     @property
+    @abc.abstractmethod
+    def block_end_date(self):
+        pass
+
+    @property
+    @abc.abstractmethod
+    def proposal(self):
+        pass
+
+    @property
+    @abc.abstractmethod
+    def blockid(self):
+        pass
+
+    @property
+    @abc.abstractmethod
+    def public_date(self):
+        pass
+
+    @public_date.setter
+    @abc.abstractmethod
+    def public_date(self, value):
+        pass
+
+    @property
     def data_type(self):
         # Convert bytes to bits
         size = 8 * min([hdu.data.itemsize for hdu in self.ccd_hdus])

--- a/banzai/main.py
+++ b/banzai/main.py
@@ -118,6 +118,14 @@ def parse_args(settings, extra_console_arguments=None, parser_description='Proce
                         help='Maximum number of times to try to process a frame')
     parser.add_argument('--broker-url', dest='broker_url',
                         help='URL for the FITS broker service.')
+    parser.add_argument('--delay-to-block-end', dest='delay_to_block_end', default=False, action='store_true',
+                        help='Delay real-time processing until after the block has ended')
+    parser.add_argument('--same-block-cals', dest='same_block_cals', default=False, action='store_true',
+                        help='Prefer calibrations taken in the same block')
+    parser.add_argument('--check-public-cals', dest='check_public_cals', default=False, action='store_true',
+                        help='Check to see if calibration frames are public before using them?')
+    parser.add_argument('--prefer-same-proposal', dest='prefer_same_proposal', default=False, action='store_true',
+                        help='Prefer calibrations taken with the same proposal')
 
     if extra_console_arguments is None:
         extra_console_arguments = []

--- a/banzai/settings.py
+++ b/banzai/settings.py
@@ -90,6 +90,8 @@ CALIBRATION_FILENAME_FUNCTIONS = {'BIAS': ('banzai.utils.file_utils.config_to_fi
                                               'banzai.utils.file_utils.ccdsum_to_filename',
                                               'banzai.utils.file_utils.filter_to_filename')}
 
+OBSTYPES_TO_DELAY = []
+
 TELESCOPE_FILENAME_FUNCTION = 'banzai.utils.file_utils.telescope_to_filename'
 
 OBSERVATION_PORTAL_URL = os.getenv('OBSERVATION_PORTAL_URL',

--- a/banzai/tests/test_frames.py
+++ b/banzai/tests/test_frames.py
@@ -384,7 +384,7 @@ def test_data_to_detector_section_full():
 
 def test_propid_public():
     proposal_ids = ['standard', 'Photometric standards', 'NRES standards', 'FLOYDS standards']
-    date_obs = '2021-09-01T00:00:00'
+    date_obs = '2021-09-01T00:00:00.000009'
     test_data = [CCDData(np.zeros((1024, 1024)), meta={'PROPID': propid,
                                                        'DATE-OBS': date_obs}) for propid in proposal_ids]
 


### PR DESCRIPTION
This PR adds functionality to choose which calibration frames are chosen and when data is processed. This is mostly for BANZAI-FLOYDS. I don't expect BANZAI imaging to use this functionality. 

### - Delaying processing until after the block is complete.
I added functionality that would delay processing until after the block is done observing. This helps for FLOYDS when you want to use an arc and flat taken along with the current data without waiting for the full end of the night.
This is implemented by adding retry logic into the realtime utils, need_to_be_processed. In the case that the block end date is later than now, we use a celery task retry with a delay of 5 minutes after the end of the block. This will only affect certain observation types as set in the settings and has to be manually enabled from the command line. 

### - Prefering same block or same proposal calibrations
For imaging, all of the calibrations are taken under a public/observatory level program so we haven't had to worry about this. For FLOYDS it is common for the user to take their own calibrations. We then don't want other observations to use that calibration (unless it's public, see below). I have added in the db queries a chain of logic to first check for observations in the same block as the frame that is being processed, then the same proposal, then everything else. The knock on of this is that we now need to store the proposal and block id in the database. The database migration for this is not very complicated but will take a while to run at this point because we have so much data. 

### - Only use public calibrations
If calibrations from the same block or same proposal don't exist we want to fall back to public data, i.e. we don't want to process data with someone else's proprietary data. To enable this, we need to include the L1PUBDAT from the data in the database. This database migration can be easily completed with the one above.