### PR TITLE
Smartstack: shipper queue

### DIFF
--- a/banzai/settings.py
+++ b/banzai/settings.py
@@ -173,6 +173,9 @@ REQUEUE_MISSING_FRAMES_TIME = datetime.time(hour=12, minute=0)
 
 SUBFRAME_TASK_QUEUE_NAME = os.getenv('SUBFRAME_TASK_QUEUE_NAME', 'subframe_tasks')
 STACK_QUEUE_NAME = os.getenv('STACK_QUEUE_NAME', 'banzai_stack_queue')
+SHIPPER_EXCHANGE = os.getenv('SHIPPER_EXCHANGE', 'ship_files')
+SHIPPER_QUEUE_NAME = os.getenv('SHIPPER_QUEUE_NAME', 'ship')
+SMARTSTACK_PREVIEWS = os.getenv('SMARTSTACK_PREVIEWS', 'true').lower() == 'true'
 
 REDIS_URL = os.getenv('REDIS_URL', 'redis://host.docker.internal:6379/0')
 RABBITMQ_URL = os.getenv('RABBITMQ_URL', 'amqp://host.docker.internal:5672')

--- a/banzai/tests/test_messaging.py
+++ b/banzai/tests/test_messaging.py
@@ -1,0 +1,156 @@
+import importlib
+
+import banzai.settings as settings
+from banzai.utils import messaging
+
+
+class RecordingChannel:
+    def __init__(self, calls):
+        self.calls = calls
+
+    def exchange_declare(self, exchange, type, durable, **kwargs):
+        self.calls.append(('exchange_declare', exchange, type, durable))
+
+    def queue_declare(self, queue, durable, **kwargs):
+        self.calls.append(('queue_declare', queue, durable))
+
+    def queue_bind(self, queue, exchange, routing_key, **kwargs):
+        self.calls.append(('queue_bind', queue, exchange, routing_key))
+
+    def prepare_queue_arguments(self, arguments, **kwargs):
+        return arguments
+
+
+class RecordingProducer:
+    def __init__(self, calls, exchange=None, **kwargs):
+        self.calls = calls
+        self.calls.append(('producer', exchange))
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        return False
+
+    def publish(self, body, **kwargs):
+        self.calls.append(('publish', body, kwargs))
+
+    def release(self):
+        self.calls.append(('release',))
+
+
+class RecordingConnection:
+    instances = []
+
+    def __init__(self, broker_url):
+        self.broker_url = broker_url
+        self.calls = []
+        self.channel_instance = RecordingChannel(self.calls)
+        self.__class__.instances.append(self)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        return False
+
+    def channel(self):
+        return self.channel_instance
+
+    def Producer(self, exchange=None, **kwargs):
+        return RecordingProducer(self.calls, exchange=exchange, **kwargs)
+
+
+def patch_connection(monkeypatch):
+    RecordingConnection.instances = []
+    monkeypatch.setattr(messaging, 'Connection', RecordingConnection)
+
+
+def test_post_to_shipper_queue_declares_durable_fanout(monkeypatch):
+    patch_connection(monkeypatch)
+
+    messaging.post_to_shipper_queue(
+        'amqp://broker',
+        'ship_files',
+        'ship',
+        '/data/final.fits',
+        '/data/final-small_thumbnail.jpg',
+        '/data/final-large_thumbnail.jpg',
+        1783200000123,
+    )
+
+    connection = RecordingConnection.instances[0]
+    exchange_declare = connection.calls[0]
+    queue_declare_index = next(i for i, call in enumerate(connection.calls) if call[0] == 'queue_declare')
+    queue_bind_index = next(i for i, call in enumerate(connection.calls) if call[0] == 'queue_bind')
+    publish_index = next(i for i, call in enumerate(connection.calls) if call[0] == 'publish')
+
+    assert exchange_declare == ('exchange_declare', 'ship_files', 'fanout', True)
+    assert ('queue_declare', 'ship', True) in connection.calls
+    assert ('queue_bind', 'ship', 'ship_files', '') in connection.calls
+    assert queue_declare_index < publish_index
+    assert queue_bind_index < publish_index
+
+
+def test_post_to_shipper_queue_body_final(monkeypatch):
+    patch_connection(monkeypatch)
+
+    messaging.post_to_shipper_queue(
+        'amqp://broker',
+        'ship_files',
+        'ship',
+        '/data/final.fits',
+        '/data/final-small_thumbnail.jpg',
+        '/data/final-large_thumbnail.jpg',
+        1783200000123,
+    )
+
+    publish_call = next(call for call in RecordingConnection.instances[0].calls if call[0] == 'publish')
+    assert publish_call[1] == {
+        'fits': '/data/final.fits',
+        'small_thumbnail': '/data/final-small_thumbnail.jpg',
+        'large_thumbnail': '/data/final-large_thumbnail.jpg',
+        'instrument_enqueue_timestamp': 1783200000123,
+    }
+
+
+def test_post_to_shipper_queue_body_preview(monkeypatch):
+    patch_connection(monkeypatch)
+
+    messaging.post_to_shipper_queue(
+        'amqp://broker',
+        'ship_files',
+        'ship',
+        None,
+        '/data/preview-small_thumbnail.jpg',
+        '/data/preview-large_thumbnail.jpg',
+        1783200000123,
+    )
+
+    publish_call = next(call for call in RecordingConnection.instances[0].calls if call[0] == 'publish')
+    assert publish_call[1]['fits'] is None
+    assert set(publish_call[1]) == {
+        'fits',
+        'small_thumbnail',
+        'large_thumbnail',
+        'instrument_enqueue_timestamp',
+    }
+
+
+def test_settings_shipper_defaults(monkeypatch):
+    try:
+        monkeypatch.delenv('SHIPPER_EXCHANGE', raising=False)
+        monkeypatch.delenv('SHIPPER_QUEUE_NAME', raising=False)
+        monkeypatch.delenv('SMARTSTACK_PREVIEWS', raising=False)
+        importlib.reload(settings)
+
+        assert settings.SHIPPER_EXCHANGE == 'ship_files'
+        assert settings.SHIPPER_QUEUE_NAME == 'ship'
+        assert settings.SMARTSTACK_PREVIEWS is True
+
+        monkeypatch.setenv('SMARTSTACK_PREVIEWS', 'false')
+        importlib.reload(settings)
+        assert settings.SMARTSTACK_PREVIEWS is False
+    finally:
+        monkeypatch.undo()
+        importlib.reload(settings)

