### PR TITLE
JPG utils for smartstacks

### DIFF
--- a/banzai/tests/test_file_utils.py
+++ b/banzai/tests/test_file_utils.py
@@ -1,0 +1,63 @@
+import pytest
+
+from banzai.utils import file_utils
+
+pytestmark = pytest.mark.smart_stacking
+
+
+def test_make_smartstack_filename_basic():
+    filename = file_utils.make_smartstack_filename('tst2m002-xx06-20260213-0031-e09.fits', 31, 42)
+
+    assert filename == 'tst2m002-xx06-20260213-0031-0042-e45.fits'
+
+
+def test_make_smartstack_filename_fz():
+    filename = file_utils.make_smartstack_filename('tst2m002-xx06-20260213-0031-e09.fits.fz', 31, 42)
+
+    assert filename == 'tst2m002-xx06-20260213-0031-0042-e45.fits.fz'
+
+
+def test_make_smartstack_filename_x_kind():
+    filename = file_utils.make_smartstack_filename('tst2m002-xx06-20260213-0031-x09.fits', 31, 42)
+
+    assert filename == 'tst2m002-xx06-20260213-0031-0042-x45.fits'
+
+
+def test_make_smartstack_filename_width():
+    filename = file_utils.make_smartstack_filename('tst2m002-xx06-20260213-000031-e09.fits', 31, 42)
+
+    assert filename == 'tst2m002-xx06-20260213-000031-000042-e45.fits'
+
+
+def test_make_smartstack_filename_single_frame():
+    filename = file_utils.make_smartstack_filename('tst2m002-xx06-20260213-0031-e09.fits', 31, 31)
+
+    assert filename == 'tst2m002-xx06-20260213-0031-0031-e45.fits'
+
+
+def test_make_smartstack_filename_garbage_raises():
+    with pytest.raises(ValueError):
+        file_utils.make_smartstack_filename('not-a-reduced-frame.txt', 31, 42)
+
+
+@pytest.mark.parametrize(
+    'smartstack_filename,expected',
+    [
+        (
+            'tst2m002-xx06-20260213-0031-0042-e45.fits',
+            ('tst2m002-xx06-20260213-0031-0042-e45-small_thumbnail.jpg',
+             'tst2m002-xx06-20260213-0031-0042-e45-large_thumbnail.jpg'),
+        ),
+        (
+            'tst2m002-xx06-20260213-0031-0042-e45.fits.fz',
+            ('tst2m002-xx06-20260213-0031-0042-e45-small_thumbnail.jpg',
+             'tst2m002-xx06-20260213-0031-0042-e45-large_thumbnail.jpg'),
+        ),
+    ],
+)
+def test_make_jpg_filenames(smartstack_filename, expected):
+    filenames = file_utils.make_jpg_filenames(smartstack_filename)
+
+    assert filenames == expected
+    assert filenames[0].endswith('-small_thumbnail.jpg')
+    assert filenames[1].endswith('-large_thumbnail.jpg')

--- a/banzai/tests/test_file_utils.py
+++ b/banzai/tests/test_file_utils.py
@@ -12,9 +12,10 @@ def test_make_smartstack_filename_basic():
     assert filename == 'tst2m002-xx06-20260213-0031-0042-e45.fits'
 
 
-def test_make_smartstack_filename_fz():
+@pytest.mark.parametrize('last_suffix', ['.fits.fz', '.fits'])
+def test_make_smartstack_filename_fz(last_suffix):
     filename = file_utils.make_smartstack_filename('tst2m002-xx06-20260213-0031-e09.fits.fz',
-                                                   'tst2m002-xx06-20260213-0042-e09.fits.fz')
+                                                   f'tst2m002-xx06-20260213-0042-e09{last_suffix}')
 
     assert filename == 'tst2m002-xx06-20260213-0031-0042-e45.fits.fz'
 
@@ -72,6 +73,23 @@ def test_make_smartstack_filename_garbage_last_raises():
                                             'not-a-reduced-frame.txt')
 
 
