### PR TITLE
Remove related frames from query that doesn't use it

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,12 @@
 Versions
 ========
 
-1.36.2 (2026-06-02)
+1.36.3 (2026-06-23)
+-------------------
+
+- Remove related frames from basename query in requeing to reduce load on archive
+
+1.36.2 (2026-06-23)
 -------------------
 
 - Bump ingester to use tagged version instead of branch

--- a/banzai/query.py
+++ b/banzai/query.py
@@ -130,6 +130,6 @@ def cross_match_missing_frames(raw_frames, reduced_frames):
         raw_frames_that_have_been_reduced += reduced_frame['related_frames']
     missing_raw_frames = []
     for raw_frame in raw_frames:
-        if raw_frame['basename'] not in raw_frames_that_have_been_reduced:
+        if raw_frame['id'] not in raw_frames_that_have_been_reduced:
             missing_raw_frames.append(raw_frame)
     return missing_raw_frames

--- a/banzai/utils/fits_utils.py
+++ b/banzai/utils/fits_utils.py
@@ -148,7 +148,7 @@ def basename_search_in_archive(filename, dateobs, context, is_raw_frame=False):
     end = (dateobs + datetime.timedelta(days=3)).strftime('%Y-%m-%d')
 
     response = requests.get(url, headers=archive_auth_header,
-                            params={'basename_exact': basename, 'start': start, 'end': end},
+                            params={'basename_exact': basename, 'start': start, 'end': end, 'include_related_frames': False},
                             timeout=15)
     response.raise_for_status()
     frames = response.json()['results']


### PR DESCRIPTION
This is what I messaged you about last week - I don't think the related frames are needed from this query so its best to not include them.

Can someone more familiar with banzai tell me why the tests are failing?