### PR TITLE
Smartstack - image stacking

### DIFF
--- a/banzai/calibrations.py
+++ b/banzai/calibrations.py
@@ -67,7 +67,7 @@ class CalibrationStacker(CalibrationMaker):
         master_image = master_frame_class.init_master_frame(images, master_calibration_filename,
                                                             grouping_criteria=grouping, hdu_order=hdu_order)
 
-        combine_images(images, master_image, nsigma=3.0, method='mean')
+        combine_images([image['SCI'] for image in images], master_image['SCI'], nsigma=3.0, method='mean')
 
         logger.info('Created master calibration stack', image=master_image,
                     extra_tags={'calibration_type': self.calibration_type})

--- a/banzai/calibrations.py
+++ b/banzai/calibrations.py
@@ -4,8 +4,7 @@ from datetime import datetime
 from banzai.stages import Stage
 from banzai import dbs, logs
 from banzai.utils import qc, import_utils, stage_utils, file_utils
-from banzai.data import stack
-from banzai.utils.image_utils import Section
+from banzai.data import combine_images
 
 logger = logs.get_logger()
 
@@ -57,7 +56,9 @@ class CalibrationStacker(CalibrationMaker):
                                                                               self.runtime_context)
 
         # use the most recent image in the stack to create the master filename
-        master_calibration_filename = make_calibration_name(max(images, key=lambda x: datetime.strptime(x.epoch, '%Y%m%d') ))
+        master_calibration_filename = make_calibration_name(
+            max(images, key=lambda x: datetime.strptime(x.epoch, '%Y%m%d'))
+        )
 
         grouping = self.runtime_context.CALIBRATION_SET_CRITERIA.get(images[0].obstype, [])
         master_frame_class = import_utils.import_attribute(self.runtime_context.CALIBRATION_FRAME_CLASS)
@@ -66,34 +67,7 @@ class CalibrationStacker(CalibrationMaker):
         master_image = master_frame_class.init_master_frame(images, master_calibration_filename,
                                                             grouping_criteria=grouping, hdu_order=hdu_order)
 
-        # turn off memory mapping for each segment
-        for image in images:
-            image.primary_hdu.memmap = False
-        # Split the image into N sections where N is the number of images
-        # This is just for convenience. Technically N can be anything you want.
-        # I assume that you can read a couple of images into memory so order N sections is good for memory management.
-        N = len(images)
-        # Split along the y-direction to get more sequential reads off of disk
-        # detector section (y_stop - y_start) // binning(y) // N, abs(x_stop - x_start) // binning(x)
-        y_step = images[0].shape[0] // N
-        for i in range(N + 1):
-            y_start = 1 + i * y_step
-            if i == N:
-                # If the image divided evenly just move on.
-                if images[0].shape[0] % N == 0:
-                    break
-                # Otherwise, don't forget to do the last %mod sized section
-                y_stop = images[0].shape[0]
-            else:
-                y_stop = (i + 1) * y_step
-
-            section_to_stack = Section(x_start=1, x_stop=images[0].data.shape[1],
-                                       y_start=y_start, y_stop=y_stop)
-
-            data_to_stack = [image.primary_hdu[section_to_stack] for image in images]
-            stacked_data = stack(data_to_stack, 3.0)
-
-            master_image.primary_hdu.copy_in(stacked_data)
+        combine_images(images, master_image, nsigma=3.0, method='mean')
 
         logger.info('Created master calibration stack', image=master_image,
                     extra_tags={'calibration_type': self.calibration_type})

--- a/banzai/data.py
+++ b/banzai/data.py
@@ -240,17 +240,21 @@ class CCDData(Data):
         inner_ny = round(self.data.shape[0] * inner_edge_width)
         return self.data[inner_ny: -inner_ny, inner_nx: -inner_nx]
 
-    def trim(self, trim_section=None):
+    def trim(self, trim_section=None, memmap=None):
         """
         :param trim_section: Always in data coords
+        :param memmap: Override whether to copy the trimmed arrays into new memory maps.
+                       Defaults to the source object's memory-map preference.
         :return:
         """
         if trim_section is None:
             trim_section = Section.parse_region_keyword(self.meta.get('TRIMSEC', 'N/A'))
+        if memmap is None:
+            memmap = self.memmap
 
         trimmed_image = type(self)(data=self.data[trim_section.to_slice()], meta=self.meta,
                                    mask=self.mask[trim_section.to_slice()], name=self.name,
-                                   uncertainty=self.uncertainty[trim_section.to_slice()], memmap=self.memmap)
+                                   uncertainty=self.uncertainty[trim_section.to_slice()], memmap=memmap)
         trimmed_image.detector_section = self.data_to_detector_section(trim_section)
         trimmed_image.data_section = Section(x_start=1, y_start=1,
                                              x_stop=trimmed_image.data.shape[1],
@@ -521,36 +525,16 @@ def stack(data_to_stack, nsigma_reject, method='mean') -> CCDData:
         stacked_data = a.sum(axis=0) * n_images / n_good_pixels
         stacked_uncertainty = np.sqrt(variances.sum(axis=0)) * n_images / n_good_pixels
     else:
-        raise ValueError(f'Unknown stack method: {method}')
+        raise ValueError(f"Unknown stack method: {method!r}; expected 'mean' or 'sum'")
 
     return CCDData(data=stacked_data, meta=data_to_stack[0].meta, uncertainty=stacked_uncertainty, mask=stacked_mask)
-
-
-def science_hdu(frame):
-    """Return the science CCDData HDU for a frame or CCDData input.
-
-    Parameters
-    ----------
-    frame : CCDData or ObservationFrame
-        Input CCD data or frame containing CCD data.
-
-    Returns
-    -------
-    CCDData
-        Primary HDU when it contains CCD data, otherwise the first CCD extension.
-    """
-    if isinstance(frame, CCDData):
-        return frame
-    if isinstance(frame.primary_hdu, CCDData):
-        return frame.primary_hdu
-    return frame.ccd_hdus[0]
 
 
 def _warn_if_exposure_times_differ(images):
     """Log a warning when input exposure times differ by more than one percent."""
     exposure_times = []
     for image in images:
-        exptime = science_hdu(image).meta.get('EXPTIME')
+        exptime = image.meta.get('EXPTIME')
         if exptime is None:
             continue
         try:
@@ -572,15 +556,15 @@ def _warn_if_exposure_times_differ(images):
                        extra_tags={'exptime_spread_fraction': exptime_spread_fraction})
 
 
-def combine_images(images, output_frame, nsigma=3.0, method='mean'):
-    """Combine images into an output frame in memory-bounded y sections.
+def combine_images(images, output_image, nsigma=3.0, method='mean'):
+    """Combine CCD data into an output image in memory-bounded y sections.
 
     Parameters
     ----------
-    images : list of CCDData or ObservationFrame
-        Input images to combine.
-    output_frame : CCDData or ObservationFrame
-        Frame or CCD data object whose science HDU receives the combined result.
+    images : list of CCDData
+        Input CCD data to combine.
+    output_image : CCDData
+        CCD data object that receives the combined result.
     nsigma : float, optional
         Robust-standard-deviation threshold for rejecting pixels from each section.
     method : {'mean', 'sum'}, optional
@@ -588,39 +572,40 @@ def combine_images(images, output_frame, nsigma=3.0, method='mean'):
 
     Returns
     -------
