### PR TITLE
Introduce DATA_ROOT env var to configure daydirs

### DIFF
--- a/banzai/main.py
+++ b/banzai/main.py
@@ -86,7 +86,7 @@ def parse_args(settings, extra_console_arguments=None, parser_description='Proce
     """
     parser = argparse.ArgumentParser(description=parser_description)
 
-    parser.add_argument("--processed-path", default='/archive/engineering',
+    parser.add_argument("--processed-path", default=os.getenv("DATA_ROOT", '/archive/engineering'),
                         help='Top level directory where the processed data will be stored')
     parser.add_argument("--log-level", default='info', choices=['debug', 'info', 'warning',
                                                                 'critical', 'fatal', 'error'])

--- a/banzai/tests/test_end_to_end.py
+++ b/banzai/tests/test_end_to_end.py
@@ -31,7 +31,7 @@ TEST_FRAMES = ascii.read(os.path.join(importlib.resources.files(TEST_PACKAGE), '
 
 PRECAL_FRAMES = ascii.read(os.path.join(importlib.resources.files(TEST_PACKAGE), 'data/test_precals.dat'))
 
-DATA_ROOT = os.path.join(os.sep, 'archive', 'engineering')
+DATA_ROOT = os.getenv('DATA_ROOT', os.path.join(os.sep, 'archive', 'engineering'))
 # Use the LCO filenaming convention to infer the sites
 SITES = set([frame[:3] for frame in TEST_FRAMES['filename']])
 INSTRUMENTS = set([os.path.join(frame[:3], frame.split('-')[1]) for frame in TEST_FRAMES['filename']])


### PR DESCRIPTION
When running end to end tests, the location of the lco style daydirs folder was hardcoded to /archive/engineering/. To make this configurable so this folder can be found somewhere else, this PR introduces a new env var DATA_ROOT that is first checked in both end to end tests and is used as a fallback for the command line option --processed-path.