### PR TITLE
Mark frames bad when archiving fails

### DIFF
--- a/banzai/dbs.py
+++ b/banzai/dbs.py
@@ -285,10 +285,10 @@ def commit_processed_image(processed_image, db_address):
         db_session.commit()
 
 
-def save_processed_image(path, md5, db_address):
+def save_processed_image(path, md5, db_address, success=True):
     filename = os.path.basename(path)
     output_record = get_processed_image(filename, db_address)
-    output_record.success = True
+    output_record.success = success
     output_record.checksum = md5
     commit_processed_image(output_record, db_address)
 

--- a/banzai/dbs.py
+++ b/banzai/dbs.py
@@ -285,10 +285,9 @@ def commit_processed_image(processed_image, db_address):
         db_session.commit()
 
 
-def save_processed_image(path, md5, db_address, success=True):
+def save_processed_image(path, md5, db_address):
     filename = os.path.basename(path)
     output_record = get_processed_image(filename, db_address)
-    output_record.success = success
     output_record.checksum = md5
     commit_processed_image(output_record, db_address)
 

--- a/banzai/lco.py
+++ b/banzai/lco.py
@@ -236,7 +236,7 @@ class LCOObservationFrame(ObservationFrame):
                 try:
                     data_product.frame_id = archived_image_info['frameid']
                 except KeyError:
-                    raise RuntimeError("Ingester response did not contain a frameid, cannot continue")
+                    raise RuntimeError("Archive ingester response did not contain a frameid, cannot continue")
 
             if not runtime_context.no_file_cache:
                 os.makedirs(self.get_output_directory(runtime_context), exist_ok=True)

--- a/banzai/lco.py
+++ b/banzai/lco.py
@@ -229,11 +229,17 @@ class LCOObservationFrame(ObservationFrame):
     def write(self, runtime_context):
         self.save_processing_metadata(runtime_context)
         output_products = self.get_output_data_products(runtime_context)
+        archive_success = True
         for data_product in output_products:
             if runtime_context.post_to_archive:
                 archived_image_info = file_utils.post_to_ingester(data_product.file_buffer, self,
                                                                   data_product.filename, meta=data_product.meta)
-                data_product.frame_id = archived_image_info.get('frameid')
+                if not archived_image_info.get('frameid'):
+                    logger.error('Failed to post to archive: %s', data_product.filename)
+                    archive_success = False
+                    data_product.frame_id = None
+                else:
+                    data_product.frame_id = archived_image_info['frameid']
 
             if not runtime_context.no_file_cache:
                 os.makedirs(self.get_output_directory(runtime_context), exist_ok=True)
@@ -243,7 +249,7 @@ class LCOObservationFrame(ObservationFrame):
 
             data_product.file_buffer.seek(0)
             md5 = hashlib.md5(data_product.file_buffer.read()).hexdigest()
-            dbs.save_processed_image(data_product.filename, md5, db_address=runtime_context.db_address)
+            dbs.save_processed_image(data_product.filename, md5, db_address=runtime_context.db_address, success=archive_success)
         return output_products
 
 


### PR DESCRIPTION
Relates to #424, when archiving a frame fails the record should be marked as bad, even if the data itself is perfectly fine. This helps to avoid operational issues stemming from unexpectedly missing data.

@cmccully It's not entirely clear to me what setting success = False in the DB actually does. My reasoning is that even if the data itself is perfectly fine, the fact that it's missing from the archive is a severe enough operational issue that reprocessing it is probably the first thing that someone will try anyway if the problem is surfaced.