--- a/banzai/tests/test_messaging.py
+++ b/banzai/tests/test_messaging.py
@@ -1,4 +1,5 @@
 import importlib
+import json
 
 import banzai.settings as settings
 from banzai.utils import messaging
@@ -106,12 +107,17 @@ def test_post_to_shipper_queue_body_final(monkeypatch):
     )
 
     publish_call = next(call for call in RecordingConnection.instances[0].calls if call[0] == 'publish')
-    assert publish_call[1] == {
+    # The shipper consumes plain-text JSON strings and json.loads them itself; a
+    # kombu-serialized dict (application/json) makes it crash on an already-decoded body.
+    assert isinstance(publish_call[1], str)
+    assert json.loads(publish_call[1]) == {
         'fits': '/data/final.fits',
         'small_thumbnail': '/data/final-small_thumbnail.jpg',
         'large_thumbnail': '/data/final-large_thumbnail.jpg',
         'instrument_enqueue_timestamp': 1783200000123,
     }
+    assert publish_call[2]['content_type'] == 'text/plain'
+    assert publish_call[2]['content_encoding'] == 'utf-8'
 
 
 def test_post_to_shipper_queue_body_preview(monkeypatch):
@@ -128,13 +134,17 @@ def test_post_to_shipper_queue_body_preview(monkeypatch):
     )
 
     publish_call = next(call for call in RecordingConnection.instances[0].calls if call[0] == 'publish')
-    assert publish_call[1]['fits'] is None
-    assert set(publish_call[1]) == {
+    assert isinstance(publish_call[1], str)
+    body = json.loads(publish_call[1])
+    assert body['fits'] is None
+    assert set(body) == {
         'fits',
         'small_thumbnail',
         'large_thumbnail',
         'instrument_enqueue_timestamp',
     }
+    assert publish_call[2]['content_type'] == 'text/plain'
+    assert publish_call[2]['content_encoding'] == 'utf-8'
 
 
 def test_settings_shipper_defaults(monkeypatch):

--- a/banzai/tests/test_messaging.py
+++ b/banzai/tests/test_messaging.py
@@ -122,6 +122,15 @@ def test_post_to_shipper_queue_body_final(monkeypatch):
 
 def test_post_to_shipper_queue_body_preview(monkeypatch):
     patch_connection(monkeypatch)
+    thumbnail_metadata = {
+        'frame_basename': 'preview-e45',
+        'DATE-OBS': '2026-07-04T12:00:00.000',
+        'DAY-OBS': '20260704',
+        'INSTRUME': 'fa16',
+        'SITEID': 'cpt',
+        'TELID': '1m0a',
+        'NCOMBINE': 2,
+    }
 
     messaging.post_to_shipper_queue(
         'amqp://broker',
@@ -131,6 +140,7 @@ def test_post_to_shipper_queue_body_preview(monkeypatch):
         '/data/preview-small_thumbnail.jpg',
         '/data/preview-large_thumbnail.jpg',
         1783200000123,
+        thumbnail_metadata=thumbnail_metadata,
     )
 
     publish_call = next(call for call in RecordingConnection.instances[0].calls if call[0] == 'publish')
@@ -142,7 +152,9 @@ def test_post_to_shipper_queue_body_preview(monkeypatch):
         'small_thumbnail',
         'large_thumbnail',
         'instrument_enqueue_timestamp',
+        'thumbnail_metadata',
     }