+@pytest.mark.parametrize('last_filename', [
+    'ogg2m001-fs02-20260213-0042-e09.fits',
+    'tst2m002-xx06-20260214-0042-e09.fits',
+    'tst2m002-xx06-20260213-0042-x09.fits',
+    'tst2m002-xx06-20260213-0042-e91.fits',
+])
+def test_make_smartstack_filename_incompatible_input_raises(last_filename):
+    with pytest.raises(ValueError, match='Incompatible smartstack input filenames'):
+        file_utils.make_smartstack_filename('tst2m002-xx06-20260213-0031-e09.fits', last_filename)
+
+
+def test_make_smartstack_filename_reversed_range_raises():
+    with pytest.raises(ValueError, match='range is reversed'):
+        file_utils.make_smartstack_filename('tst2m002-xx06-20260213-0042-e09.fits',
+                                            'tst2m002-xx06-20260213-0031-e09.fits')
+
+
 @pytest.mark.parametrize(
     'smartstack_filename,expected',
     [
@@ -91,5 +109,3 @@ def test_make_jpg_filenames(smartstack_filename, expected):
     filenames = file_utils.make_jpg_filenames(smartstack_filename)
 
     assert filenames == expected
-    assert filenames[0].endswith('-small_thumbnail.jpg')
-    assert filenames[1].endswith('-large_thumbnail.jpg')

--- a/banzai/tests/test_file_utils.py
+++ b/banzai/tests/test_file_utils.py
@@ -6,31 +6,6 @@ pytestmark = pytest.mark.smart_stacking
 
 
 @pytest.mark.parametrize(
-    'first_filename,expected',
-    [
-        ('tst2m002-xx06-20260213-0031-e09.fits', 'tst2m002-xx06-20260213-0031-e45.fits'),
-        ('tst2m002-xx06-20260213-0031-e09.fits.fz', 'tst2m002-xx06-20260213-0031-e45.fits.fz'),
-        ('tst2m002-xx06-20260213-0031-x09.fits', 'tst2m002-xx06-20260213-0031-x45.fits'),
-        ('/data/tst2m002-xx06-20260213-000031-e09.fits', 'tst2m002-xx06-20260213-000031-e45.fits'),
-    ],
-)
-def test_make_smartstack_filename(first_filename, expected):
-    assert file_utils.make_smartstack_filename(first_filename) == expected
-
-
-def test_make_smartstack_filename_same_night_stacks_do_not_collide():
-    first_stack = file_utils.make_smartstack_filename('tfn0m419-sq32-20260712-0202-e09.fits')
-    second_stack = file_utils.make_smartstack_filename('tfn0m419-sq32-20260712-0216-e09.fits')
-
-    assert first_stack != second_stack
-
-
-def test_make_smartstack_filename_garbage_first_raises():
-    with pytest.raises(ValueError):
-        file_utils.make_smartstack_filename('not-a-reduced-frame.txt')
-
-
-@pytest.mark.parametrize(
     'smartstack_filename,expected',
     [
         (

--- a/banzai/tests/test_file_utils.py
+++ b/banzai/tests/test_file_utils.py
@@ -5,103 +5,43 @@ from banzai.utils import file_utils
 pytestmark = pytest.mark.smart_stacking
 
 
-def test_make_smartstack_filename_basic():
-    filename = file_utils.make_smartstack_filename('tst2m002-xx06-20260213-0031-e09.fits',
-                                                   'tst2m002-xx06-20260213-0042-e09.fits')
-
-    assert filename == 'tst2m002-xx06-20260213-0031-0042-e45.fits'
-
-
-@pytest.mark.parametrize('last_suffix', ['.fits.fz', '.fits'])
-def test_make_smartstack_filename_fz(last_suffix):
-    filename = file_utils.make_smartstack_filename('tst2m002-xx06-20260213-0031-e09.fits.fz',
-                                                   f'tst2m002-xx06-20260213-0042-e09{last_suffix}')
-
-    assert filename == 'tst2m002-xx06-20260213-0031-0042-e45.fits.fz'
-
-
-def test_make_smartstack_filename_x_kind():
-    filename = file_utils.make_smartstack_filename('tst2m002-xx06-20260213-0031-x09.fits',
-                                                   'tst2m002-xx06-20260213-0042-x09.fits')
-
-    assert filename == 'tst2m002-xx06-20260213-0031-0042-x45.fits'
-
-
-def test_make_smartstack_filename_width():
-    filename = file_utils.make_smartstack_filename('tst2m002-xx06-20260213-000031-e09.fits',
-                                                   'tst2m002-xx06-20260213-000042-e09.fits')
-
-    assert filename == 'tst2m002-xx06-20260213-000031-000042-e45.fits'
-
-
-def test_make_smartstack_filename_single_frame():
-    filename = file_utils.make_smartstack_filename('tst2m002-xx06-20260213-0031-e09.fits',
-                                                   'tst2m002-xx06-20260213-0031-e09.fits')
-
-    assert filename == 'tst2m002-xx06-20260213-0031-0031-e45.fits'
-
-
-def test_make_smartstack_filename_nonsequential_file_numbers():
-    # File numbers, not stack positions, drive the range: a group whose inputs are
-    # frames 0216..0227 must not be named 0001-0012.
-    filename = file_utils.make_smartstack_filename('tfn0m419-sq32-20260712-0216-e09.fits',
-                                                   'tfn0m419-sq32-20260712-0227-e09.fits')
-
-    assert filename == 'tfn0m419-sq32-20260712-0216-0227-e45.fits'
+@pytest.mark.parametrize(
+    'first_filename,expected',
+    [
+        ('tst2m002-xx06-20260213-0031-e09.fits', 'tst2m002-xx06-20260213-0031-e45.fits'),
+        ('tst2m002-xx06-20260213-0031-e09.fits.fz', 'tst2m002-xx06-20260213-0031-e45.fits.fz'),
+        ('tst2m002-xx06-20260213-0031-x09.fits', 'tst2m002-xx06-20260213-0031-x45.fits'),
+        ('/data/tst2m002-xx06-20260213-000031-e09.fits', 'tst2m002-xx06-20260213-000031-e45.fits'),
+    ],
+)
+def test_make_smartstack_filename(first_filename, expected):
+    assert file_utils.make_smartstack_filename(first_filename) == expected
 
 
 def test_make_smartstack_filename_same_night_stacks_do_not_collide():
-    # Regression: two stacks from one camera on one night must get distinct product
-    # names even when they contain the same number of frames.
-    first_stack = file_utils.make_smartstack_filename('tfn0m419-sq32-20260712-0202-e09.fits',
-                                                      'tfn0m419-sq32-20260712-0207-e09.fits')
-    second_stack = file_utils.make_smartstack_filename('tfn0m419-sq32-20260712-0216-e09.fits',
-                                                       'tfn0m419-sq32-20260712-0221-e09.fits')
+    first_stack = file_utils.make_smartstack_filename('tfn0m419-sq32-20260712-0202-e09.fits')
+    second_stack = file_utils.make_smartstack_filename('tfn0m419-sq32-20260712-0216-e09.fits')
 
     assert first_stack != second_stack
 
 
 def test_make_smartstack_filename_garbage_first_raises():
     with pytest.raises(ValueError):
-        file_utils.make_smartstack_filename('not-a-reduced-frame.txt',
-                                            'tst2m002-xx06-20260213-0042-e09.fits')
-
-
-def test_make_smartstack_filename_garbage_last_raises():
-    with pytest.raises(ValueError):
-        file_utils.make_smartstack_filename('tst2m002-xx06-20260213-0031-e09.fits',
-                                            'not-a-reduced-frame.txt')
-
-
-@pytest.mark.parametrize('last_filename', [
-    'ogg2m001-fs02-20260213-0042-e09.fits',
-    'tst2m002-xx06-20260214-0042-e09.fits',
-    'tst2m002-xx06-20260213-0042-x09.fits',
-    'tst2m002-xx06-20260213-0042-e91.fits',
-])
-def test_make_smartstack_filename_incompatible_input_raises(last_filename):
-    with pytest.raises(ValueError, match='Incompatible smartstack input filenames'):
-        file_utils.make_smartstack_filename('tst2m002-xx06-20260213-0031-e09.fits', last_filename)
-
-
-def test_make_smartstack_filename_reversed_range_raises():
-    with pytest.raises(ValueError, match='range is reversed'):
-        file_utils.make_smartstack_filename('tst2m002-xx06-20260213-0042-e09.fits',
-                                            'tst2m002-xx06-20260213-0031-e09.fits')
+        file_utils.make_smartstack_filename('not-a-reduced-frame.txt')
 
 
 @pytest.mark.parametrize(
     'smartstack_filename,expected',
     [
         (
-            'tst2m002-xx06-20260213-0031-0042-e45.fits',
-            ('tst2m002-xx06-20260213-0031-0042-e45-small_thumbnail.jpg',
-             'tst2m002-xx06-20260213-0031-0042-e45-large_thumbnail.jpg'),
+            'tst2m002-xx06-20260213-0031-e45.fits',
+            ('tst2m002-xx06-20260213-0031-e45-small_thumbnail.jpg',
+             'tst2m002-xx06-20260213-0031-e45-large_thumbnail.jpg'),
         ),
         (
-            'tst2m002-xx06-20260213-0031-0042-e45.fits.fz',
-            ('tst2m002-xx06-20260213-0031-0042-e45-small_thumbnail.jpg',
-             'tst2m002-xx06-20260213-0031-0042-e45-large_thumbnail.jpg'),
+            'tst2m002-xx06-20260213-0031-e45.fits.fz',
+            ('tst2m002-xx06-20260213-0031-e45-small_thumbnail.jpg',
+             'tst2m002-xx06-20260213-0031-e45-large_thumbnail.jpg'),
         ),
     ],
 )

--- a/banzai/tests/test_file_utils.py
+++ b/banzai/tests/test_file_utils.py
@@ -6,38 +6,70 @@ pytestmark = pytest.mark.smart_stacking
 
 
 def test_make_smartstack_filename_basic():
-    filename = file_utils.make_smartstack_filename('tst2m002-xx06-20260213-0031-e09.fits', 31, 42)
+    filename = file_utils.make_smartstack_filename('tst2m002-xx06-20260213-0031-e09.fits',
+                                                   'tst2m002-xx06-20260213-0042-e09.fits')
 
     assert filename == 'tst2m002-xx06-20260213-0031-0042-e45.fits'
 
 
 def test_make_smartstack_filename_fz():
-    filename = file_utils.make_smartstack_filename('tst2m002-xx06-20260213-0031-e09.fits.fz', 31, 42)
+    filename = file_utils.make_smartstack_filename('tst2m002-xx06-20260213-0031-e09.fits.fz',
+                                                   'tst2m002-xx06-20260213-0042-e09.fits.fz')
 
     assert filename == 'tst2m002-xx06-20260213-0031-0042-e45.fits.fz'
 
 
 def test_make_smartstack_filename_x_kind():
-    filename = file_utils.make_smartstack_filename('tst2m002-xx06-20260213-0031-x09.fits', 31, 42)
+    filename = file_utils.make_smartstack_filename('tst2m002-xx06-20260213-0031-x09.fits',
+                                                   'tst2m002-xx06-20260213-0042-x09.fits')
 
     assert filename == 'tst2m002-xx06-20260213-0031-0042-x45.fits'
 
 
 def test_make_smartstack_filename_width():
-    filename = file_utils.make_smartstack_filename('tst2m002-xx06-20260213-000031-e09.fits', 31, 42)
+    filename = file_utils.make_smartstack_filename('tst2m002-xx06-20260213-000031-e09.fits',
+                                                   'tst2m002-xx06-20260213-000042-e09.fits')
 
     assert filename == 'tst2m002-xx06-20260213-000031-000042-e45.fits'
 
 
 def test_make_smartstack_filename_single_frame():
-    filename = file_utils.make_smartstack_filename('tst2m002-xx06-20260213-0031-e09.fits', 31, 31)
+    filename = file_utils.make_smartstack_filename('tst2m002-xx06-20260213-0031-e09.fits',
+                                                   'tst2m002-xx06-20260213-0031-e09.fits')
 
     assert filename == 'tst2m002-xx06-20260213-0031-0031-e45.fits'
 
 
-def test_make_smartstack_filename_garbage_raises():
+def test_make_smartstack_filename_nonsequential_file_numbers():
+    # File numbers, not stack positions, drive the range: a group whose inputs are
+    # frames 0216..0227 must not be named 0001-0012.
+    filename = file_utils.make_smartstack_filename('tfn0m419-sq32-20260712-0216-e09.fits',
+                                                   'tfn0m419-sq32-20260712-0227-e09.fits')
+
+    assert filename == 'tfn0m419-sq32-20260712-0216-0227-e45.fits'
+
+
+def test_make_smartstack_filename_same_night_stacks_do_not_collide():
+    # Regression: two stacks from one camera on one night must get distinct product
+    # names even when they contain the same number of frames.
+    first_stack = file_utils.make_smartstack_filename('tfn0m419-sq32-20260712-0202-e09.fits',
+                                                      'tfn0m419-sq32-20260712-0207-e09.fits')
+    second_stack = file_utils.make_smartstack_filename('tfn0m419-sq32-20260712-0216-e09.fits',
+                                                       'tfn0m419-sq32-20260712-0221-e09.fits')
+
+    assert first_stack != second_stack
+
+
+def test_make_smartstack_filename_garbage_first_raises():
     with pytest.raises(ValueError):
-        file_utils.make_smartstack_filename('not-a-reduced-frame.txt', 31, 42)
+        file_utils.make_smartstack_filename('not-a-reduced-frame.txt',
+                                            'tst2m002-xx06-20260213-0042-e09.fits')
+
+
+def test_make_smartstack_filename_garbage_last_raises():
+    with pytest.raises(ValueError):
+        file_utils.make_smartstack_filename('tst2m002-xx06-20260213-0031-e09.fits',
+                                            'not-a-reduced-frame.txt')
 
 
 @pytest.mark.parametrize(

--- a/banzai/tests/test_jpg_utils.py
+++ b/banzai/tests/test_jpg_utils.py
@@ -24,7 +24,7 @@ def test_stretch_for_display_decimates():
 def test_stretch_for_display_all_nan():
     display_image = jpg_utils.stretch_for_display(np.full((5, 7), np.nan))
 
-    assert np.isfinite(display_image).all()
+    np.testing.assert_array_equal(display_image, np.zeros((5, 7), dtype=np.uint8))
 
 
 def test_stretch_for_display_nan_speckle_matches_median_fill():
@@ -39,23 +39,20 @@ def test_stretch_for_display_nan_speckle_matches_median_fill():
     np.testing.assert_array_equal(display_image, expected_image)
 
 
-def test_save_jpg_sizes(tmp_path):
-    display_image = np.arange(1200 * 1200, dtype=np.uint32).reshape(1200, 1200).astype(np.uint8)
-    rectangular_display_image = np.zeros((600, 1200), dtype=np.uint8)
-    small_path = tmp_path / 'small.jpg'
-    large_path = tmp_path / 'large.jpg'
-    rectangular_path = tmp_path / 'rectangular.jpg'
+@pytest.mark.parametrize(
+    'shape,max_size,expected_size',
+    [
+        pytest.param((1200, 1200), 300, (300, 300), id='small-square'),
+        pytest.param((1200, 1200), 900, (900, 900), id='large-square'),
+        pytest.param((600, 1200), 300, (300, 150), id='rectangular'),
+    ],
+)
+def test_save_jpg_sizes(tmp_path, shape, max_size, expected_size):
+    display_image = np.arange(np.prod(shape), dtype=np.uint32).reshape(shape).astype(np.uint8)
+    path = tmp_path / f'{shape[0]}x{shape[1]}-{max_size}.jpg'
 
-    assert jpg_utils.save_jpg(display_image, small_path, 300) == small_path
-    assert jpg_utils.save_jpg(display_image, large_path, 900) == large_path
-    jpg_utils.save_jpg(rectangular_display_image, rectangular_path, 300)
+    assert jpg_utils.save_jpg(display_image, path, max_size) == path
 
-    with Image.open(small_path) as image:
-        assert image.size == (300, 300)
-        assert image.mode == 'L'
-    with Image.open(large_path) as image:
-        assert image.size == (900, 900)
-        assert image.mode == 'L'
-    with Image.open(rectangular_path) as image:
-        assert image.size == (300, 150)
+    with Image.open(path) as image:
+        assert image.size == expected_size
         assert image.mode == 'L'

--- a/banzai/tests/test_jpg_utils.py
+++ b/banzai/tests/test_jpg_utils.py
@@ -12,13 +12,12 @@ def test_stretch_for_display_returns_uint8_2d():
 
     assert display_image.dtype == np.uint8
     assert display_image.shape == (3, 4)
-    assert display_image.ndim == 2
 
 
 def test_stretch_for_display_decimates():
-    display_image = jpg_utils.stretch_for_display(np.zeros((4000, 6000), dtype=np.float32), max_size=3600)
+    display_image = jpg_utils.stretch_for_display(np.zeros((40, 60), dtype=np.float32), max_size=36)
 
-    assert display_image.shape == (2000, 3000)
+    assert display_image.shape == (20, 30)
 
 
 def test_stretch_for_display_all_nan():

--- a/banzai/tests/test_jpg_utils.py
+++ b/banzai/tests/test_jpg_utils.py
@@ -1,0 +1,61 @@
+import numpy as np
+import pytest
+from PIL import Image
+
+from banzai.utils import jpg_utils
+
+pytestmark = pytest.mark.smart_stacking
+
+
+def test_stretch_for_display_returns_uint8_2d():
+    display_image = jpg_utils.stretch_for_display(np.arange(12).reshape(3, 4))
+
+    assert display_image.dtype == np.uint8
+    assert display_image.shape == (3, 4)
+    assert display_image.ndim == 2
+
+
+def test_stretch_for_display_decimates():
+    display_image = jpg_utils.stretch_for_display(np.zeros((4000, 6000), dtype=np.float32), max_size=3600)
+
+    assert display_image.shape == (2000, 3000)
+
+
+def test_stretch_for_display_all_nan():
+    display_image = jpg_utils.stretch_for_display(np.full((5, 7), np.nan))
+
+    assert np.isfinite(display_image).all()
+
+
+def test_stretch_for_display_nan_speckle_matches_median_fill():
+    data = np.arange(25, dtype=float).reshape(5, 5)
+    data[2, 3] = np.nan
+    median_filled = data.copy()
+    median_filled[2, 3] = np.nanmedian(data)
+
+    display_image = jpg_utils.stretch_for_display(data)
+    expected_image = jpg_utils.stretch_for_display(median_filled)
+
+    np.testing.assert_array_equal(display_image, expected_image)
+
+
+def test_save_jpg_sizes(tmp_path):
+    display_image = np.arange(1200 * 1200, dtype=np.uint32).reshape(1200, 1200).astype(np.uint8)
+    rectangular_display_image = np.zeros((600, 1200), dtype=np.uint8)
+    small_path = tmp_path / 'small.jpg'
+    large_path = tmp_path / 'large.jpg'
+    rectangular_path = tmp_path / 'rectangular.jpg'
+
+    assert jpg_utils.save_jpg(display_image, small_path, 300) == small_path
+    assert jpg_utils.save_jpg(display_image, large_path, 900) == large_path
+    jpg_utils.save_jpg(rectangular_display_image, rectangular_path, 300)
+
+    with Image.open(small_path) as image:
+        assert image.size == (300, 300)
+        assert image.mode == 'L'
+    with Image.open(large_path) as image:
+        assert image.size == (900, 900)
+        assert image.mode == 'L'
+    with Image.open(rectangular_path) as image:
+        assert image.size == (300, 150)
+        assert image.mode == 'L'

--- a/banzai/utils/file_utils.py
+++ b/banzai/utils/file_utils.py
@@ -1,5 +1,6 @@
 import hashlib
 import os
+import re
 from time import sleep
 
 from ocs_ingester import ingester
@@ -10,9 +11,76 @@ from banzai.logs import get_logger
 
 logger = get_logger()
 
+SMARTSTACK_FILENAME_RE = re.compile(
+    r'(?P<prefix>.*-)(?P<frame_number>\d+)-(?P<kind>[ex])(?P<rlevel>\d{2})(?P<suffix>\.fits(?:\.fz)?)$'
+)
+
 
 def get_processed_path(base_path, site, camera, epoch):
     return os.path.join(base_path, site, camera, epoch, 'processed')
+
+
+def make_smartstack_filename(first_filename, first_stack_num, last_stack_num, reduction_level=45):
+    """Build a smartstack FITS filename for a stack frame range.
+
+    Parameters
+    ----------
+    first_filename : str
+        Filename of the first reduced input frame.
+    first_stack_num : int
+        First stack frame number.
+    last_stack_num : int
+        Last stack frame number.
+    reduction_level : int, optional
+        Output reduction level.
+
+    Returns
+    -------
+    str
+        Smartstack FITS filename with the frame range.
+
+    Raises
+    ------
+    ValueError
+        If first_filename cannot be parsed as a reduced FITS filename.
+    """
+    match = SMARTSTACK_FILENAME_RE.match(first_filename)
+    if match is None:
+        raise ValueError(f'Could not parse smartstack input filename: {first_filename}')
+
+    frame_number_width = len(match.group('frame_number'))
+    first_frame = f'{first_stack_num:0{frame_number_width}d}'
+    last_frame = f'{last_stack_num:0{frame_number_width}d}'
+    rlevel = f'{reduction_level:02d}'
+
+    return (
+        f"{match.group('prefix')}{first_frame}-{last_frame}-"
+        f"{match.group('kind')}{rlevel}{match.group('suffix')}"
+    )
+
+
+def make_jpg_filenames(smartstack_filename):
+    """Build small and large JPEG filenames for a smartstack FITS filename.
+
+    Parameters
+    ----------
+    smartstack_filename : str
+        Smartstack FITS filename.
+
+    Returns
+    -------
+    tuple
+        Tuple of ``(small_thumbnail, large_thumbnail)`` JPEG filenames, matching
+        the ``small_thumbnail``/``large_thumbnail`` keys in the shipper message.
+    """
+    if smartstack_filename.endswith('.fits.fz'):
+        base = smartstack_filename[:-len('.fits.fz')]
+    elif smartstack_filename.endswith('.fits'):
+        base = smartstack_filename[:-len('.fits')]
+    else:
+        base = smartstack_filename
+
+    return f'{base}-small_thumbnail.jpg', f'{base}-large_thumbnail.jpg'
 
 
 def post_to_ingester(file_object, image, output_filename, meta=None):

--- a/banzai/utils/file_utils.py
+++ b/banzai/utils/file_utils.py
@@ -20,42 +20,47 @@ def get_processed_path(base_path, site, camera, epoch):
     return os.path.join(base_path, site, camera, epoch, 'processed')
 
 
-def make_smartstack_filename(first_filename, first_stack_num, last_stack_num, reduction_level=45):
-    """Build a smartstack FITS filename for a stack frame range.
+def make_smartstack_filename(first_filename, last_filename, reduction_level=45):
+    """Build a smartstack FITS filename from the first and last input frame filenames.
+
+    The range comes from the inputs' file frame numbers (unique per camera and
+    night), not their stack positions — stack positions always start at 1, so
+    two same-night stacks from one camera would collide.
 
     Parameters
     ----------
     first_filename : str
         Filename of the first reduced input frame.
-    first_stack_num : int
-        First stack frame number.
-    last_stack_num : int
-        Last stack frame number.
+    last_filename : str
+        Filename of the last reduced input frame.
     reduction_level : int, optional
         Output reduction level.
 
     Returns
     -------
     str
-        Smartstack FITS filename with the frame range.
+        Smartstack FITS filename with the file frame-number range.
 
     Raises
     ------
     ValueError
-        If first_filename cannot be parsed as a reduced FITS filename.
+        If either filename cannot be parsed as a reduced FITS filename.
     """
-    match = SMARTSTACK_FILENAME_RE.match(first_filename)
-    if match is None:
+    first_match = SMARTSTACK_FILENAME_RE.match(first_filename)
+    if first_match is None:
         raise ValueError(f'Could not parse smartstack input filename: {first_filename}')
+    last_match = SMARTSTACK_FILENAME_RE.match(last_filename)
+    if last_match is None:
+        raise ValueError(f'Could not parse smartstack input filename: {last_filename}')
 
-    frame_number_width = len(match.group('frame_number'))
-    first_frame = f'{first_stack_num:0{frame_number_width}d}'
-    last_frame = f'{last_stack_num:0{frame_number_width}d}'
+    frame_number_width = len(first_match.group('frame_number'))
+    first_frame = f"{int(first_match.group('frame_number')):0{frame_number_width}d}"
+    last_frame = f"{int(last_match.group('frame_number')):0{frame_number_width}d}"
     rlevel = f'{reduction_level:02d}'
 
     return (
-        f"{match.group('prefix')}{first_frame}-{last_frame}-"
-        f"{match.group('kind')}{rlevel}{match.group('suffix')}"
+        f"{first_match.group('prefix')}{first_frame}-{last_frame}-"
+        f"{first_match.group('kind')}{rlevel}{first_match.group('suffix')}"
     )
 
 

--- a/banzai/utils/file_utils.py
+++ b/banzai/utils/file_utils.py
@@ -44,7 +44,8 @@ def make_smartstack_filename(first_filename, last_filename, reduction_level=45):
     Raises
     ------
     ValueError
-        If either filename cannot be parsed as a reduced FITS filename.
+        If either filename cannot be parsed, the inputs identify different
+        frame series, or the frame-number range is reversed.
     """
     first_match = SMARTSTACK_FILENAME_RE.match(first_filename)
     if first_match is None:
@@ -53,9 +54,15 @@ def make_smartstack_filename(first_filename, last_filename, reduction_level=45):
     if last_match is None:
         raise ValueError(f'Could not parse smartstack input filename: {last_filename}')
 
-    frame_number_width = len(first_match.group('frame_number'))
-    first_frame = f"{int(first_match.group('frame_number')):0{frame_number_width}d}"
-    last_frame = f"{int(last_match.group('frame_number')):0{frame_number_width}d}"
+    # Compression and frame-number width are storage/formatting details, not series identity.
+    identity_fields = ('prefix', 'kind', 'rlevel')
+    if any(first_match.group(field) != last_match.group(field) for field in identity_fields):
+        raise ValueError(f'Incompatible smartstack input filenames: {first_filename}, {last_filename}')
+
+    first_frame = first_match.group('frame_number')
+    last_frame = last_match.group('frame_number')
+    if int(first_frame) > int(last_frame):
+        raise ValueError(f'Smartstack input filename range is reversed: {first_filename}, {last_filename}')
     rlevel = f'{reduction_level:02d}'
 
     return (

--- a/banzai/utils/file_utils.py
+++ b/banzai/utils/file_utils.py
@@ -1,6 +1,5 @@
 import hashlib
 import os
-import re
 from time import sleep
 
 from ocs_ingester import ingester
@@ -11,45 +10,8 @@ from banzai.logs import get_logger
 
 logger = get_logger()
 
-SMARTSTACK_FILENAME_RE = re.compile(
-    r'(?P<prefix>.*-)(?P<frame_number>\d+)-(?P<kind>[ex])(?P<rlevel>\d{2})(?P<suffix>\.fits(?:\.fz)?)$'
-)
-
-
 def get_processed_path(base_path, site, camera, epoch):
     return os.path.join(base_path, site, camera, epoch, 'processed')
-
-
-def make_smartstack_filename(first_filename, reduction_level=45):
-    """Build a smartstack FITS filename from the first input frame's basename.
-
-    Parameters
-    ----------
-    first_filename : str
-        Filename of the first reduced input frame.
-    reduction_level : int, optional
-        Output reduction level.
-
-    Returns
-    -------
-    str
-        First input frame's basename with the requested reduction level.
-
-    Raises
-    ------
-    ValueError
-        If the filename cannot be parsed as a reduced FITS filename.
-    """
-    basename = os.path.basename(first_filename)
-    match = SMARTSTACK_FILENAME_RE.match(basename)
-    if match is None:
-        raise ValueError(f'Could not parse smartstack input filename: {first_filename}')
-    rlevel = f'{reduction_level:02d}'
-
-    return (
-        f"{match.group('prefix')}{match.group('frame_number')}-"
-        f"{match.group('kind')}{rlevel}{match.group('suffix')}"
-    )
 
 
 def make_jpg_filenames(smartstack_filename):

--- a/banzai/utils/file_utils.py
+++ b/banzai/utils/file_utils.py
@@ -20,54 +20,35 @@ def get_processed_path(base_path, site, camera, epoch):
     return os.path.join(base_path, site, camera, epoch, 'processed')
 
 
-def make_smartstack_filename(first_filename, last_filename, reduction_level=45):
-    """Build a smartstack FITS filename from the first and last input frame filenames.
-
-    The range comes from the inputs' file frame numbers (unique per camera and
-    night), not their stack positions — stack positions always start at 1, so
-    two same-night stacks from one camera would collide.
+def make_smartstack_filename(first_filename, reduction_level=45):
+    """Build a smartstack FITS filename from the first input frame's basename.
 
     Parameters
     ----------
     first_filename : str
         Filename of the first reduced input frame.
-    last_filename : str
-        Filename of the last reduced input frame.
     reduction_level : int, optional
         Output reduction level.
 
     Returns
     -------
     str
-        Smartstack FITS filename with the file frame-number range.
+        First input frame's basename with the requested reduction level.
 
     Raises
     ------
     ValueError
-        If either filename cannot be parsed, the inputs identify different
-        frame series, or the frame-number range is reversed.
+        If the filename cannot be parsed as a reduced FITS filename.
     """
-    first_match = SMARTSTACK_FILENAME_RE.match(first_filename)
-    if first_match is None:
+    basename = os.path.basename(first_filename)
+    match = SMARTSTACK_FILENAME_RE.match(basename)
+    if match is None:
         raise ValueError(f'Could not parse smartstack input filename: {first_filename}')
-    last_match = SMARTSTACK_FILENAME_RE.match(last_filename)
-    if last_match is None:
-        raise ValueError(f'Could not parse smartstack input filename: {last_filename}')
-
-    # Compression and frame-number width are storage/formatting details, not series identity.
-    identity_fields = ('prefix', 'kind', 'rlevel')
-    if any(first_match.group(field) != last_match.group(field) for field in identity_fields):
-        raise ValueError(f'Incompatible smartstack input filenames: {first_filename}, {last_filename}')
-
-    first_frame = first_match.group('frame_number')
-    last_frame = last_match.group('frame_number')
-    if int(first_frame) > int(last_frame):
-        raise ValueError(f'Smartstack input filename range is reversed: {first_filename}, {last_filename}')
     rlevel = f'{reduction_level:02d}'
 
     return (
-        f"{first_match.group('prefix')}{first_frame}-{last_frame}-"
-        f"{first_match.group('kind')}{rlevel}{first_match.group('suffix')}"
+        f"{match.group('prefix')}{match.group('frame_number')}-"
+        f"{match.group('kind')}{rlevel}{match.group('suffix')}"
     )
 
 

--- a/banzai/utils/jpg_utils.py
+++ b/banzai/utils/jpg_utils.py
@@ -18,8 +18,9 @@ def stretch_for_display(data, max_size=1800):
     display_data = np.asarray(data[::stride, ::stride], dtype=np.float64)
 
     finite_mask = np.isfinite(display_data)
-    fill_value = np.median(display_data[finite_mask]) if finite_mask.any() else 0.0
-    display_data = np.where(finite_mask, display_data, fill_value)
+    if not finite_mask.all():
+        fill_value = np.median(display_data[finite_mask]) if finite_mask.any() else 0.0
+        display_data = np.where(finite_mask, display_data, fill_value)
 
     stretched_data = apply_stretch(display_data)
     display_image = np.clip(stretched_data * 255.0, 0.0, 255.0).astype(np.uint8)
@@ -32,7 +33,7 @@ def save_jpg(display_image, path, max_size, quality=85):
     Parameters
     ----------
     display_image : numpy.ndarray
-        Display-ready image data.
+        Two-dimensional display-ready image data.
     path : str or pathlib.Path
         Output JPEG path.
     max_size : int
@@ -46,8 +47,6 @@ def save_jpg(display_image, path, max_size, quality=85):
         The output path.
     """
     image = Image.fromarray(np.asarray(display_image, dtype=np.uint8))
-    if image.mode != 'L':
-        image = image.convert('L')
     image.thumbnail((max_size, max_size))
     image.save(path, quality=quality)
     return path

--- a/banzai/utils/jpg_utils.py
+++ b/banzai/utils/jpg_utils.py
@@ -1,0 +1,53 @@
+import math
+
+import numpy as np
+from auto_stretch import apply_stretch
+from PIL import Image
+
+
+def stretch_for_display(data, max_size=1800):
+    """Create a display-ready uint8 image from FITS image data.
+
+    Decimation happens before both the float64 conversion and the stretch, because stretching a full big-sensor frame
+    costs a full-size float64 copy, GB-scale memory, and seconds per arrival; stride-decimated previews are visually
+    equivalent and finish in milliseconds.
+    """
+    data = np.asarray(data)
+    longest_side = max(data.shape)
+    stride = max(1, math.ceil(longest_side / max_size))
+    display_data = np.asarray(data[::stride, ::stride], dtype=np.float64)
+
+    finite_mask = np.isfinite(display_data)
+    fill_value = np.median(display_data[finite_mask]) if finite_mask.any() else 0.0
+    display_data = np.where(finite_mask, display_data, fill_value)
+
+    stretched_data = apply_stretch(display_data)
+    display_image = np.clip(stretched_data * 255.0, 0.0, 255.0).astype(np.uint8)
+    return np.flipud(display_image)
+
+
+def save_jpg(display_image, path, max_size, quality=85):
+    """Save a display image as a grayscale JPEG, shrinking but never upscaling it.
+
+    Parameters
+    ----------
+    display_image : numpy.ndarray
+        Display-ready image data.
+    path : str or pathlib.Path
+        Output JPEG path.
+    max_size : int
+        Maximum width or height in pixels; PIL thumbnail only shrinks.
+    quality : int, optional
+        JPEG quality setting.
+
+    Returns
+    -------
+    str or pathlib.Path
+        The output path.
+    """
+    image = Image.fromarray(np.asarray(display_image, dtype=np.uint8))
+    if image.mode != 'L':
+        image = image.convert('L')
+    image.thumbnail((max_size, max_size))
+    image.save(path, quality=quality)
+    return path

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,9 @@ dependencies = [
   "numcodecs>=0.16.0",
   "cosmic-conn[cpu]>=0.6.1",
   "torch>=2.3",
-  "alembic"
+  "alembic",
+  "auto-stretch>=1.1.0",
+  "pillow>=10",
 ]
 
 [project.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -144,6 +144,18 @@ wheels = [
 ]
 
 [[package]]
+name = "auto-stretch"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/57/7a/7a44e43ef7e76cc186ae8cc7792978eeac31e272386c7bc617c231999a20/auto_stretch-1.1.0.tar.gz", hash = "sha256:c8c91dbb1c32914d64f9ec065df5abe274f9b5f707f4497deba8fcb05acc4ab9", size = 1060848, upload-time = "2026-07-03T16:08:12.828Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4d/16/af03a65d260bd3d8634d8e3bb6423cbae5b9c52f4b9709611d2592177da4/auto_stretch-1.1.0-py3-none-any.whl", hash = "sha256:5029de2771f5de667a6663c4f21ac7d1fc8c6d23e4293789892955651dbca4e4", size = 5308, upload-time = "2026-07-03T16:08:11.686Z" },
+]
+
+[[package]]
 name = "babel"
 version = "2.18.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1170,6 +1182,7 @@ dependencies = [
     { name = "alembic" },
     { name = "apscheduler" },
     { name = "astropy" },
+    { name = "auto-stretch" },
     { name = "bottleneck" },
     { name = "celery", extra = ["redis"] },
     { name = "cosmic-conn", extra = ["cpu"] },
@@ -1183,6 +1196,7 @@ dependencies = [
     { name = "ocs-ingester" },
     { name = "opensearch-py" },
     { name = "photutils" },
+    { name = "pillow" },
     { name = "psycopg", extra = ["binary"] },
     { name = "pytest" },
     { name = "python-dateutil" },
@@ -1227,6 +1241,7 @@ requires-dist = [
     { name = "alembic" },
     { name = "apscheduler" },
     { name = "astropy", git = "https://github.com/cmccully/astropy.git?rev=fix%2Ffunpack" },
+    { name = "auto-stretch", specifier = ">=1.1.0" },
     { name = "bottleneck" },
     { name = "celery", extras = ["redis"], specifier = ">=5.5.0rc5" },
     { name = "cosmic-conn", extras = ["cpu"], specifier = ">=0.6.1" },
@@ -1243,6 +1258,7 @@ requires-dist = [
     { name = "ocs-ingester", specifier = ">=3.2.0,<4.0.0" },
     { name = "opensearch-py" },
     { name = "photutils" },
+    { name = "pillow", specifier = ">=10" },
     { name = "psycopg", extras = ["binary"] },
     { name = "pycodestyle", marker = "extra == 'style'" },
     { name = "pytest", specifier = ">=4.0" },


### PR DESCRIPTION
This PR adds two capabilities: generate smartstack jpg filenames, and create stretched jpg files. 

Jpg stretching uses auto-stretch (see [this](https://github.com/LCOGT/auto_stretch) repository) and pillow for file creation. Both are new dependencies for the project. 

Jpg filenames are created using a simple modification of the smartstack filename, inserting `large_thumbnail` or `small_thumbnail` before the file extension. 