-    CCDData or ObservationFrame
-        The same output object passed in, with combined science data copied into it.
+    CCDData
+        The same output object passed in, with combined data copied into it.
     """
-    _warn_if_exposure_times_differ(images)
+    if method == 'sum':
+        _warn_if_exposure_times_differ(images)
 
-    # Turn off memory mapping for each segment.
-    for image in images:
-        science_hdu(image).memmap = False
-
-    input_hdu = science_hdu(images[0])
-    output_hdu = science_hdu(output_frame)
+    input_image = images[0]
 
     # Split the image into order-N sections. This is just for convenience: technically N can be anything, but
     # assuming we can read a couple of images at once makes order-N sections good for memory management.
     # Clamp the section count so tiny images never get y_step=0.
-    n_sections = min(len(images), input_hdu.shape[0])
+    n_sections = min(len(images), input_image.shape[0])
 
     # Split along the y-direction to get more sequential reads off of disk.
     # detector section (y_stop - y_start) // binning(y) // N, abs(x_stop - x_start) // binning(x)
-    y_step = input_hdu.shape[0] // n_sections
+    y_step = input_image.shape[0] // n_sections
     for i in range(n_sections + 1):
         y_start = 1 + i * y_step
         if i == n_sections:
-            if input_hdu.shape[0] % n_sections == 0:
+            if input_image.shape[0] % n_sections == 0:
                 break
-            y_stop = input_hdu.shape[0]
+            y_stop = input_image.shape[0]
         else:
             y_stop = (i + 1) * y_step
 
-        section_to_stack = Section(x_start=1, x_stop=input_hdu.data.shape[1], y_start=y_start, y_stop=y_stop)
-        data_to_stack = [science_hdu(image)[section_to_stack] for image in images]
+        section_to_stack = Section(x_start=1, x_stop=input_image.data.shape[1], y_start=y_start, y_stop=y_stop)
+        # Source arrays are already memory mapped. Keep each section as a view of its source instead of copying it
+        # into another temporary memory map.
+        data_to_stack = [image.trim(trim_section=section_to_stack, memmap=False) for image in images]
         stacked_data = stack(data_to_stack, nsigma, method=method)
 
-        output_hdu.copy_in(stacked_data)
+        output_slice = section_to_stack.to_slice()
+        output_image.data[output_slice] = stacked_data.data
+        output_image.mask[output_slice] = stacked_data.mask
+        output_image.uncertainty[output_slice] = stacked_data.uncertainty
 
-    return output_frame
+    return output_image

--- a/banzai/data.py
+++ b/banzai/data.py
@@ -1,4 +1,5 @@
 import abc
+from io import BytesIO
 import tempfile
 from typing import Union, Type
 
@@ -6,9 +7,11 @@ import numpy as np
 from astropy.io import fits
 from astropy.table import Table
 
+from banzai import logs
 from banzai.utils.image_utils import Section
 from banzai.utils import fits_utils, stats
-from io import BytesIO
+
+logger = logs.get_logger()
 
 
 class DataProduct:
@@ -420,8 +423,26 @@ class CCDData(Data):
         self.data -= self._background
 
 
-def stack(data_to_stack, nsigma_reject) -> CCDData:
-    """
+def _apply_sigma_rejection(data_to_stack, nsigma_reject):
+    """Build masked stack arrays after applying robust sigma rejection.
+
+    Parameters
+    ----------
+    data_to_stack : list of CCDData
+        Image sections to combine. Data, mask, and uncertainty arrays must have matching shapes.
+    nsigma_reject : float
+        Robust-standard-deviation threshold for rejecting pixels from the stack.
+
+    Returns
+    -------
+    data : numpy.ndarray
+        Three-dimensional data array with rejected and masked pixels set to zero.
+    variances : numpy.ndarray
+        Three-dimensional variance array with rejected and masked pixels set to zero.
+    n_good_pixels : numpy.ndarray
+        Number of unmasked inputs for each output pixel. All-bad pixels are forced to the input count.
+    stacked_mask : numpy.ndarray
+        Output mask, including the bitwise OR of input masks for all-bad pixels.
     """
     shape3d = [len(data_to_stack)] + list(data_to_stack[0].shape)
     a = np.zeros(shape3d, dtype=data_to_stack[0].dtype)
@@ -458,11 +479,148 @@ def stack(data_to_stack, nsigma_reject) -> CCDData:
     mask3d[:, bad_pixels] = False
 
     a[mask3d] = 0.0
-    stacked_data = a.sum(axis=0) / n_good_pixels
 
     # Again if a pixel is bad in all images, fill the uncertainties with the quadrature sum / N images
     uncertainties[mask3d] = 0.0
-    uncertainties *= uncertainties
-    stacked_uncertainty = np.sqrt(uncertainties.sum(axis=0) / (n_good_pixels ** 2.0))
+    variances = uncertainties
+    variances *= variances
+
+    return a, variances, n_good_pixels, stacked_mask
+
+
+def stack(data_to_stack, nsigma_reject, method='mean') -> CCDData:
+    """Stack CCD data with robust sigma rejection.
+
+    Parameters
+    ----------
+    data_to_stack : list of CCDData
+        Image sections to combine. Data, mask, and uncertainty arrays must have matching shapes.
+    nsigma_reject : float
+        Robust-standard-deviation threshold for rejecting pixels from the stack.
+    method : {'mean', 'sum'}, optional
+        Combine mode. ``mean`` preserves the existing arithmetic mean behavior. ``sum`` scales the sum of unmasked
+        pixels and quadrature uncertainties by ``N / n_good`` for science smartstacks.
+
+    Returns
+    -------
+    CCDData
+        Combined data, uncertainty, and mask.
+
+    Raises
+    ------
+    ValueError
+        Raised when ``method`` is not ``mean`` or ``sum``.
+    """
+    a, variances, n_good_pixels, stacked_mask = _apply_sigma_rejection(data_to_stack, nsigma_reject)
+
+    if method == 'mean':
+        stacked_data = a.sum(axis=0) / n_good_pixels
+        stacked_uncertainty = np.sqrt(variances.sum(axis=0) / (n_good_pixels ** 2.0))
+    elif method == 'sum':
+        n_images = len(data_to_stack)
+        stacked_data = a.sum(axis=0) * n_images / n_good_pixels
+        stacked_uncertainty = np.sqrt(variances.sum(axis=0)) * n_images / n_good_pixels
+    else:
+        raise ValueError(f'Unknown stack method: {method}')
 
     return CCDData(data=stacked_data, meta=data_to_stack[0].meta, uncertainty=stacked_uncertainty, mask=stacked_mask)