+    assert body['thumbnail_metadata'] == thumbnail_metadata
     assert publish_call[2]['content_type'] == 'text/plain'
     assert publish_call[2]['content_encoding'] == 'utf-8'
 

--- a/banzai/tests/test_messaging.py
+++ b/banzai/tests/test_messaging.py
@@ -1,127 +1,38 @@
-import importlib
 import json
 
-import banzai.settings as settings
+from kombu import Connection, Queue
+
 from banzai.utils import messaging
 
 
-class RecordingChannel:
-    def __init__(self, calls):
-        self.calls = calls
-
-    def exchange_declare(self, exchange, type, durable, **kwargs):
-        self.calls.append(('exchange_declare', exchange, type, durable))
-
-    def queue_declare(self, queue, durable, **kwargs):
-        self.calls.append(('queue_declare', queue, durable))
-
-    def queue_bind(self, queue, exchange, routing_key, **kwargs):
-        self.calls.append(('queue_bind', queue, exchange, routing_key))
-
-    def prepare_queue_arguments(self, arguments, **kwargs):
-        return arguments
+def publish_and_fetch(fits_path, small_thumbnail, large_thumbnail, **kwargs):
+    messaging.post_to_shipper_queue('memory://', 'ship_files', 'ship', fits_path, small_thumbnail,
+                                    large_thumbnail, 1783200000123, **kwargs)
+    with Connection('memory://') as connection:
+        queue = Queue('ship')(connection.channel())
+        message = queue.get(no_ack=True)
+        queue.purge()
+    return message
 
 
-class RecordingProducer:
-    def __init__(self, calls, exchange=None, **kwargs):
-        self.calls = calls
-        self.calls.append(('producer', exchange))
-
-    def __enter__(self):
-        return self
-
-    def __exit__(self, exc_type, exc_value, traceback):
-        return False
-
-    def publish(self, body, **kwargs):
-        self.calls.append(('publish', body, kwargs))
-
-    def release(self):
-        self.calls.append(('release',))
-
-
-class RecordingConnection:
-    instances = []
-
-    def __init__(self, broker_url):
-        self.broker_url = broker_url
-        self.calls = []
-        self.channel_instance = RecordingChannel(self.calls)
-        self.__class__.instances.append(self)
-
-    def __enter__(self):
-        return self
-
-    def __exit__(self, exc_type, exc_value, traceback):
-        return False
-
-    def channel(self):
-        return self.channel_instance
-
-    def Producer(self, exchange=None, **kwargs):
-        return RecordingProducer(self.calls, exchange=exchange, **kwargs)
-
-
-def patch_connection(monkeypatch):
-    RecordingConnection.instances = []
-    monkeypatch.setattr(messaging, 'Connection', RecordingConnection)
-
-
-def test_post_to_shipper_queue_declares_durable_fanout(monkeypatch):
-    patch_connection(monkeypatch)
-
-    messaging.post_to_shipper_queue(
-        'amqp://broker',
-        'ship_files',
-        'ship',
-        '/data/final.fits',
-        '/data/final-small_thumbnail.jpg',
-        '/data/final-large_thumbnail.jpg',
-        1783200000123,
-    )
-
-    connection = RecordingConnection.instances[0]
-    exchange_declare = connection.calls[0]
-    queue_declare_index = next(i for i, call in enumerate(connection.calls) if call[0] == 'queue_declare')
-    queue_bind_index = next(i for i, call in enumerate(connection.calls) if call[0] == 'queue_bind')
-    publish_index = next(i for i, call in enumerate(connection.calls) if call[0] == 'publish')
-
-    assert exchange_declare == ('exchange_declare', 'ship_files', 'fanout', True)
-    assert ('queue_declare', 'ship', True) in connection.calls
-    assert ('queue_bind', 'ship', 'ship_files', '') in connection.calls
-    assert queue_declare_index < publish_index
-    assert queue_bind_index < publish_index
-
-
-def test_post_to_shipper_queue_body_final(monkeypatch):
-    patch_connection(monkeypatch)
-
-    messaging.post_to_shipper_queue(
-        'amqp://broker',
-        'ship_files',
-        'ship',
-        '/data/final.fits',
-        '/data/final-small_thumbnail.jpg',
-        '/data/final-large_thumbnail.jpg',
-        1783200000123,
-    )
-
-    publish_call = next(call for call in RecordingConnection.instances[0].calls if call[0] == 'publish')
-    # The shipper consumes plain-text JSON strings and json.loads them itself; a
-    # kombu-serialized dict (application/json) makes it crash on an already-decoded body.
-    assert isinstance(publish_call[1], str)
-    assert json.loads(publish_call[1]) == {
+def test_post_to_shipper_queue_body_final():
+    message = publish_and_fetch('/data/final.fits', '/data/final-small_thumbnail.jpg',
+                                '/data/final-large_thumbnail.jpg')
+    # Receiving the message at all proves the durable queue was bound before
+    # publish: fanout exchanges drop messages with no bound queue.
+    assert message is not None
+    # The shipper json.loads the raw body itself; a kombu-serialized dict
+    # (application/json) crashes it as a non-retryable failure.
+    assert message.content_type == 'text/plain'
+    assert json.loads(message.body) == {
         'fits': '/data/final.fits',
         'small_thumbnail': '/data/final-small_thumbnail.jpg',
         'large_thumbnail': '/data/final-large_thumbnail.jpg',
         'instrument_enqueue_timestamp': 1783200000123,
     }
-    assert publish_call[2]['content_type'] == 'text/plain'
-    assert publish_call[2]['content_encoding'] == 'utf-8'
 
 
-def test_post_to_shipper_queue_body_preview(monkeypatch):
-    patch_connection(monkeypatch)
+def test_post_to_shipper_queue_body_preview():
     thumbnail_metadata = {
         'frame_basename': 'preview-e45',
         'DATE-OBS': '2026-07-04T12:00:00.000',
@@ -131,48 +42,11 @@ def test_post_to_shipper_queue_body_preview(monkeypatch):
         'TELID': '1m0a',
         'NCOMBINE': 2,
     }
-
-    messaging.post_to_shipper_queue(
-        'amqp://broker',
-        'ship_files',
-        'ship',
-        None,
-        '/data/preview-small_thumbnail.jpg',
-        '/data/preview-large_thumbnail.jpg',
-        1783200000123,
-        thumbnail_metadata=thumbnail_metadata,
-    )
-
-    publish_call = next(call for call in RecordingConnection.instances[0].calls if call[0] == 'publish')
-    assert isinstance(publish_call[1], str)
-    body = json.loads(publish_call[1])
+    message = publish_and_fetch(None, '/data/preview-small_thumbnail.jpg',
+                                '/data/preview-large_thumbnail.jpg',
+                                thumbnail_metadata=thumbnail_metadata)
+    assert message is not None
+    assert message.content_type == 'text/plain'
+    body = json.loads(message.body)
     assert body['fits'] is None
-    assert set(body) == {
-        'fits',
-        'small_thumbnail',
-        'large_thumbnail',
-        'instrument_enqueue_timestamp',
-        'thumbnail_metadata',
-    }
     assert body['thumbnail_metadata'] == thumbnail_metadata
-    assert publish_call[2]['content_type'] == 'text/plain'
-    assert publish_call[2]['content_encoding'] == 'utf-8'
-
-
-def test_settings_shipper_defaults(monkeypatch):
-    try:
-        monkeypatch.delenv('SHIPPER_EXCHANGE', raising=False)
-        monkeypatch.delenv('SHIPPER_QUEUE_NAME', raising=False)
-        monkeypatch.delenv('SMARTSTACK_PREVIEWS', raising=False)
-        importlib.reload(settings)
-
-        assert settings.SHIPPER_EXCHANGE == 'ship_files'
-        assert settings.SHIPPER_QUEUE_NAME == 'ship'
-        assert settings.SMARTSTACK_PREVIEWS is True
-
-        monkeypatch.setenv('SMARTSTACK_PREVIEWS', 'false')
-        importlib.reload(settings)
-        assert settings.SMARTSTACK_PREVIEWS is False
-    finally:
-        monkeypatch.undo()
-        importlib.reload(settings)

--- a/banzai/tests/test_messaging.py
+++ b/banzai/tests/test_messaging.py
@@ -7,7 +7,7 @@ from banzai.utils import messaging
 
 def publish_and_fetch(fits_path, small_thumbnail, large_thumbnail, **kwargs):
     messaging.post_to_shipper_queue('memory://', 'ship_files', 'ship', fits_path, small_thumbnail,
-                                    large_thumbnail, 1783200000123, **kwargs)
+                                    large_thumbnail, **kwargs)
     with Connection('memory://') as connection:
         queue = Queue('ship')(connection.channel())
         message = queue.get(no_ack=True)
