### PR TITLE
Fix to local to utc that only worked with datetimes and not time objects.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,7 @@ Versions
 1.36.1 (2026-05-26)
 -------------------
 
-- Fix to dateutil.local_to_utc to take both datetime
+- Fix to banzai.utils.date_utils.local_to_utc to take both datetime
   and time objects.
 
 1.36.0 (2026-05-08)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,12 @@
 Versions
 ========
 
+1.36.1 (2026-05-26)
+-------------------
+
+- Fix to dateutil.local_to_utc to take both datetime
+  and time objects.
+
 1.36.0 (2026-05-08)
 -------------------
 

--- a/banzai/tests/test_date_utils.py
+++ b/banzai/tests/test_date_utils.py
@@ -64,7 +64,7 @@ def test_get_dayobs(mock_datetime):
     (time(6, 30, 0), 10, time(20, 30, 0, tzinfo=timezone.utc)),
     (time(21, 0, 0), -4, time(1, 0, 0, tzinfo=timezone.utc)),
     (time(12, 0, 0), 0, time(12, 0, 0, tzinfo=timezone.utc)),
-    (datetime(2019, 5, 1, 6, 30, 0), 10, time(20, 30, 0, tzinfo=timezone.utc)),
+    (datetime(2019, 5, 1, 6, 30, 0), 10, datetime(2019, 4, 30, 20, 30, 0, tzinfo=timezone.utc)),
 ])
 def test_local_to_utc(local_time, tz_offset, expected_utc):
     assert date_utils.local_to_utc(local_time, tz_offset) == expected_utc

--- a/banzai/tests/test_date_utils.py
+++ b/banzai/tests/test_date_utils.py
@@ -1,6 +1,6 @@
 import mock
 
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta, timezone, time
 import pytest
 
 from banzai.utils import date_utils
@@ -61,9 +61,10 @@ def test_get_dayobs(mock_datetime):
 
 
 @pytest.mark.parametrize('local_time,tz_offset,expected_utc', [
-    (datetime(2019, 5, 1, 6, 30, 0), 10, datetime(2019, 4, 30, 20, 30, 0, tzinfo=timezone.utc)),
-    (datetime(2019, 5, 1, 21, 0, 0), -4, datetime(2019, 5, 2, 1, 0, 0, tzinfo=timezone.utc)),
-    (datetime(2019, 5, 1, 12, 0, 0), 0, datetime(2019, 5, 1, 12, 0, 0, tzinfo=timezone.utc)),
+    (time(6, 30, 0), 10, time(20, 30, 0, tzinfo=timezone.utc)),
+    (time(21, 0, 0), -4, time(1, 0, 0, tzinfo=timezone.utc)),
+    (time(12, 0, 0), 0, time(12, 0, 0, tzinfo=timezone.utc)),
+    (datetime(2019, 5, 1, 6, 30, 0), 10, time(20, 30, 0, tzinfo=timezone.utc)),
 ])
 def test_local_to_utc(local_time, tz_offset, expected_utc):
     assert date_utils.local_to_utc(local_time, tz_offset) == expected_utc

--- a/banzai/utils/date_utils.py
+++ b/banzai/utils/date_utils.py
@@ -133,25 +133,25 @@ def get_stacking_date_range(timezone: int, lookback_days: float = 0.5) -> (str, 
     return min_date.strftime(TIMESTAMP_FORMAT), max_date.strftime(TIMESTAMP_FORMAT)
 
 
-def local_to_utc(local_time, timezone):
+def local_to_utc(local_time: datetime.time | datetime.datetime,
+                 timezone: int) -> datetime.time | datetime.datetime:
     """
     Convert a local time to UTC based on the timezone of the site.
 
     Parameters
     ----------
-    local_time : datetime.time
+    local_time : datetime.time or datetime.datetime
         Local time to convert to UTC.
     timezone : int
         Timezone offset in hours.
 
     Returns
     -------
-    datetime.time
-        UTC time.
+    datetime.time or datetime.datetime
+        UTC time, returned as the same type as ``local_time``.
     """
     tz = datetime.timezone(datetime.timedelta(hours=timezone))
     if isinstance(local_time, datetime.datetime):
-        local_dt = local_time.replace(tzinfo=tz)
-    else:
-        local_dt = datetime.datetime.combine(datetime.date.today(), local_time, tzinfo=tz)
+        return local_time.replace(tzinfo=tz).astimezone(datetime.timezone.utc)
+    local_dt = datetime.datetime.combine(datetime.date.today(), local_time, tzinfo=tz)
     return local_dt.astimezone(datetime.timezone.utc).timetz()

--- a/banzai/utils/date_utils.py
+++ b/banzai/utils/date_utils.py
@@ -149,5 +149,9 @@ def local_to_utc(local_time, timezone):
     datetime.time
         UTC time.
     """
-    local_time = local_time.replace(tzinfo=datetime.timezone(datetime.timedelta(hours=timezone)))
-    return local_time.astimezone(datetime.timezone.utc)
+    tz = datetime.timezone(datetime.timedelta(hours=timezone))
+    if isinstance(local_time, datetime.datetime):
+        local_dt = local_time.replace(tzinfo=tz)
+    else:
+        local_dt = datetime.datetime.combine(datetime.date.today(), local_time, tzinfo=tz)
+    return local_dt.astimezone(datetime.timezone.utc).timetz()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "lco-banzai"
 requires-python = ">=3.11,<4"
-version = "1.36.0"
+version = "1.36.1"
 description = "Python data reduction package for LCOGT data"
 
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -1164,7 +1164,7 @@ wheels = [
 
 [[package]]
 name = "lco-banzai"
-version = "1.36.0"
+version = "1.36.1"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
We were passing a datetime.time object into the time conversion for requeuing frames, but the function we were calling only works with datetime.dateime objects. This fixes that.