### PR TITLE
Add auth to obs-portal calls for calibration block schedule.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,12 @@
 Versions
 ========
 
+1.35.1 (2026-04-20)
+-------------------
+
+- Added authentication to the observation portal to get the times when
+  calibration blocks are scheduled.
+
 1.35.0 (2026-04-16)
 -------------------
 

--- a/banzai/utils/observation_utils.py
+++ b/banzai/utils/observation_utils.py
@@ -10,7 +10,7 @@ def get_calibration_blocks_for_time_range(site, start_before, start_after, conte
     payload = {'start_before': start_before, 'start_after': start_after, 'site': site,
                'proposal': context.CALIBRATE_PROPOSAL_ID, 'aborted': 'false', 'canceled': 'false', 'order': '-start',
                'offset': '', 'limit': 1000}
-    response = requests.get(context.OBSERVATION_PORTAL_URL, params=payload)
+    response = requests.get(context.OBSERVATION_PORTAL_URL, params=payload, headers=context.ARCHIVE_AUTH_HEADER)
     response.raise_for_status()
     results = response.json()['results']
     for observation in results:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "lco-banzai"
 requires-python = ">=3.11,<4"
-version = "1.35.0"
+version = "1.35.1"
 description = "Python data reduction package for LCOGT data"
 
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -1164,7 +1164,7 @@ wheels = [
 
 [[package]]
 name = "lco-banzai"
-version = "1.35.0"
+version = "1.35.1"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
We do this for obs portal queries to schedule when we need to stack calibrations. This is now required by the obs portal in an attempt to block outside bots.