### PR TITLE
Suppress meaningless opentsdb metrics connection warning

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,11 @@
 Versions
 ========
 
+1.33.2 (2026-04-07)
+-------------------
+
+- Suppress ingester warning for opentsdb if OPENTSDB_HOSTNAME env variable is not set.
+
 1.33.1 (2026-04-07)
 -------------------
 

--- a/banzai/__init__.py
+++ b/banzai/__init__.py
@@ -3,8 +3,12 @@
 # Packages may add whatever they like to this file, but
 # should keep this content at the top.
 # ----------------------------------------------------------------------------
+import os
 import banzai.logs  # noqa: F401
 # ----------------------------------------------------------------------------
+
+# Remove useless warning: max retries exceeded on host scheduler-dev.lco.gtn
+os.environ.setdefault("OPENTSDB_PYTHON_METRICS_TEST_MODE", "1")
 
 try:
     import importlib.metadata as metadata

--- a/banzai/__init__.py
+++ b/banzai/__init__.py
@@ -7,8 +7,14 @@ import os
 import banzai.logs  # noqa: F401
 # ----------------------------------------------------------------------------
 
-# Remove useless warning: max retries exceeded on host scheduler-dev.lco.gtn
-os.environ.setdefault("OPENTSDB_PYTHON_METRICS_TEST_MODE", "1")
+# OPENTSDB_PYTHON_METRICS_TEST_MODE activates test mode if it has been set,
+# regardless of its value. Test mode is good in dev environments because it
+# surpresses noisy "max retries exceeded" connection warnings, but we need it
+# disabled in production to enable metrics reporting.
+#
+# If OPENTSDB_HOSTNAME is set, we can assume we're running in prod.
+if "OPENTSDB_HOSTNAME" not in os.environ:
+    os.environ["OPENTSDB_PYTHON_METRICS_TEST_MODE"] = "True"
 
 try:
     import importlib.metadata as metadata

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "lco-banzai"
 requires-python = ">=3.11,<4"
-version = "1.33.1"
+version = "1.33.2"
 description = "Python data reduction package for LCOGT data"
 
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -1153,7 +1153,7 @@ wheels = [
 
 [[package]]
 name = "lco-banzai"
-version = "1.33.1"
+version = "1.33.2"
 source = { editable = "." }
 dependencies = [
     { name = "apscheduler" },


### PR DESCRIPTION
Set default `OPENTSDB_PYTHON_METRICS_TEST_MODE=1` in `banzai/__init__.py` so users don't see this confusing error on every run:

`ERROR: metric_wrappers: ConnectionError(MaxRetryError("HTTPConnectionPool(host='scheduler-dev.lco.gtn', port=80): Max retries exceeded with url: /api/version (Caused by NewConnectionError('<urllib3.connection.HTTPConnection object at 0x112013230>: Failed to establish a new connection: [Errno 8] nodename nor servname provided, or not known'))"))`