+
+
+def science_hdu(frame):
+    """Return the science CCDData HDU for a frame or CCDData input.
+
+    Parameters
+    ----------
+    frame : CCDData or ObservationFrame
+        Input CCD data or frame containing CCD data.
+
+    Returns
+    -------
+    CCDData
+        Primary HDU when it contains CCD data, otherwise the first CCD extension.
+    """
+    if isinstance(frame, CCDData):
+        return frame
+    if isinstance(frame.primary_hdu, CCDData):
+        return frame.primary_hdu
+    return frame.ccd_hdus[0]
+
+
+def _warn_if_exposure_times_differ(images):
+    """Log a warning when input exposure times differ by more than one percent."""
+    exposure_times = []
+    for image in images:
+        exptime = science_hdu(image).meta.get('EXPTIME')
+        if exptime is None:
+            continue
+        try:
+            exposure_times.append(float(exptime))
+        except (TypeError, ValueError):
+            continue
+
+    exposure_times = np.array(exposure_times, dtype=np.float64)
+    if exposure_times.size < 2:
+        return
+
+    median_exptime = np.median(exposure_times)
+    if median_exptime == 0.0:
+        return
+
+    exptime_spread_fraction = (exposure_times.max() - exposure_times.min()) / median_exptime
+    if exptime_spread_fraction > 0.01:
+        logger.warning('Stacking images with exposure times that differ by more than 1%',
+                       extra_tags={'exptime_spread_fraction': exptime_spread_fraction})
+
+
+def combine_images(images, output_frame, nsigma=3.0, method='mean'):
+    """Combine images into an output frame in memory-bounded y sections.
+
+    Parameters
+    ----------
+    images : list of CCDData or ObservationFrame
+        Input images to combine.
+    output_frame : CCDData or ObservationFrame
+        Frame or CCD data object whose science HDU receives the combined result.
+    nsigma : float, optional
+        Robust-standard-deviation threshold for rejecting pixels from each section.
+    method : {'mean', 'sum'}, optional
+        Combine mode passed through to :func:`stack`.
+
+    Returns
+    -------
+    CCDData or ObservationFrame
+        The same output object passed in, with combined science data copied into it.
+    """
+    _warn_if_exposure_times_differ(images)
+
+    # Turn off memory mapping for each segment.
+    for image in images:
+        science_hdu(image).memmap = False
+
+    input_hdu = science_hdu(images[0])
+    output_hdu = science_hdu(output_frame)
+
+    # Split the image into order-N sections. This is just for convenience: technically N can be anything, but
+    # assuming we can read a couple of images at once makes order-N sections good for memory management.
+    # Clamp the section count so tiny images never get y_step=0.
+    n_sections = min(len(images), input_hdu.shape[0])
+
+    # Split along the y-direction to get more sequential reads off of disk.
+    # detector section (y_stop - y_start) // binning(y) // N, abs(x_stop - x_start) // binning(x)
+    y_step = input_hdu.shape[0] // n_sections
+    for i in range(n_sections + 1):
+        y_start = 1 + i * y_step
+        if i == n_sections:
+            if input_hdu.shape[0] % n_sections == 0:
+                break
+            y_stop = input_hdu.shape[0]
+        else:
+            y_stop = (i + 1) * y_step
+
+        section_to_stack = Section(x_start=1, x_stop=input_hdu.data.shape[1], y_start=y_start, y_stop=y_stop)
+        data_to_stack = [science_hdu(image)[section_to_stack] for image in images]
+        stacked_data = stack(data_to_stack, nsigma, method=method)
+
+        output_hdu.copy_in(stacked_data)
+
+    return output_frame

--- a/banzai/lco.py
+++ b/banzai/lco.py
@@ -294,9 +294,10 @@ class LCOCalibrationFrame(LCOObservationFrame, CalibrationFrame):
     @classmethod
     def init_master_frame(cls, images: list, file_path: str, frame_id: int = None,
                           grouping_criteria: list = None, hdu_order: list = None):
-        data_class = type(images[0].primary_hdu)
-        hdu_list = [data_class(data=np.zeros(images[0].data.shape, dtype=images[0].data.dtype),
-                               meta=cls.init_master_header(images[0].meta, images))]
+        input_science = images[0]['SCI']
+        data_class = type(input_science)
+        hdu_list = [data_class(data=np.zeros(input_science.shape, dtype=input_science.dtype),
+                               meta=cls.init_master_header(images[0].meta, images), name='SCI')]
         frame = cls(hdu_list=hdu_list, file_path=file_path, frame_id=frame_id,
                     grouping_criteria=grouping_criteria, hdu_order=hdu_order)
         frame.is_master = True

--- a/banzai/tests/test_bias_maker.py
+++ b/banzai/tests/test_bias_maker.py
@@ -35,6 +35,7 @@ def test_header_cal_type_bias(mock_namer):
 
     image = maker.do_stage([FakeLCOObservationFrame(hdu_list=[FakeCCDData(data=np.zeros((ny, nx)),
                                                                            meta=image_header,
+                                                                           name='SCI',
                                                                            bias_level=0.0)])
                              for x in range(6)])
 