@@ -58,7 +58,8 @@ def test_post_to_shipper_queue_confirms_on_declared_channel(monkeypatch):
     assert publish_calls[0]['confirm_timeout'] == 5
 
 
-def test_post_to_shipper_queue_body_final():
+def test_post_to_shipper_queue_body_final(monkeypatch):
+    monkeypatch.setattr(messaging.time, 'time', lambda: 1783200000.123)
     message = publish_and_fetch('/data/final.fits', '/data/final-small_thumbnail.jpg',
                                 '/data/final-large_thumbnail.jpg')
     # Receiving the message at all proves the durable queue was bound before

--- a/banzai/tests/test_messaging.py
+++ b/banzai/tests/test_messaging.py
@@ -1,6 +1,6 @@
 import json
 
-from kombu import Connection, Queue
+from kombu import Connection, Producer, Queue
 
 from banzai.utils import messaging
 
@@ -13,6 +13,49 @@ def publish_and_fetch(fits_path, small_thumbnail, large_thumbnail, **kwargs):
         message = queue.get(no_ack=True)
         queue.purge()
     return message
+
+
+def test_post_to_shipper_queue_confirms_on_declared_channel(monkeypatch):
+    # The memory transport preserves the real kombu topology and publish path,
+    # but does not model broker acknowledgements, so record the safety options.
+    declared_queues = []
+    producer_calls = []
+    publish_calls = []
+    real_queue_declare = Queue.declare
+    real_connection_producer = Connection.Producer
+    real_producer_publish = Producer.publish
+
+    def record_queue_declare(self, *args, **kwargs):
+        declared_queues.append(self)
+        return real_queue_declare(self, *args, **kwargs)
+
+    def record_connection_producer(self, channel=None, *args, **kwargs):
+        producer_calls.append((self, channel, kwargs.copy()))
+        return real_connection_producer(self, channel, *args, **kwargs)
+
+    def record_producer_publish(self, body, *args, **kwargs):
+        publish_calls.append(kwargs.copy())
+        return real_producer_publish(self, body, *args, **kwargs)
+
+    monkeypatch.setattr(Queue, 'declare', record_queue_declare)
+    monkeypatch.setattr(Connection, 'Producer', record_connection_producer)
+    monkeypatch.setattr(Producer, 'publish', record_producer_publish)
+
+    message = publish_and_fetch('/data/final.fits', '/data/final-small_thumbnail.jpg',
+                                '/data/final-large_thumbnail.jpg')
+
+    connection, producer_channel, producer_kwargs = producer_calls[0]
+    declared_queue = declared_queues[0]
+    assert message is not None
+    assert connection.connect_timeout == 5
+    assert connection.transport_options['confirm_publish'] is True
+    assert declared_queue.durable is True
+    assert declared_queue.exchange.type == 'fanout'
+    assert declared_queue.exchange.durable is True
+    assert producer_channel is declared_queue.channel
+    assert producer_kwargs['exchange'].name == declared_queue.exchange.name
+    assert producer_kwargs['auto_declare'] is False
+    assert publish_calls[0]['confirm_timeout'] == 5
 
 
 def test_post_to_shipper_queue_body_final():

