### PR TITLE
Fix issue preventing use of local BPM files

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -59,7 +59,8 @@ BANZAI has a variety of console entry points:
 * `banzai_migrate_db`: Migrate data from a database from before 0.16.0 to the current database format
 * `banzai_add_instrument`: Add an instrument to the database
 * `banzai_add_site`: Add a site to the database
-* `banzai_add_bpm`: Add a BPM to the database
+* `banzai_add_super_calibration`: Add a super calibration frame to the database
+* `banzai_populate_bpms`: Automatically populate the db with bpms from the archive
 * `banzai_create_db`: Initialize a database to be used when running the pipeline
 
 You can see more about the parameters the commands take by adding a `--help` to any command of interest.
@@ -82,13 +83,12 @@ If you are not running this at LCO, you will have to add the instrument of inter
 by running `banzai_add_instrument` before you can process any data.
 
 By default, BANZAI requires a bad pixel mask. You can create one that BANZAI can use by using the tool
-`here <https://github.com/LCOGT/pixel-mask-gen>`_. If the bad pixel mask is in the current directory when you
-create the database it will get automatically added. Otherwise run
+`here <https://github.com/LCOGT/pixel-mask-gen>`_.
+To add a local bpm to the database, run
 
-.. code-block:: python
+.. code-block:: bash
 
-    from banzai.dbs import populate_calibration_table_with_bpms
-    populate_calibration_table_with_bpms('/directory/with/bad/pixel/mask', db_address='sqlite://banzai.db')
+    banzai_add_super_calibration path/to/bpm/file --skip-ingester --db-address path/to/db
 
 Generally, you have to reduce individual bias frames first by running `banzai_reduce_individual_frame` command.
 If the processing went well, you can mark them as good in the database using `banzai_mark_frame_as_good`.

--- a/README.rst
+++ b/README.rst
@@ -88,7 +88,7 @@ To add a local bpm to the database, run
 
 .. code-block:: bash
 
-    banzai_add_super_calibration path/to/bpm/file --skip-ingester --db-address path/to/db
+    banzai_add_super_calibration path/to/bpm/file --db-address path/to/db
 
 Generally, you have to reduce individual bias frames first by running `banzai_reduce_individual_frame` command.
 If the processing went well, you can mark them as good in the database using `banzai_mark_frame_as_good`.

--- a/banzai/main.py
+++ b/banzai/main.py
@@ -314,31 +314,45 @@ def add_super_calibration():
     parser.add_argument('--db-address', dest='db_address',
                         default='mysql://cmccully:password@localhost/test',
                         help='Database address: Should be in SQLAlchemy form')
+    parser.add_argument('--skip-ingester', dest='skip_ingester', action='store_true')
+    parser.add_argument('--frame-id', dest='frame_id', help="Frame ID for this calibration frame, if sourced from the archive.")
     args = parser.parse_args()
     add_settings_to_context(args, settings)
     logs.set_log_level(args.log_level)
     frame_factory = import_utils.import_attribute(settings.FRAME_FACTORY)()
+
     try:
         cal_image = frame_factory.open({'path': args.filepath}, args)
     except Exception:
         logger.error(f"Calibration file not able to be opened by BANZAI. Aborting... {logs.format_exception()}",
                      extra_tags={'filename': args.filepath})
-        cal_image = None
+        return
+
+    if args.skip_ingester:
+        logger.debug("Skipped posting frame to archive. Saving to database.", extra_tags={'frameid': args.frame_id})
+        cal_image.frameid = args.frame_id
 
     # upload calibration file via ingester
-    if cal_image is not None:
+    else:
         with open(args.filepath, 'rb') as f:
             logger.debug("Posting calibration file to s3 archive")
             ingester_response = file_utils.post_to_ingester(f, cal_image, args.filepath)
+        frame_id = ingester_response['frameid']
+        logger.debug("File posted to s3 archive. Saving to database.", extra_tags={'frameid': frame_id})
+        cal_image.frameid = frame_id
 
-        logger.debug("File posted to s3 archive. Saving to database.",
-                     extra_tags={'frameid': ingester_response['frameid']})
-        cal_image.frame_id = ingester_response['frameid']
-        cal_image.is_bad = False
-        cal_image.is_master = True
-        dbs.save_calibration_info(cal_image.to_db_record(DataProduct(None, filename=os.path.basename(args.filepath),
-                                                                     filepath=os.path.dirname(args.filepath))),
-                                  args.db_address)
+    cal_image.is_bad = False
+    cal_image.is_master = True
+    dbs.save_calibration_info(
+        cal_image.to_db_record(
+            DataProduct(
+                None,
+                filename=os.path.basename(args.filepath),
+                filepath=os.path.dirname(args.filepath)
+            )
+        ),
+        args.db_address
+    )
 
 
 def add_bpms_from_archive():

--- a/banzai/main.py
+++ b/banzai/main.py
@@ -315,7 +315,6 @@ def add_super_calibration():
                         default='mysql://cmccully:password@localhost/test',
                         help='Database address: Should be in SQLAlchemy form')
     parser.add_argument('--skip-ingester', dest='skip_ingester', action='store_true')
-    parser.add_argument('--frame-id', dest='frame_id', help="Frame ID for this calibration frame, if sourced from the archive.")
     args = parser.parse_args()
     add_settings_to_context(args, settings)
     logs.set_log_level(args.log_level)
@@ -329,8 +328,7 @@ def add_super_calibration():
         return
 
     if args.skip_ingester:
-        logger.debug("Skipped posting frame to archive. Saving to database.", extra_tags={'frameid': args.frame_id})
-        cal_image.frameid = args.frame_id
+        logger.debug("Skipped posting frame to archive. Saving to database.")
 
     # upload calibration file via ingester
     else:


### PR DESCRIPTION
This PR modifies the `add_super_calibration` function (exposed to the console as `banzai_add_super_calibration`), adding an optional boolean flag `--skip-ingester` that will take the calibration file and add it directly to the database without posting to the ingester. 

Before making this change, I was unable to use a local BPM file because it was failing the ingester step. It seems like that shouldn't be a required step, nor is it one that most users would have permission to do anyways. 

I also added an optional arg (`--frame-id`) to manually pass in the calibration frame_id, which is otherwise sourced from the ingester step. However, it seems to work just fine without this. Actually, regardless of whether or not this value is supplied, manually querying the db for the bpm file shows a null entry for db `frameid`. Do we need this at all? 