@@ -48,7 +49,8 @@ def test_bias_level_is_average_of_inputs(mock_namer):
     bias_levels = np.arange(nimages, dtype=float)
 
     images = [FakeLCOObservationFrame(hdu_list=[FakeCCDData(data=np.random.normal(i, size=(99,99)),
-                                                            bias_level=i, meta=Header({'DATE-OBS': '2019-12-04T14:34:00',
+                                                            bias_level=i, name='SCI',
+                                                            meta=Header({'DATE-OBS': '2019-12-04T14:34:00',
                                                                                        'DETSEC': '[1:100,1:100]',
                                                                                        'DATASEC': '[1:100,1:100]',
                                                                                        'OBSTYPE': 'BIAS',
@@ -69,14 +71,19 @@ def test_makes_a_sensible_master_bias(mock_namer):
     nimages = 20
     expected_readnoise = 15.0
 
-    images = [FakeLCOObservationFrame(hdu_list=[FakeCCDData(data=np.random.normal(0.0, size=(99, 99), scale=expected_readnoise),
-                                                            bias_level=0.0,
-                                                            read_noise=expected_readnoise,
-                                                            meta=Header({'DATE-OBS': '2019-12-04T14:34:00',
-                                                                         'DETSEC': '[1:100,1:100]',
-                                                                         'DATASEC': '[1:100,1:100]',
-                                                                         'OBSTYPE': 'BIAS', 'RA': 0.0, 'DEC': 0.0}))])
-              for i in range(nimages)]
+    images = [
+        FakeLCOObservationFrame(hdu_list=[FakeCCDData(
+            data=np.random.normal(0.0, size=(99, 99), scale=expected_readnoise),
+            bias_level=0.0,
+            read_noise=expected_readnoise,
+            name='SCI',
+            meta=Header({'DATE-OBS': '2019-12-04T14:34:00',
+                         'DETSEC': '[1:100,1:100]',
+                         'DATASEC': '[1:100,1:100]',
+                         'OBSTYPE': 'BIAS', 'RA': 0.0, 'DEC': 0.0}),
+        )])
+        for _ in range(nimages)
+    ]
 
     maker = BiasMaker(FakeContext())
     stacked_image = maker.do_stage(images)
@@ -98,6 +105,7 @@ def test_multiread_bias_maker():
     for i in range(nimages):
         data = nreads * bias_pattern
         image = FakeLCOObservationFrame(hdu_list=[FakeCCDData(data=data, bias_level=bias_level,
+                                                              name='SCI',
                                                               meta=Header({'DATE-OBS': '2019-12-04T14:34:00',
                                                                            'DETSEC': f'[1:{nx},1:{ny}]',
                                                                            'DATASEC': f'[1:{nx},1:{ny}]',

--- a/banzai/tests/test_calibration_stacker.py
+++ b/banzai/tests/test_calibration_stacker.py
@@ -3,6 +3,7 @@ from banzai.data import CCDData
 from banzai.context import Context
 from banzai.calibrations import CalibrationStacker
 from banzai.dbs import Instrument
+from banzai.tests.utils import current_stack_snapshot
 import numpy as np
 from astropy.io import fits
 import pytest
@@ -47,7 +48,8 @@ def test_stacking():
 
 
 def test_stacking_with_noise():
-    test_images = [LCOCalibrationFrame([CCDData(np.random.normal(0.0, 3.0, size=(ny, nx)), meta=fits.Header(header))], '')
+    test_images = [LCOCalibrationFrame([CCDData(np.random.normal(0.0, 3.0, size=(ny, nx)),
+                                                meta=fits.Header(header))], '')
                    for i in range(81)]
     for image in test_images:
         image.instrument = instrument
@@ -69,3 +71,28 @@ def test_stacking_with_different_pixels():
     np.testing.assert_allclose(stacked_data.data, d * np.mean(np.arange(9)))
     np.testing.assert_allclose(stacked_data.primary_hdu.uncertainty, np.ones((ny, nx)))
     assert np.all(stacked_data.mask == 0)
+
+
+def test_calibration_stacker_matches_current_stack_snapshot():
+    rng = np.random.default_rng(920381)
+    test_images = []
+    for i in range(7):
+        image_data = rng.normal(loc=i, scale=2.0, size=(ny, nx))
+        mask = np.zeros((ny, nx), dtype=np.uint8)
+        uncertainty = rng.uniform(1.0, 3.0, size=(ny, nx))
+        hdu = CCDData(image_data, meta=fits.Header(header), mask=mask, uncertainty=uncertainty)
+        test_images.append(LCOCalibrationFrame([hdu], ''))
+
+    test_images[0].primary_hdu.data[2, 3] = 1000.0
+    test_images[1].primary_hdu.mask[5, 7] = 1
+    test_images[3].primary_hdu.mask[11, 13] = 2
+    for image in test_images:
+        image.instrument = instrument
+
+    stage = FakeStacker(context)
+    stacked_data = stage.do_stage(test_images)
+    expected = current_stack_snapshot([image.primary_hdu for image in test_images], 3.0)
+
+    assert np.array_equal(stacked_data.data, expected.data)
+    assert np.array_equal(stacked_data.primary_hdu.uncertainty, expected.uncertainty)
+    assert np.array_equal(stacked_data.mask, expected.mask)

--- a/banzai/tests/test_calibration_stacker.py
+++ b/banzai/tests/test_calibration_stacker.py
@@ -3,7 +3,6 @@ from banzai.data import CCDData
 from banzai.context import Context
 from banzai.calibrations import CalibrationStacker
 from banzai.dbs import Instrument
-from banzai.tests.utils import pre_refactor_stack_snapshot
 import numpy as np
 from astropy.io import fits
 import pytest
@@ -11,7 +10,7 @@ import pytest
 nx, ny = 102, 105
 header = {'DATASEC': f'[1:{nx},1:{ny}]', 'DETSEC': f'[1:{nx},1:{ny}]', 'CCDSUM': '1 1',
           'OBSTYPE': 'TEST', 'RDNOISE': 3.0, 'TELESCOP': '1m0-02', 'DAY-OBS': '20191209',
-          'DATE-OBS': '2019-12-09T00:00:00', 'RA': 0.0, 'DEC': 0.0}
+          'DATE-OBS': '2019-12-09T00:00:00', 'RA': 0.0, 'DEC': 0.0, 'EXTNAME': 'SCI'}
 context = {'CALIBRATION_MIN_FRAMES': {'TEST': 1},
            'CALIBRATION_FILENAME_FUNCTIONS': {'TEST': ['banzai.utils.file_utils.ccdsum_to_filename']},
            'CALIBRATION_SET_CRITERIA': {'TEST': ['binning']},
@@ -36,12 +35,13 @@ class FakeStacker(CalibrationStacker):
 
 
 def test_stacking():
-    test_images = [LCOCalibrationFrame([CCDData(np.ones((ny, nx)) * i, meta=fits.Header(header))], '')
+    test_images = [LCOCalibrationFrame([CCDData(np.ones((ny, nx)) * i, meta=fits.Header(header), name='SCI')], '')
                    for i in range(9)]
     for image in test_images:
         image.instrument = instrument
     stage = FakeStacker(context)
     stacked_data = stage.do_stage(test_images)
+    assert stacked_data['SCI'] is stacked_data.primary_hdu
     np.testing.assert_allclose(stacked_data.data, np.ones((ny, nx)) * np.mean(np.arange(9)))
     np.testing.assert_allclose(stacked_data.primary_hdu.uncertainty, np.ones((ny, nx)))
     assert np.all(stacked_data.mask == 0)
@@ -49,7 +49,7 @@ def test_stacking():
 
 def test_stacking_with_noise():
     test_images = [LCOCalibrationFrame([CCDData(np.random.normal(0.0, 3.0, size=(ny, nx)),
-                                                meta=fits.Header(header))], '')
+                                                meta=fits.Header(header), name='SCI')], '')
                    for i in range(81)]
     for image in test_images:
         image.instrument = instrument
@@ -62,7 +62,7 @@ def test_stacking_with_noise():
 
 def test_stacking_with_different_pixels():
     d = np.arange(nx*ny, dtype=np.float64).reshape(ny, nx)
-    test_images = [LCOCalibrationFrame([CCDData(d * i, meta=fits.Header(header))], '')
+    test_images = [LCOCalibrationFrame([CCDData(d * i, meta=fits.Header(header), name='SCI')], '')
                    for i in range(9)]
     for image in test_images:
         image.instrument = instrument
@@ -71,28 +71,3 @@ def test_stacking_with_different_pixels():
     np.testing.assert_allclose(stacked_data.data, d * np.mean(np.arange(9)))
     np.testing.assert_allclose(stacked_data.primary_hdu.uncertainty, np.ones((ny, nx)))
     assert np.all(stacked_data.mask == 0)
-
-
-def test_calibration_stacker_matches_pre_refactor_snapshot():
-    rng = np.random.default_rng(920381)
-    test_images = []
-    for i in range(7):
-        image_data = rng.normal(loc=i, scale=2.0, size=(ny, nx))
-        mask = np.zeros((ny, nx), dtype=np.uint8)
-        uncertainty = rng.uniform(1.0, 3.0, size=(ny, nx))
-        hdu = CCDData(image_data, meta=fits.Header(header), mask=mask, uncertainty=uncertainty)
-        test_images.append(LCOCalibrationFrame([hdu], ''))
-
-    test_images[0].primary_hdu.data[2, 3] = 1000.0
-    test_images[1].primary_hdu.mask[5, 7] = 1
-    test_images[3].primary_hdu.mask[11, 13] = 2
-    for image in test_images:
-        image.instrument = instrument
-
-    stage = FakeStacker(context)
-    stacked_data = stage.do_stage(test_images)
-    expected = pre_refactor_stack_snapshot([image.primary_hdu for image in test_images], 3.0)
-
-    assert np.array_equal(stacked_data.data, expected.data)
-    assert np.array_equal(stacked_data.primary_hdu.uncertainty, expected.uncertainty)
-    assert np.array_equal(stacked_data.mask, expected.mask)

--- a/banzai/tests/test_calibration_stacker.py
+++ b/banzai/tests/test_calibration_stacker.py
@@ -3,7 +3,7 @@ from banzai.data import CCDData
 from banzai.context import Context
 from banzai.calibrations import CalibrationStacker
 from banzai.dbs import Instrument
-from banzai.tests.utils import current_stack_snapshot
+from banzai.tests.utils import pre_refactor_stack_snapshot
 import numpy as np
 from astropy.io import fits
 import pytest
@@ -73,7 +73,7 @@ def test_stacking_with_different_pixels():
     assert np.all(stacked_data.mask == 0)
 
 
-def test_calibration_stacker_matches_current_stack_snapshot():
+def test_calibration_stacker_matches_pre_refactor_snapshot():
     rng = np.random.default_rng(920381)
     test_images = []
     for i in range(7):
@@ -91,7 +91,7 @@ def test_calibration_stacker_matches_current_stack_snapshot():
 
     stage = FakeStacker(context)
     stacked_data = stage.do_stage(test_images)
-    expected = current_stack_snapshot([image.primary_hdu for image in test_images], 3.0)
+    expected = pre_refactor_stack_snapshot([image.primary_hdu for image in test_images], 3.0)
 
     assert np.array_equal(stacked_data.data, expected.data)
     assert np.array_equal(stacked_data.primary_hdu.uncertainty, expected.uncertainty)

--- a/banzai/tests/test_dark_maker.py
+++ b/banzai/tests/test_dark_maker.py
@@ -29,7 +29,7 @@ def test_header_cal_type_dark(mock_namer):
                            'OBSTYPE': 'DARK'})
 
     image = maker.do_stage([FakeLCOObservationFrame(hdu_list=[FakeCCDData(data=np.zeros((ny,nx)),
-                                                                           meta=image_header)])
+                                                                           meta=image_header, name='SCI')])
                              for x in range(6)])
 
     assert image.meta['OBSTYPE'].upper() == 'DARK'
@@ -46,7 +46,7 @@ def test_makes_a_sensible_master_dark(mock_namer):
                            'DATASEC': '[1:100,1:100]',
                            'OBSTYPE': 'DARK'})
     images = [FakeLCOObservationFrame(hdu_list=[FakeCCDData(data=np.ones((ny, nx)) * x,
-                                                            meta=image_header)])
+                                                            meta=image_header, name='SCI')])
               for x in range(nimages)]
 
     expected_master_dark = stats.sigma_clipped_mean(np.arange(nimages), 3.0)

--- a/banzai/tests/test_flat_maker.py
+++ b/banzai/tests/test_flat_maker.py
@@ -31,7 +31,7 @@ def test_header_cal_type_flat(mock_namer):
                            'OBSTYPE': 'SKYFLAT',
                            'RA': 0.0,
                            'DEC': 0.0})
-    master_flat = maker.do_stage([FakeLCOObservationFrame(hdu_list=[FakeCCDData(meta=image_header)])
+    master_flat = maker.do_stage([FakeLCOObservationFrame(hdu_list=[FakeCCDData(meta=image_header, name='SCI')])
                                   for x in range(6)])
 
     assert master_flat.meta['OBSTYPE'].upper() == 'SKYFLAT'
@@ -55,9 +55,14 @@ def test_makes_a_sensible_master_flat(mock_namer):
                            'DEC': 0.0})
 
     flat_pattern = np.random.normal(1.0, master_flat_variation, size=(ny, nx))
-    images = [FakeLCOObservationFrame(hdu_list=[FakeCCDData(data=flat_pattern + np.random.normal(0.0, 0.02, size=(ny, nx)),
-                                                            meta=image_header)])
-              for _ in range(nimages)]
+    images = [
+        FakeLCOObservationFrame(hdu_list=[FakeCCDData(
+            data=flat_pattern + np.random.normal(0.0, 0.02, size=(ny, nx)),
+            meta=image_header,
+            name='SCI',
+        )])
+        for _ in range(nimages)
+    ]
 
     maker = FlatMaker(FakeContext())
     stacked_image = maker.do_stage(images)

--- a/banzai/tests/test_frames.py
+++ b/banzai/tests/test_frames.py
@@ -180,6 +180,19 @@ def test_trim():
     assert trimmed_data.uncertainty.shape == (945, 950)
 
 
+def test_trim_can_keep_views_of_existing_memory_maps():
+    meta = Header({'DATASEC': '[1:4,1:4]', 'DETSEC': '[1:4,1:4]'})
+    test_data = CCDData(data=np.arange(16, dtype=np.float64).reshape(4, 4), meta=meta,
+                        uncertainty=np.ones((4, 4), dtype=np.float64))
+
+    trimmed_data = test_data.trim(Section(x_start=1, x_stop=2, y_start=1, y_stop=2), memmap=False)
+
+    assert test_data.memmap is True
+    assert trimmed_data.memmap is False
+    assert isinstance(trimmed_data.data, np.memmap)
+    assert np.shares_memory(trimmed_data.data, test_data.data)
+
+
 def test_init_poisson_uncertainties():
     # Make sure the uncertainties add in quadrature
     nx = 101

--- a/banzai/tests/test_stacking.py
+++ b/banzai/tests/test_stacking.py
@@ -1,10 +1,24 @@
 import numpy as np
 import pytest
+from astropy.io import fits
 
-from banzai.data import stack
-from banzai.tests.utils import FakeCCDData
+from banzai import data as data_module
+from banzai.data import CCDData, stack
+from banzai.tests.utils import FakeCCDData, current_stack_snapshot
 
 pytestmark = pytest.mark.stacking
+
+
+def _make_ccd(data, mask=None, uncertainty=None):
+    data = np.asarray(data, dtype=np.float64)
+    meta = fits.Header({'DATASEC': f'[1:{data.shape[1]},1:{data.shape[0]}]',
+                        'DETSEC': f'[1:{data.shape[1]},1:{data.shape[0]}]',
+                        'CCDSUM': '1 1'})
+    if mask is None:
+        mask = np.zeros(data.shape, dtype=np.uint8)
+    if uncertainty is None:
+        uncertainty = np.ones(data.shape, dtype=data.dtype)
+    return FakeCCDData(data=data, mask=np.asarray(mask, dtype=np.uint8), uncertainty=np.asarray(uncertainty), meta=meta)
 
 
 @pytest.fixture(scope='module')
@@ -47,3 +61,127 @@ def test_stacking_with_different_pixels(set_random_seed):
     np.testing.assert_allclose(stacked_data.data, 4.0 * d)
     np.testing.assert_allclose(stacked_data.uncertainty, np.ones((ny, nx)))
     assert np.all(stacked_data.mask == 0)
+
+
+def test_stack_mean_matches_current_snapshot():
+    rng = np.random.default_rng(318209)
+    data_to_stack = []
+    for i in range(7):
+        data = rng.normal(loc=100.0 + i, scale=2.0, size=(6, 8))
+        mask = np.zeros(data.shape, dtype=np.uint8)
+        uncertainty = rng.uniform(0.5, 2.5, size=data.shape)
+        data_to_stack.append(_make_ccd(data, mask=mask, uncertainty=uncertainty))
+
+    data_to_stack[0].data[2, 3] = 1000.0
+    data_to_stack[1].mask[1, 2] = 1
+    data_to_stack[3].mask[4, 5] = 2
+    data_to_stack[5].mask[0, 0] = 4
+
+    expected = current_stack_snapshot(data_to_stack, 3.0)
+    actual_default = stack(data_to_stack, 3.0)
+
+    assert np.array_equal(actual_default.data, expected.data)
+    assert np.array_equal(actual_default.uncertainty, expected.uncertainty)
+    assert np.array_equal(actual_default.mask, expected.mask)
+
+    actual_mean = stack(data_to_stack, 3.0, method='mean')
+    assert np.array_equal(actual_mean.data, expected.data)
+    assert np.array_equal(actual_mean.uncertainty, expected.uncertainty)
+    assert np.array_equal(actual_mean.mask, expected.mask)
+
+
+def test_stack_sum_equals_mean_times_n_when_nothing_rejected():
+    data_to_stack = [_make_ccd(np.ones((3, 4)) * value) for value in [2.0, 4.0, 6.0, 8.0]]
+
+    stacked_mean = stack(data_to_stack, 1e5, method='mean')
+    stacked_sum = stack(data_to_stack, 1e5, method='sum')
+
+    np.testing.assert_allclose(stacked_sum.data, stacked_mean.data * len(data_to_stack))
+
+
+def test_stack_sum_uncertainty_scaling():
+    n_images = 5
+    sigma = 3.25
+    data_to_stack = [_make_ccd(np.ones((3, 4)), uncertainty=np.ones((3, 4)) * sigma) for _ in range(n_images)]
+
+    stacked_sum = stack(data_to_stack, 1e5, method='sum')
+
+    np.testing.assert_allclose(stacked_sum.uncertainty, np.ones((3, 4)) * np.sqrt(n_images) * sigma)
+
+
+def test_stack_rejects_outlier():
+    data_to_stack = [_make_ccd(np.ones((2, 2)) * 10.0) for _ in range(5)]
+    data_to_stack[2].data[0, 0] = 1010.0
+
+    stacked_sum = stack(data_to_stack, 3.0, method='sum')
+
+    assert stacked_sum.data[0, 0] == 50.0
+
+
+def test_stack_all_bad_pixel():
+    data_to_stack = [
+        _make_ccd([[1.0, 10.0]], mask=[[1, 0]], uncertainty=[[0.5, 1.0]]),
+        _make_ccd([[2.0, 10.0]], mask=[[2, 0]], uncertainty=[[0.5, 1.0]]),
+        _make_ccd([[3.0, 10.0]], mask=[[4, 0]], uncertainty=[[0.5, 1.0]]),
+    ]
+
+    stacked_sum = stack(data_to_stack, 3.0, method='sum')
+
+    assert stacked_sum.mask[0, 0] == 7
+    assert np.isfinite(stacked_sum.data[0, 0])
+    assert np.isfinite(stacked_sum.uncertainty[0, 0])
+
+
+def test_stack_n1_and_n2_do_not_reject():
+    one_image = [_make_ccd([[1000.0]])]
+    two_images = [_make_ccd([[0.0]]), _make_ccd([[1000.0]])]
+
+    assert stack(one_image, 3.0, method='sum').data[0, 0] == 1000.0
+    assert stack(two_images, 3.0, method='sum').data[0, 0] == 1000.0
+
+
+def test_stack_unknown_method_raises():
+    data_to_stack = [_make_ccd([[1.0]]), _make_ccd([[2.0]])]
+
+    with pytest.raises(ValueError):
+        stack(data_to_stack, 3.0, method='median')
+
+
+def test_combine_images_matches_whole_array():
+    rng = np.random.default_rng(826190)
+    data_to_stack = []
+    for value in [1.0, 2.0, 3.0]:
+        data_to_stack.append(_make_ccd(rng.normal(value, 0.1, size=(7, 4))))
+
+    data_to_stack[0].data[5, 2] = 1000.0
+    data_to_stack[1].mask[6, 1] = 1
+    output_frame = type('OutputFrame', (), {})()
+    output_frame.primary_hdu = _make_ccd(np.zeros((7, 4)))
+
+    data_module.combine_images(data_to_stack, output_frame, nsigma=3.0, method='sum')
+    expected = stack(data_to_stack, 3.0, method='sum')
+
+    np.testing.assert_allclose(output_frame.primary_hdu.data, expected.data)
+    np.testing.assert_allclose(output_frame.primary_hdu.uncertainty, expected.uncertainty)
+    assert np.array_equal(output_frame.primary_hdu.mask, expected.mask)
+
+
+def test_combine_images_warns_when_exposure_spread_exceeds_one_percent(monkeypatch):
+    warnings = []
+
+    class FakeLogger:
+        def warning(self, message, extra_tags=None):
+            warnings.append((message, extra_tags))
+
+    data_to_stack = [_make_ccd(np.ones((2, 2)) * value) for value in [1.0, 2.0, 3.0]]
+    for data, exptime in zip(data_to_stack, [10.0, 10.05, 10.2]):
+        data.meta['EXPTIME'] = exptime
+
+    output_frame = type('OutputFrame', (), {})()
+    output_frame.primary_hdu = _make_ccd(np.zeros((2, 2)))
+    monkeypatch.setattr(data_module, 'logger', FakeLogger(), raising=False)
+
+    data_module.combine_images(data_to_stack, output_frame, nsigma=3.0, method='mean')
+
+    assert len(warnings) == 1
+    assert warnings[0][1]['exptime_spread_fraction'] > 0.01

--- a/banzai/tests/test_stacking.py
+++ b/banzai/tests/test_stacking.py
@@ -4,7 +4,7 @@ from astropy.io import fits
 
 from banzai import data as data_module
 from banzai.data import CCDData, stack
-from banzai.tests.utils import FakeCCDData, current_stack_snapshot
+from banzai.tests.utils import FakeCCDData, pre_refactor_stack_snapshot
 
 pytestmark = pytest.mark.stacking
 
@@ -63,7 +63,7 @@ def test_stacking_with_different_pixels(set_random_seed):
     assert np.all(stacked_data.mask == 0)
 
 
-def test_stack_mean_matches_current_snapshot():
+def test_stack_mean_matches_pre_refactor_snapshot():
     rng = np.random.default_rng(318209)
     data_to_stack = []
     for i in range(7):
@@ -77,7 +77,7 @@ def test_stack_mean_matches_current_snapshot():
     data_to_stack[3].mask[4, 5] = 2
     data_to_stack[5].mask[0, 0] = 4
 
-    expected = current_stack_snapshot(data_to_stack, 3.0)
+    expected = pre_refactor_stack_snapshot(data_to_stack, 3.0)
     actual_default = stack(data_to_stack, 3.0)
 
     assert np.array_equal(actual_default.data, expected.data)

--- a/banzai/tests/test_stacking.py
+++ b/banzai/tests/test_stacking.py
@@ -3,13 +3,13 @@ import pytest
 from astropy.io import fits
 
 from banzai import data as data_module
-from banzai.data import CCDData, stack
-from banzai.tests.utils import FakeCCDData, pre_refactor_stack_snapshot
+from banzai.data import stack
+from banzai.tests.utils import FakeCCDData
 
 pytestmark = pytest.mark.stacking
 
 
-def _make_ccd(data, mask=None, uncertainty=None):
+def _make_ccd_data(data, mask=None, uncertainty=None):
     data = np.asarray(data, dtype=np.float64)
     meta = fits.Header({'DATASEC': f'[1:{data.shape[1]},1:{data.shape[0]}]',
                         'DETSEC': f'[1:{data.shape[1]},1:{data.shape[0]}]',
@@ -18,7 +18,8 @@ def _make_ccd(data, mask=None, uncertainty=None):
         mask = np.zeros(data.shape, dtype=np.uint8)
     if uncertainty is None:
         uncertainty = np.ones(data.shape, dtype=data.dtype)
-    return FakeCCDData(data=data, mask=np.asarray(mask, dtype=np.uint8), uncertainty=np.asarray(uncertainty), meta=meta)
+    return FakeCCDData(data=data, mask=np.asarray(mask, dtype=np.uint8),
+                       uncertainty=np.asarray(uncertainty), meta=meta)
 
 
 @pytest.fixture(scope='module')
@@ -63,35 +64,23 @@ def test_stacking_with_different_pixels(set_random_seed):
     assert np.all(stacked_data.mask == 0)
 
 
-def test_stack_mean_matches_pre_refactor_snapshot():
-    rng = np.random.default_rng(318209)
-    data_to_stack = []
-    for i in range(7):
-        data = rng.normal(loc=100.0 + i, scale=2.0, size=(6, 8))
-        mask = np.zeros(data.shape, dtype=np.uint8)
-        uncertainty = rng.uniform(0.5, 2.5, size=data.shape)
-        data_to_stack.append(_make_ccd(data, mask=mask, uncertainty=uncertainty))
+def test_stack_mean_with_rejection_and_masks():
+    data_to_stack = [
+        _make_ccd_data([[10.0, 1.0, 10.0]], mask=[[0, 1, 0]], uncertainty=[[1.0, 0.5, 1.0]]),
+        _make_ccd_data([[10.0, 2.0, 10.0]], mask=[[0, 2, 0]], uncertainty=[[1.0, 0.5, 1.0]]),
+        _make_ccd_data([[10.0, 3.0, 1000.0]], mask=[[0, 4, 0]], uncertainty=[[1.0, 0.5, 1.0]]),
+    ]
 
-    data_to_stack[0].data[2, 3] = 1000.0
-    data_to_stack[1].mask[1, 2] = 1
-    data_to_stack[3].mask[4, 5] = 2
-    data_to_stack[5].mask[0, 0] = 4
+    stacked_mean = stack(data_to_stack, 3.0, method='mean')
 
-    expected = pre_refactor_stack_snapshot(data_to_stack, 3.0)
-    actual_default = stack(data_to_stack, 3.0)
-
-    assert np.array_equal(actual_default.data, expected.data)
-    assert np.array_equal(actual_default.uncertainty, expected.uncertainty)
-    assert np.array_equal(actual_default.mask, expected.mask)
-
-    actual_mean = stack(data_to_stack, 3.0, method='mean')
-    assert np.array_equal(actual_mean.data, expected.data)
-    assert np.array_equal(actual_mean.uncertainty, expected.uncertainty)
-    assert np.array_equal(actual_mean.mask, expected.mask)
+    np.testing.assert_allclose(stacked_mean.data, [[10.0, 2.0, 10.0]])
+    np.testing.assert_allclose(stacked_mean.uncertainty,
+                               [[1.0 / np.sqrt(3.0), 0.5 / np.sqrt(3.0), 1.0 / np.sqrt(2.0)]])
+    assert np.array_equal(stacked_mean.mask, [[0, 7, 0]])
 
 
 def test_stack_sum_equals_mean_times_n_when_nothing_rejected():
-    data_to_stack = [_make_ccd(np.ones((3, 4)) * value) for value in [2.0, 4.0, 6.0, 8.0]]
+    data_to_stack = [_make_ccd_data(np.ones((3, 4)) * value) for value in [2.0, 4.0, 6.0, 8.0]]
 
     stacked_mean = stack(data_to_stack, 1e5, method='mean')
     stacked_sum = stack(data_to_stack, 1e5, method='sum')
@@ -102,7 +91,10 @@ def test_stack_sum_equals_mean_times_n_when_nothing_rejected():
 def test_stack_sum_uncertainty_scaling():
     n_images = 5
     sigma = 3.25
-    data_to_stack = [_make_ccd(np.ones((3, 4)), uncertainty=np.ones((3, 4)) * sigma) for _ in range(n_images)]
+    data_to_stack = [
+        _make_ccd_data(np.ones((3, 4)), uncertainty=np.ones((3, 4)) * sigma)
+        for _ in range(n_images)
+    ]
 
     stacked_sum = stack(data_to_stack, 1e5, method='sum')
 
@@ -110,7 +102,7 @@ def test_stack_sum_uncertainty_scaling():
 
 
 def test_stack_rejects_outlier():
-    data_to_stack = [_make_ccd(np.ones((2, 2)) * 10.0) for _ in range(5)]
+    data_to_stack = [_make_ccd_data(np.ones((2, 2)) * 10.0) for _ in range(5)]
     data_to_stack[2].data[0, 0] = 1010.0
 
     stacked_sum = stack(data_to_stack, 3.0, method='sum')
@@ -120,9 +112,9 @@ def test_stack_rejects_outlier():
 
 def test_stack_all_bad_pixel():
     data_to_stack = [
-        _make_ccd([[1.0, 10.0]], mask=[[1, 0]], uncertainty=[[0.5, 1.0]]),
-        _make_ccd([[2.0, 10.0]], mask=[[2, 0]], uncertainty=[[0.5, 1.0]]),
-        _make_ccd([[3.0, 10.0]], mask=[[4, 0]], uncertainty=[[0.5, 1.0]]),
+        _make_ccd_data([[1.0, 10.0]], mask=[[1, 0]], uncertainty=[[0.5, 1.0]]),
+        _make_ccd_data([[2.0, 10.0]], mask=[[2, 0]], uncertainty=[[0.5, 1.0]]),
+        _make_ccd_data([[3.0, 10.0]], mask=[[4, 0]], uncertainty=[[0.5, 1.0]]),
     ]
 
     stacked_sum = stack(data_to_stack, 3.0, method='sum')
@@ -133,17 +125,17 @@ def test_stack_all_bad_pixel():
 
 
 def test_stack_n1_and_n2_do_not_reject():
-    one_image = [_make_ccd([[1000.0]])]
-    two_images = [_make_ccd([[0.0]]), _make_ccd([[1000.0]])]
+    one_image = [_make_ccd_data([[1000.0]])]
+    two_images = [_make_ccd_data([[0.0]]), _make_ccd_data([[1000.0]])]
 
     assert stack(one_image, 3.0, method='sum').data[0, 0] == 1000.0
     assert stack(two_images, 3.0, method='sum').data[0, 0] == 1000.0
 
 
 def test_stack_unknown_method_raises():
-    data_to_stack = [_make_ccd([[1.0]]), _make_ccd([[2.0]])]
+    data_to_stack = [_make_ccd_data([[1.0]]), _make_ccd_data([[2.0]])]
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="Unknown stack method: 'median'; expected 'mean' or 'sum'"):
         stack(data_to_stack, 3.0, method='median')
 
 
@@ -151,37 +143,40 @@ def test_combine_images_matches_whole_array():
     rng = np.random.default_rng(826190)
     data_to_stack = []
     for value in [1.0, 2.0, 3.0]:
-        data_to_stack.append(_make_ccd(rng.normal(value, 0.1, size=(7, 4))))
+        data_to_stack.append(_make_ccd_data(rng.normal(value, 0.1, size=(7, 4))))
+    original_memmap_flags = [data.memmap for data in data_to_stack]
 
     data_to_stack[0].data[5, 2] = 1000.0
     data_to_stack[1].mask[6, 1] = 1
-    output_frame = type('OutputFrame', (), {})()
-    output_frame.primary_hdu = _make_ccd(np.zeros((7, 4)))
+    output_image = _make_ccd_data(np.zeros((7, 4)))
 
-    data_module.combine_images(data_to_stack, output_frame, nsigma=3.0, method='sum')
+    result = data_module.combine_images(data_to_stack, output_image, nsigma=3.0, method='sum')
     expected = stack(data_to_stack, 3.0, method='sum')
 
-    np.testing.assert_allclose(output_frame.primary_hdu.data, expected.data)
-    np.testing.assert_allclose(output_frame.primary_hdu.uncertainty, expected.uncertainty)
-    assert np.array_equal(output_frame.primary_hdu.mask, expected.mask)
+    assert result is output_image
+    np.testing.assert_allclose(output_image.data, expected.data)
+    np.testing.assert_allclose(output_image.uncertainty, expected.uncertainty)
+    assert np.array_equal(output_image.mask, expected.mask)
+    assert [data.memmap for data in data_to_stack] == original_memmap_flags
 
 
-def test_combine_images_warns_when_exposure_spread_exceeds_one_percent(monkeypatch):
+@pytest.mark.parametrize(('method', 'warns'), [('sum', True), ('mean', False)])
+def test_combine_images_exposure_warning_depends_on_method(monkeypatch, method, warns):
     warnings = []
 
     class FakeLogger:
         def warning(self, message, extra_tags=None):
             warnings.append((message, extra_tags))
 
-    data_to_stack = [_make_ccd(np.ones((2, 2)) * value) for value in [1.0, 2.0, 3.0]]
+    data_to_stack = [_make_ccd_data(np.ones((2, 2)) * value) for value in [1.0, 2.0, 3.0]]
     for data, exptime in zip(data_to_stack, [10.0, 10.05, 10.2]):
         data.meta['EXPTIME'] = exptime
 
-    output_frame = type('OutputFrame', (), {})()
-    output_frame.primary_hdu = _make_ccd(np.zeros((2, 2)))
+    output_image = _make_ccd_data(np.zeros((2, 2)))
     monkeypatch.setattr(data_module, 'logger', FakeLogger(), raising=False)
 
-    data_module.combine_images(data_to_stack, output_frame, nsigma=3.0, method='mean')
+    data_module.combine_images(data_to_stack, output_image, nsigma=3.0, method=method)
 
-    assert len(warnings) == 1
-    assert warnings[0][1]['exptime_spread_fraction'] > 0.01
+    assert bool(warnings) is warns
+    if warns:
+        assert warnings[0][1]['exptime_spread_fraction'] > 0.01

--- a/banzai/tests/utils.py
+++ b/banzai/tests/utils.py
@@ -11,6 +11,7 @@ from banzai.lco import LCOObservationFrame, LCOCalibrationFrame
 from banzai.utils.image_utils import Section
 from banzai.data import HeaderOnly, CCDData
 from banzai.utils.date_utils import TIMESTAMP_FORMAT
+from banzai.utils import stats
 from banzai.logs import get_logger
 
 logger = get_logger()
@@ -52,6 +53,52 @@ class FakeCCDData(CCDData):
             self.meta['MAXLIN'] = 65535.0
         for keyword in kwargs:
             setattr(self, keyword, kwargs[keyword])
+
+
+def current_stack_snapshot(data_to_stack, nsigma_reject):
+    shape3d = [len(data_to_stack)] + list(data_to_stack[0].shape)
+    a = np.zeros(shape3d, dtype=data_to_stack[0].dtype)
+    uncertainties = np.zeros(shape3d, dtype=data_to_stack[0].dtype)
+    mask = np.zeros(shape3d, dtype=np.uint8)
+
+    for i, data in enumerate(data_to_stack):
+        a[i, :, :] = data.data[:, :]
+        mask[i, :, :] = data.mask[:, :]
+        uncertainties[i, :, :] = data.uncertainty[:, :]
+
+    abs_deviation = stats.absolute_deviation(a, axis=0, mask=mask)
+
+    robust_std = stats.robust_standard_deviation(a, axis=0, abs_deviation=abs_deviation, mask=mask)
+
+    robust_std = np.expand_dims(robust_std, axis=0)
+
+    # Mask values that are N sigma from the median
+    sigma_mask = abs_deviation > (nsigma_reject * robust_std)
+
+    mask3d = np.logical_or(sigma_mask, mask > 0)
+    n_good_pixels = np.logical_not(mask3d).sum(axis=0)
+
+    stacked_mask = np.zeros(n_good_pixels.shape, dtype=np.uint8)
+
+    # If a pixel is bad in all images, make sure we don't divide by zero
+    bad_pixels = n_good_pixels == 0
+
+    # If pixel is bad in all of the images, we take the logical or of all of the bits to go in the final mask
+    stacked_mask[bad_pixels] = np.bitwise_or.reduce(mask, axis=0)[bad_pixels]
+
+    # If a pixel is bad in all images, fill that pixel with the mean from the images
+    n_good_pixels[bad_pixels] = len(data_to_stack)
+    mask3d[:, bad_pixels] = False
+
+    a[mask3d] = 0.0
+    stacked_data = a.sum(axis=0) / n_good_pixels
+
+    # Again if a pixel is bad in all images, fill the uncertainties with the quadrature sum / N images
+    uncertainties[mask3d] = 0.0
+    uncertainties *= uncertainties
+    stacked_uncertainty = np.sqrt(uncertainties.sum(axis=0) / (n_good_pixels ** 2.0))
+
+    return CCDData(data=stacked_data, meta=data_to_stack[0].meta, uncertainty=stacked_uncertainty, mask=stacked_mask)
 
 
 class FakeLCOObservationFrame(LCOObservationFrame):

--- a/banzai/tests/utils.py
+++ b/banzai/tests/utils.py
@@ -55,7 +55,7 @@ class FakeCCDData(CCDData):
             setattr(self, keyword, kwargs[keyword])
 
 
-def current_stack_snapshot(data_to_stack, nsigma_reject):
+def pre_refactor_stack_snapshot(data_to_stack, nsigma_reject):
     """Return the pre-refactor mean-stack result for regression comparisons only."""
     shape3d = [len(data_to_stack)] + list(data_to_stack[0].shape)
     a = np.zeros(shape3d, dtype=data_to_stack[0].dtype)

--- a/banzai/tests/utils.py
+++ b/banzai/tests/utils.py
@@ -56,6 +56,7 @@ class FakeCCDData(CCDData):
 
 
 def current_stack_snapshot(data_to_stack, nsigma_reject):
+    """Return the pre-refactor mean-stack result for regression comparisons only."""
     shape3d = [len(data_to_stack)] + list(data_to_stack[0].shape)
     a = np.zeros(shape3d, dtype=data_to_stack[0].dtype)
     uncertainties = np.zeros(shape3d, dtype=data_to_stack[0].dtype)

--- a/banzai/tests/utils.py
+++ b/banzai/tests/utils.py
@@ -11,7 +11,6 @@ from banzai.lco import LCOObservationFrame, LCOCalibrationFrame
 from banzai.utils.image_utils import Section
 from banzai.data import HeaderOnly, CCDData
 from banzai.utils.date_utils import TIMESTAMP_FORMAT
-from banzai.utils import stats
 from banzai.logs import get_logger
 
 logger = get_logger()
@@ -55,53 +54,6 @@ class FakeCCDData(CCDData):
             setattr(self, keyword, kwargs[keyword])
 
 
-def pre_refactor_stack_snapshot(data_to_stack, nsigma_reject):
-    """Return the pre-refactor mean-stack result for regression comparisons only."""
-    shape3d = [len(data_to_stack)] + list(data_to_stack[0].shape)
-    a = np.zeros(shape3d, dtype=data_to_stack[0].dtype)
-    uncertainties = np.zeros(shape3d, dtype=data_to_stack[0].dtype)
-    mask = np.zeros(shape3d, dtype=np.uint8)
-
-    for i, data in enumerate(data_to_stack):
-        a[i, :, :] = data.data[:, :]
-        mask[i, :, :] = data.mask[:, :]
-        uncertainties[i, :, :] = data.uncertainty[:, :]
-
-    abs_deviation = stats.absolute_deviation(a, axis=0, mask=mask)
-
-    robust_std = stats.robust_standard_deviation(a, axis=0, abs_deviation=abs_deviation, mask=mask)
-
-    robust_std = np.expand_dims(robust_std, axis=0)
-
-    # Mask values that are N sigma from the median
-    sigma_mask = abs_deviation > (nsigma_reject * robust_std)
-
-    mask3d = np.logical_or(sigma_mask, mask > 0)
-    n_good_pixels = np.logical_not(mask3d).sum(axis=0)
-
-    stacked_mask = np.zeros(n_good_pixels.shape, dtype=np.uint8)
-
-    # If a pixel is bad in all images, make sure we don't divide by zero
-    bad_pixels = n_good_pixels == 0
-
-    # If pixel is bad in all of the images, we take the logical or of all of the bits to go in the final mask
-    stacked_mask[bad_pixels] = np.bitwise_or.reduce(mask, axis=0)[bad_pixels]
-
-    # If a pixel is bad in all images, fill that pixel with the mean from the images
-    n_good_pixels[bad_pixels] = len(data_to_stack)
-    mask3d[:, bad_pixels] = False
-
-    a[mask3d] = 0.0
-    stacked_data = a.sum(axis=0) / n_good_pixels
-
-    # Again if a pixel is bad in all images, fill the uncertainties with the quadrature sum / N images
-    uncertainties[mask3d] = 0.0
-    uncertainties *= uncertainties
-    stacked_uncertainty = np.sqrt(uncertainties.sum(axis=0) / (n_good_pixels ** 2.0))
-
-    return CCDData(data=stacked_data, meta=data_to_stack[0].meta, uncertainty=stacked_uncertainty, mask=stacked_mask)
-
-
 class FakeLCOObservationFrame(LCOObservationFrame):
     def __init__(self, hdu_list=None, file_path='/tmp/test_image.fits', instrument=None, epoch='20160101',
                  **kwargs):
@@ -109,6 +61,7 @@ class FakeLCOObservationFrame(LCOObservationFrame):
             self._hdus = [FakeCCDData()]
         else:
             self._hdus = hdu_list
+        self._hdu_mapping = {hdu.name: i for i, hdu in enumerate(self._hdus)}
         if instrument is None:
             self.instrument = FakeInstrument(0, 'cpt', 'fa16', 'doma', '1m0a', '1M-SCICAM-SINISTRO', schedulable=True)
         else:


### PR DESCRIPTION
This is the first of four PRs that can be reviewed independently in service of smartstacking now that the scaffolding is in place.

The calibration stacking code has been refactored so that it can be reused for smartstacking as well. Added method="sum" for smartstacks, in addition to the existing mean capabilities used for calibrations. 

I've included regression coverage with the prior implementation in pre_refactor_stack_snapshot to demonstrate that behavior for calibration frames has not changed. Is this useful to keep around long term? 

I have _warn_if_exposure_times_differ for all stacks, which issues a warning if exposures times differ by more than 1%. If calibration frames use different exposure times then I can have this only run for smartstacks. 