--- a/banzai/utils/messaging.py
+++ b/banzai/utils/messaging.py
@@ -26,8 +26,8 @@ import time
 from kombu import Connection, Exchange, Queue
 
 
-SHIPPER_CONNECT_TIMEOUT = 5
-SHIPPER_CONFIRM_TIMEOUT = 5
+SHIPPER_CONNECT_TIMEOUT = 5  # seconds
+SHIPPER_CONFIRM_TIMEOUT = 5  # seconds
 
 
 def post_to_archive_queue(filename, broker_url, exchange_name='fits_files', **kwargs):

--- a/banzai/utils/messaging.py
+++ b/banzai/utils/messaging.py
@@ -47,7 +47,7 @@ def post_to_archive_queue(filename, broker_url, exchange_name='fits_files', **kw
 
 
 def post_to_shipper_queue(broker_url, exchange_name, queue_name, fits_path, small_thumbnail, large_thumbnail,
-                          instrument_enqueue_timestamp):
+                          instrument_enqueue_timestamp, thumbnail_metadata=None):
     """Publish smartstack product paths for the site shipper to upload.
 
     Fanout exchanges drop messages when no queue is bound, so the durable
@@ -55,7 +55,8 @@ def post_to_shipper_queue(broker_url, exchange_name, queue_name, fits_path, smal
 
     The body is sent as a plain-text JSON string: the shipper json.loads the
     raw body itself and rejects kombu-serialized dicts as non-transient
-    failures (no retry), silently dropping the product.
+    failures (no retry), silently dropping the product. Preview callers may
+    submit thumbnail_metadata when no FITS path is available.
     """
     exchange = Exchange(exchange_name, type='fanout', durable=True)
     queue = Queue(queue_name, exchange=exchange, durable=True)
@@ -65,6 +66,8 @@ def post_to_shipper_queue(broker_url, exchange_name, queue_name, fits_path, smal
         'large_thumbnail': large_thumbnail,
         'instrument_enqueue_timestamp': instrument_enqueue_timestamp,
     }
+    if thumbnail_metadata is not None:
+        body['thumbnail_metadata'] = thumbnail_metadata
 
     with Connection(broker_url) as conn:
         channel = conn.channel()

--- a/banzai/utils/messaging.py
+++ b/banzai/utils/messaging.py
@@ -21,6 +21,7 @@ kombu-serialized dict (``application/json``) hands them an already-decoded
 dict and crashes them.
 """
 import json
+import time
 
 from kombu import Connection, Exchange, Queue
 
@@ -51,7 +52,7 @@ def post_to_archive_queue(filename, broker_url, exchange_name='fits_files', **kw
 
 
 def post_to_shipper_queue(broker_url, exchange_name, queue_name, fits_path, small_thumbnail, large_thumbnail,
-                          instrument_enqueue_timestamp, thumbnail_metadata=None):
+                          thumbnail_metadata=None):
     """Publish smartstack product paths for the site shipper to upload.
 
     Fanout exchanges drop messages when no queue is bound, so the durable
@@ -62,7 +63,8 @@ def post_to_shipper_queue(broker_url, exchange_name, queue_name, fits_path, smal
     failures (no retry), silently dropping the product. Preview callers may
     submit thumbnail_metadata when no FITS path is available. Publisher
     confirms make broker rejection or acknowledgement timeout visible to the
-    caller so the stack finalizer can retry.
+    caller so the stack finalizer can retry. Each publish gets a fresh epoch-ms
+    timestamp marking when this product is submitted to the shipper.
     """
     exchange = Exchange(exchange_name, type='fanout', durable=True)
     queue = Queue(queue_name, exchange=exchange, durable=True)
@@ -70,7 +72,6 @@ def post_to_shipper_queue(broker_url, exchange_name, queue_name, fits_path, smal
         'fits': fits_path,
         'small_thumbnail': small_thumbnail,
         'large_thumbnail': large_thumbnail,
-        'instrument_enqueue_timestamp': instrument_enqueue_timestamp,
     }
     if thumbnail_metadata is not None:
         body['thumbnail_metadata'] = thumbnail_metadata
@@ -81,6 +82,7 @@ def post_to_shipper_queue(broker_url, exchange_name, queue_name, fits_path, smal
         bound_queue = queue(channel)
         bound_queue.declare()
         with conn.Producer(channel=channel, exchange=bound_queue.exchange, auto_declare=False) as producer:
+            body['instrument_enqueue_timestamp'] = int(time.time() * 1000)
             producer.publish(json.dumps(body), content_type='text/plain', content_encoding='utf-8',
                              confirm_timeout=SHIPPER_CONFIRM_TIMEOUT)
 

--- a/banzai/utils/messaging.py
+++ b/banzai/utils/messaging.py
@@ -25,6 +25,10 @@ import json
 from kombu import Connection, Exchange, Queue
 
 
+SHIPPER_CONNECT_TIMEOUT = 5
+SHIPPER_CONFIRM_TIMEOUT = 5
+
+
 def post_to_archive_queue(filename, broker_url, exchange_name='fits_files', **kwargs):
     """Post file to RabbitMQ listener queue for processing.
 
@@ -56,7 +60,9 @@ def post_to_shipper_queue(broker_url, exchange_name, queue_name, fits_path, smal
     The body is sent as a plain-text JSON string: the shipper json.loads the
     raw body itself and rejects kombu-serialized dicts as non-transient
     failures (no retry), silently dropping the product. Preview callers may
-    submit thumbnail_metadata when no FITS path is available.
+    submit thumbnail_metadata when no FITS path is available. Publisher
+    confirms make broker rejection or acknowledgement timeout visible to the
+    caller so the stack finalizer can retry.
     """
     exchange = Exchange(exchange_name, type='fanout', durable=True)
     queue = Queue(queue_name, exchange=exchange, durable=True)
@@ -69,15 +75,14 @@ def post_to_shipper_queue(broker_url, exchange_name, queue_name, fits_path, smal
     if thumbnail_metadata is not None:
         body['thumbnail_metadata'] = thumbnail_metadata
 
-    with Connection(broker_url) as conn:
+    with Connection(broker_url, connect_timeout=SHIPPER_CONNECT_TIMEOUT,
+                    transport_options={'confirm_publish': True}) as conn:
         channel = conn.channel()
-        bound_exchange = exchange(channel)
-        bound_exchange.declare()
         bound_queue = queue(channel)
         bound_queue.declare()
-        producer = conn.Producer(exchange=bound_exchange)
-        producer.publish(json.dumps(body), content_type='text/plain', content_encoding='utf-8')
-        producer.release()
+        with conn.Producer(channel=channel, exchange=bound_queue.exchange, auto_declare=False) as producer:
+            producer.publish(json.dumps(body), content_type='text/plain', content_encoding='utf-8',
+                             confirm_timeout=SHIPPER_CONFIRM_TIMEOUT)
 
 
 def publish_raw_string_to_queue(queue_name, body, broker_url='amqp://localhost:5672'):

--- a/banzai/utils/messaging.py
+++ b/banzai/utils/messaging.py
@@ -5,7 +5,7 @@ Three patterns are used in banzai:
 - ``post_to_archive_queue`` publishes a kombu-serialized dict to the
   ``fits_files`` fanout exchange. Consumed by ``PipelineListener`` in
   ``banzai/main.py`` as the archive-ingestion path.
-- ``post_to_shipper_queue`` publishes a kombu-serialized dict to the fanout
+- ``post_to_shipper_queue`` publishes a plain-text JSON string to the fanout
   exchange consumed by the site shipper. It declares the durable queue
   binding before publishing so RabbitMQ does not drop fanout messages with
   no bound queue.
@@ -14,7 +14,14 @@ Three patterns are used in banzai:
   publishes stackframe-ready notifications: bodies arrive as bytes/str and
   the consumer must ``json.loads`` them rather than relying on kombu to
   deserialize a dict.
+
+The site convention is plain-text JSON everywhere the site software is the
+peer: consumers ``json.loads`` the raw body themselves, so publishing a
+kombu-serialized dict (``application/json``) hands them an already-decoded
+dict and crashes them.
 """
+import json
+
 from kombu import Connection, Exchange, Queue
 
 
@@ -45,6 +52,10 @@ def post_to_shipper_queue(broker_url, exchange_name, queue_name, fits_path, smal
 
     Fanout exchanges drop messages when no queue is bound, so the durable
     queue binding is declared before publishing each message.
+
+    The body is sent as a plain-text JSON string: the shipper json.loads the
+    raw body itself and rejects kombu-serialized dicts as non-transient
+    failures (no retry), silently dropping the product.
     """
     exchange = Exchange(exchange_name, type='fanout', durable=True)
     queue = Queue(queue_name, exchange=exchange, durable=True)
@@ -62,7 +73,7 @@ def post_to_shipper_queue(broker_url, exchange_name, queue_name, fits_path, smal
         bound_queue = queue(channel)
         bound_queue.declare()
         producer = conn.Producer(exchange=bound_exchange)
-        producer.publish(body)
+        producer.publish(json.dumps(body), content_type='text/plain', content_encoding='utf-8')
         producer.release()
 
 

--- a/banzai/utils/messaging.py
+++ b/banzai/utils/messaging.py
@@ -1,13 +1,17 @@
 """RabbitMQ publishing helpers.
 
-Two patterns are used in banzai:
+Three patterns are used in banzai:
 
 - ``post_to_archive_queue`` publishes a kombu-serialized dict to the
   ``fits_files`` fanout exchange. Consumed by ``PipelineListener`` in
   ``banzai/main.py`` as the archive-ingestion path.
+- ``post_to_shipper_queue`` publishes a kombu-serialized dict to the fanout
+  exchange consumed by the site shipper. It declares the durable queue
+  binding before publishing so RabbitMQ does not drop fanout messages with
+  no bound queue.
 - ``publish_raw_string_to_queue`` publishes a plain-text JSON string to a
   named queue via the default exchange. Mirrors how the site software
-  publishes subframe-ready notifications: bodies arrive as bytes/str and
+  publishes stackframe-ready notifications: bodies arrive as bytes/str and
   the consumer must ``json.loads`` them rather than relying on kombu to
   deserialize a dict.
 """
@@ -35,10 +39,37 @@ def post_to_archive_queue(filename, broker_url, exchange_name='fits_files', **kw
         producer.release()
 
 
+def post_to_shipper_queue(broker_url, exchange_name, queue_name, fits_path, small_thumbnail, large_thumbnail,
+                          instrument_enqueue_timestamp):
+    """Publish smartstack product paths for the site shipper to upload.
+
+    Fanout exchanges drop messages when no queue is bound, so the durable
+    queue binding is declared before publishing each message.
+    """
+    exchange = Exchange(exchange_name, type='fanout', durable=True)
+    queue = Queue(queue_name, exchange=exchange, durable=True)
+    body = {
+        'fits': fits_path,
+        'small_thumbnail': small_thumbnail,
+        'large_thumbnail': large_thumbnail,
+        'instrument_enqueue_timestamp': instrument_enqueue_timestamp,
+    }
+
+    with Connection(broker_url) as conn:
+        channel = conn.channel()
+        bound_exchange = exchange(channel)
+        bound_exchange.declare()
+        bound_queue = queue(channel)
+        bound_queue.declare()
+        producer = conn.Producer(exchange=bound_exchange)
+        producer.publish(body)
+        producer.release()
+
+
 def publish_raw_string_to_queue(queue_name, body, broker_url='amqp://localhost:5672'):
     """Publish a raw string to a named RabbitMQ queue.
 
-    Mirrors how the site software publishes subframe-ready notifications:
+    Mirrors how the site software publishes stackframe-ready notifications:
     the body is sent as a plain-text JSON string to a named queue via the
     default exchange, with content_type='text/plain' (no kombu serialization).
     Consumers receive a bytes/str body and must json.loads it themselves


### PR DESCRIPTION
Summary

This is PR 4 of 8 completing the v1 banzai implementation of Smartstacking at site.

PR1 (#469): combine math
PR2 (#470): JPEG utilities
PR3 (#471): DB updates   
PR4 (#473): shipper contract         &emsp;&emsp;&emsp;&emsp;    <-- you are here            
PR5 (#474): smartstack data products
PR6 (#475): stack worker polling
PR7 (#476): e2e tests, compose cleanup
PR8 (#477): logging

```text
PR1 combine math ───────┐
PR2 JPEG utilities ─────┤
PR3 DB updates ─────────┼──> PR5 data products --> PR6 stack workers --> PR7 E2E --> PR8 logs/docs
PR4 shipper contract ───┘
```

PRs 1–4 provide the independent foundations for combining images, rendering JPEGs, storing stack state, and shipper integration (this PR). PR5 builds the products, PR6 adds the polling worker, and PR7–8 add end-to-end proof, logging, and final documentation.


## What changes here

Added methods to post data to the shipper queue. In the case of smartstack previews, this includes passing in a subset of the fits header so that the ingester has the metadata it needs without the inclusion of a fits file. 

## Publishing contract

`post_to_shipper_queue()` publishes UTF-8, plain-text JSON:

| Field | Final product | Preview |
|---|---|---|
| `fits` | `e45` FITS path | `null` |
| `small_thumbnail` | JPEG path | JPEG path |
| `large_thumbnail` | JPEG path | JPEG path |
| `instrument_enqueue_timestamp` | Created at queue insert time | Created at queue insert time |
| `thumbnail_metadata` | Omitted by the current final caller | Included when supplied |

The publisher also:

- Declares the durable fanout exchange, queue, and binding before publishing.
- Uses publisher confirms so broker rejection or acknowledgement timeout reaches PR6’s retry path.
- Applies bounded five-second connection and confirmation timeouts.
- Publishes and declares through the same channel.

New settings provide these defaults:

- `SHIPPER_EXCHANGE=ship_files`
- `SHIPPER_QUEUE_NAME=ship`
- `SMARTSTACK_PREVIEWS=true`

## Scope

This PR defines and tests the publishing boundary only. It does not create products or decide when to preview, finalize, or retry; those responsibilities belong to PR5 and PR6.

Focused tests cover the durable binding, plain-text JSON bodies for previews and finals, optional thumbnail metadata, publisher confirms, and timeout options.