### PR TITLE
Smartstack: build data products (e45 fits and jpgs)

### DIFF
--- a/banzai/data.py
+++ b/banzai/data.py
@@ -556,6 +556,18 @@ def _warn_if_exposure_times_differ(images):
                        extra_tags={'exptime_spread_fraction': exptime_spread_fraction})
 
 
+def create_combination_output_hdu(source, meta, *, memmap):
+    """Create the blank SCI HDU populated in place by combine_images."""
+    return type(source)(
+        data=np.zeros_like(source.data),
+        meta=meta.copy(),
+        name=source.name,
+        mask=np.zeros_like(source.mask),
+        uncertainty=np.zeros_like(source.uncertainty),
+        memmap=memmap,
+    )
+
+
 def combine_images(images, output_image, nsigma=3.0, method='mean'):
     """Combine CCD data into an output image in memory-bounded y sections.
 

--- a/banzai/lco.py
+++ b/banzai/lco.py
@@ -12,7 +12,7 @@ from astropy.coordinates import Angle
 import hashlib
 
 from banzai import dbs
-from banzai.data import CCDData, HeaderOnly, DataTable, ArrayData, DataProduct
+from banzai.data import CCDData, HeaderOnly, DataTable, ArrayData, DataProduct, create_combination_output_hdu
 from banzai.frames import ObservationFrame, CalibrationFrame, logger, FrameFactory
 from banzai.utils import date_utils, fits_utils, image_utils, file_utils
 from banzai.utils.image_utils import Section
@@ -295,9 +295,8 @@ class LCOCalibrationFrame(LCOObservationFrame, CalibrationFrame):
     def init_master_frame(cls, images: list, file_path: str, frame_id: int = None,
                           grouping_criteria: list = None, hdu_order: list = None):
         input_science = images[0]['SCI']
-        data_class = type(input_science)
-        hdu_list = [data_class(data=np.zeros(input_science.shape, dtype=input_science.dtype),
-                               meta=cls.init_master_header(images[0].meta, images), name='SCI')]
+        master_header = cls.init_master_header(images[0].meta, images)
+        hdu_list = [create_combination_output_hdu(input_science, master_header, memmap=True)]
         frame = cls(hdu_list=hdu_list, file_path=file_path, frame_id=frame_id,
                     grouping_criteria=grouping_criteria, hdu_order=hdu_order)
         frame.is_master = True

--- a/banzai/photometry.py
+++ b/banzai/photometry.py
@@ -5,12 +5,12 @@ from astropy.table import Table
 from requests.exceptions import RequestException
 
 from banzai.utils import stats, array_utils
+from banzai.utils.background_utils import background_header_cards, estimate_background
 from banzai.utils.photometry_utils import get_reference_sources, match_catalogs, to_magnitude, fit_photometry
 from banzai.stages import Stage
 from banzai.data import DataTable
 from banzai import logs
 
-from photutils.background import Background2D
 from skimage import measure
 from photutils.segmentation import make_2dgaussian_kernel, detect_sources, deblend_sources, SourceCatalog
 from astropy.convolution import convolve
@@ -79,12 +79,8 @@ class SourceDetector(Stage):
             data = image.data.copy()
             error = image.uncertainty
 
-            # From what I can piece together, the background estimator makes a low resolution mesh set by box size
-            # (32, 32) here and then applies a filter to the low resolution image. The filter size is 3x3 here.
-            # The defaults we use here are a mesh creator is from source extractor which is a mode estimator.
-            # The default filter that works on the mesh image is a median filter.
-            bkg = Background2D(data, (32, 32), filter_size=(3, 3))
-            data -= bkg.background
+            background = estimate_background(data)
+            data -= background
 
             # Convolve the image with a 2D Guassian, but with the normalization SEP uses as
             # that is correct.
@@ -115,7 +111,7 @@ class SourceDetector(Stage):
             logger.info('Finished deblending. Saving catalog', image=image)
             # Convert the segmentation map to a source catalog
             catalog = SourceCatalog(data, deblended_seg_map, convolved_data=convolved_data, error=error,
-                                    background=bkg.background)
+                                    background=background)
 
             sources = Table({'x': catalog.xcentroid + 1.0, 'y': catalog.ycentroid + 1.0,
                              'xwin': catalog.xcentroid_win + 1.0, 'ywin': catalog.ycentroid_win + 1.0,
@@ -237,17 +233,8 @@ class SourceDetector(Stage):
             sources.reverse()
 
             # Save some background statistics in the header
-            mean_background = stats.sigma_clipped_mean(bkg.background, 5.0)
-            image.meta['L1MEAN'] = (mean_background,
-                                    '[counts] Sigma clipped mean of frame background')
-
-            median_background = np.median(bkg.background)
-            image.meta['L1MEDIAN'] = (median_background,
-                                      '[counts] Median of frame background')
-
-            std_background = stats.robust_standard_deviation(bkg.background)
-            image.meta['L1SIGMA'] = (std_background,
-                                     '[counts] Robust std dev of frame background')
+            for keyword, card in background_header_cards(background).items():
+                image.meta[keyword] = card
 
             # Save some image statistics to the header
             good_objects = sources['flag'] == 0

--- a/banzai/smartstack_products.py
+++ b/banzai/smartstack_products.py
@@ -119,13 +119,20 @@ def apply_smartstack_metadata(output_frame, input_images, stackframes, moluid):
     if science_header is not primary_header:
         headers.append(science_header)
 
+    # The stack is a sum renormalized per-pixel by N/n_good (see data.stack), so every pixel is on an
+    # N-frame-equivalent flux scale: N * SATURATE/MAXLIN are exact upper bounds for trustworthy values,
+    # and summed read-noise variances give sqrt(N) * RDNOISE.
     n_stacked = len(sorted_inputs)
     keyword_scale_factors = {'SATURATE': n_stacked, 'MAXLIN': n_stacked, 'RDNOISE': np.sqrt(n_stacked)}
+    # UTSTOP from the newest input so DATE-OBS (earliest) and UTSTOP bracket the full time span.
     newest_image = sorted_inputs[-1][1]
     utstop = newest_image['SCI'].meta.get('UTSTOP')
     if utstop is None:
         utstop = newest_image.primary_hdu.meta.get('UTSTOP')
 
+    # The inherited L1MEAN/L1MEDIAN/L1SIGMA describe the first input, not the stack. Remeasure with the
+    # same background-map method as photometry.SourceDetector so e45 values are comparable to e09 ones
+    # (raw-pixel stats would inflate L1SIGMA with pixel noise; the map measures background variation).
     background = Background2D(output_frame['SCI'].data, BACKGROUND_BOX_SIZE,
                               filter_size=BACKGROUND_FILTER_SIZE).background
     mean_background = stats.sigma_clipped_mean(background, BACKGROUND_NSIGMA_CLIP)
@@ -138,6 +145,7 @@ def apply_smartstack_metadata(output_frame, input_images, stackframes, moluid):
         header['NCOMBINE'] = (n_stacked, 'Number of images combined')
         header['MOLUID'] = (moluid, 'Observation request UID')
         header['DATE'] = (date_utils.date_obs_to_string(date_created), '[UTC] Date this FITS file was written')
+        # MOLFRNUM is a per-exposure sequence number; the combined product has no single position.
         if 'MOLFRNUM' in header:
             del header['MOLFRNUM']
         for keyword, scale_factor in keyword_scale_factors.items():

--- a/banzai/smartstack_products.py
+++ b/banzai/smartstack_products.py
@@ -3,7 +3,7 @@ import os
 
 import numpy as np
 
-from banzai.data import CCDData, HeaderOnly, combine_images, science_hdu
+from banzai.data import CCDData, HeaderOnly, combine_images
 from banzai.logs import get_logger
 from banzai.utils import date_utils, import_utils
 from banzai.utils.file_utils import make_jpg_filenames
@@ -68,14 +68,14 @@ def apply_smartstack_metadata(output_frame, input_images, stackframes, moluid):
 
     total_exptime = 0.0
     for _, image in sorted_inputs:
-        exptime = science_hdu(image).meta.get('EXPTIME')
+        exptime = image['SCI'].meta.get('EXPTIME')
         if exptime is None:
             exptime = image.exptime
         total_exptime += float(exptime or 0.0)
     earliest_dateobs = min(image.dateobs for _, image in sorted_inputs)
     date_created = datetime.datetime.now(datetime.timezone.utc)
     primary_header = output_frame.primary_hdu.meta
-    science_header = science_hdu(output_frame).meta
+    science_header = output_frame['SCI'].meta
     headers = [primary_header]
     if science_header is not primary_header:
         headers.append(science_header)
@@ -103,7 +103,8 @@ def build_stacked_frame(stackframes, runtime_context, moluid):
         raise ValueError(f'Could not parse smartstack input filename: {input_images[0].filename}')
     output_filename = f'{base}-e45{file_extension}'
     output_frame = init_smartstack_frame(input_images[0], output_filename)
-    combine_images(input_images, output_frame, nsigma=STACK_NSIGMA_REJECT, method='sum')
+    combine_images([image['SCI'] for image in input_images], output_frame['SCI'],
+                   nsigma=STACK_NSIGMA_REJECT, method='sum')
     apply_smartstack_metadata(output_frame, input_images, stackframes, moluid)
     return output_frame
 
@@ -114,7 +115,7 @@ def render_jpgs(output_frame, runtime_context):
     small_filename, large_filename = make_jpg_filenames(output_frame.filename)
     small_path = os.path.join(output_directory, small_filename)
     large_path = os.path.join(output_directory, large_filename)
-    display_image = stretch_for_display(science_hdu(output_frame).data)
+    display_image = stretch_for_display(output_frame['SCI'].data)
     save_jpg(display_image, large_path, 900)
     save_jpg(display_image, small_path, 300)
     return small_path, large_path

--- a/banzai/smartstack_products.py
+++ b/banzai/smartstack_products.py
@@ -1,0 +1,148 @@
+import datetime
+import os
+
+import numpy as np
+
+from banzai.data import CCDData, HeaderOnly, combine_images, science_hdu
+from banzai.logs import get_logger
+from banzai.utils import date_utils, import_utils
+from banzai.utils.file_utils import make_jpg_filenames, make_smartstack_filename
+from banzai.utils.jpg_utils import save_jpg, stretch_for_display
+from banzai.utils.messaging import post_to_shipper_queue
+
+
+logger = get_logger()
+
+SMARTSTACK_REDUCTION_LEVEL = 45
+STACK_NSIGMA_REJECT = 3.0
+
+
+def open_stackframe_images(stackframes, runtime_context):
+    frame_factory = import_utils.import_attribute(runtime_context.FRAME_FACTORY)()
+    images = []
+    for stackframe in stackframes:
+        image = frame_factory.open({'path': stackframe.filepath}, runtime_context)
+        if image is None:
+            raise RuntimeError(f'Could not open smartstack input image: {stackframe.filepath}')
+        images.append(image)
+    return images
+
+
+def _zeroed_ccd_hdu(ccd_hdu):
+    return type(ccd_hdu)(
+        data=np.zeros_like(ccd_hdu.data),
+        meta=ccd_hdu.meta.copy(),
+        name=ccd_hdu.name,
+        mask=np.zeros_like(ccd_hdu.mask),
+        uncertainty=np.zeros_like(ccd_hdu.uncertainty),
+        memmap=ccd_hdu.memmap,
+    )
+
+
+def init_smartstack_frame(first_image, output_filename):
+    hdu_list = []
+    copied_science_hdu = False
+    for hdu in first_image._hdus:
+        if isinstance(hdu, HeaderOnly):
+            hdu_list.append(HeaderOnly(meta=hdu.meta.copy(), name=hdu.name))
+        elif isinstance(hdu, CCDData) and not copied_science_hdu:
+            hdu_list.append(_zeroed_ccd_hdu(hdu))
+            copied_science_hdu = True
+
+    if not copied_science_hdu:
+        raise ValueError('Smartstack inputs must contain at least one CCDData HDU')
+
+    hdu_order = first_image.hdu_order
+    if hdu_list and isinstance(hdu_list[0], HeaderOnly):
+        primary_name = hdu_list[0].name
+        if primary_name not in (None, ''):
+            raise ValueError('Smartstack primary HeaderOnly HDU must have a blank name')
+        hdu_order = [''] + [hdu_name for hdu_name in (first_image.hdu_order or []) if hdu_name != '']
+
+    output_frame = first_image.__class__(hdu_list, output_filename, frame_id=None, hdu_order=hdu_order)
+    output_frame.instrument = first_image.instrument
+    return output_frame
+
+
+def apply_smartstack_metadata(output_frame, input_images, stackframes, moluid):
+    sorted_inputs = sorted(zip(stackframes, input_images), key=lambda item: item[0].stack_num)
+
+    total_exptime = 0.0
+    for _, image in sorted_inputs:
+        exptime = science_hdu(image).meta.get('EXPTIME')
+        if exptime is None:
+            exptime = image.exptime
+        total_exptime += float(exptime or 0.0)
+    earliest_dateobs = min(image.dateobs for _, image in sorted_inputs)
+    date_created = datetime.datetime.now(datetime.timezone.utc)
+    primary_header = output_frame.primary_hdu.meta
+    science_header = science_hdu(output_frame).meta
+    headers = [primary_header]
+    if science_header is not primary_header:
+        headers.append(science_header)
+
+    for header in headers:
+        header['EXPTIME'] = (total_exptime, '[s] Total exposure time')
+        header['DATE-OBS'] = (date_utils.date_obs_to_string(earliest_dateobs), '[UTC] Earliest observation time')
+        header['NCOMBINE'] = (len(sorted_inputs), 'Number of images combined')
+        header['MOLUID'] = (moluid, 'Observation request UID')
+        header['DATE'] = (date_utils.date_obs_to_string(date_created), '[UTC] Date this FITS file was written')
+        if 'MOLFRNUM' in header:
+            del header['MOLFRNUM']
+        header.add_history('Images combined to create smartstack image:')
+        for index, (_, image) in enumerate(sorted_inputs, start=1):
+            header[f'IMCOM{index:03d}'] = (image.filename, 'Image combined to create smartstack')
+
+
+def build_stacked_frame(stackframes, runtime_context, moluid):
+    if not stackframes:
+        raise ValueError('Cannot build a smartstack without stackframes')
+    stackframes = sorted(stackframes, key=lambda stackframe: stackframe.stack_num)
+    input_images = open_stackframe_images(stackframes, runtime_context)
+    output_filename = make_smartstack_filename(
+        input_images[0].filename,
+        stackframes[0].stack_num,
+        stackframes[-1].stack_num,
+        reduction_level=SMARTSTACK_REDUCTION_LEVEL,
+    )
+    output_frame = init_smartstack_frame(input_images[0], output_filename)
+    combine_images(input_images, output_frame, nsigma=STACK_NSIGMA_REJECT, method='sum')
+    apply_smartstack_metadata(output_frame, input_images, stackframes, moluid)
+    return output_frame
+
+
+def render_jpgs(output_frame, runtime_context):
+    output_directory = output_frame.get_output_directory(runtime_context)
+    os.makedirs(output_directory, exist_ok=True)
+    small_filename, large_filename = make_jpg_filenames(output_frame.filename)
+    small_path = os.path.join(output_directory, small_filename)
+    large_path = os.path.join(output_directory, large_filename)
+    display_image = stretch_for_display(science_hdu(output_frame).data)
+    save_jpg(display_image, large_path, 900)
+    save_jpg(display_image, small_path, 300)
+    return small_path, large_path
+
+
+def run_preview(stackframes, runtime_context, moluid):
+    output_frame = build_stacked_frame(stackframes, runtime_context, moluid)
+    small_path, large_path = render_jpgs(output_frame, runtime_context)
+    newest_stackframe = max(stackframes, key=lambda stackframe: stackframe.stack_num)
+    post_to_shipper_queue(
+        runtime_context.broker_url,
+        runtime_context.SHIPPER_EXCHANGE,
+        runtime_context.SHIPPER_QUEUE_NAME,
+        fits_path=None,
+        small_thumbnail=small_path,
+        large_thumbnail=large_path,
+        instrument_enqueue_timestamp=newest_stackframe.instrument_enqueue_timestamp,
+    )
+    logger.debug('Published smartstack preview', image=output_frame, extra_tags={'moluid': moluid})
+
+
+def run_final(stackframes, runtime_context, moluid):
+    output_frame = build_stacked_frame(stackframes, runtime_context, moluid)
+    output_products = output_frame.write(runtime_context)
+    small_path, large_path = render_jpgs(output_frame, runtime_context)
+    fits_path = os.path.join(output_products[0].filepath, output_products[0].filename)
+    logger.info('Created final smartstack', image=output_frame, extra_tags={'moluid': moluid})
+    return fits_path, small_path, large_path

--- a/banzai/smartstack_products.py
+++ b/banzai/smartstack_products.py
@@ -3,6 +3,7 @@ import os
 
 import numpy as np
 
+from banzai.context import Context
 from banzai.data import CCDData, HeaderOnly, combine_images
 from banzai.logs import get_logger
 from banzai.utils import date_utils, import_utils
@@ -14,6 +15,9 @@ from banzai.utils.messaging import post_to_shipper_queue
 logger = get_logger()
 
 STACK_NSIGMA_REJECT = 3.0
+# Smartstack products are RLEVEL 45 by definition: the filename, the thumbnail metadata, and the
+# written FITS header all derive from this constant rather than the caller's reduction_level.
+SMARTSTACK_REDUCTION_LEVEL = 45
 
 THUMBNAIL_HEADER_KEYS = (
     'DATE-OBS',
@@ -132,7 +136,7 @@ def build_stacked_frame(stackframes, runtime_context, moluid):
     base, rlevel, file_extension = input_images[0].filename.rpartition('-e09')
     if rlevel != '-e09' or file_extension not in ('.fits', '.fits.fz'):
         raise ValueError(f'Could not parse smartstack input filename: {input_images[0].filename}')
-    output_filename = f'{base}-e45{file_extension}'
+    output_filename = f'{base}-e{SMARTSTACK_REDUCTION_LEVEL}{file_extension}'
     output_frame = init_smartstack_frame(input_images[0], output_filename)
     combine_images([image['SCI'] for image in input_images], output_frame['SCI'],
                    nsigma=STACK_NSIGMA_REJECT, method='sum')
@@ -151,7 +155,7 @@ def build_thumbnail_metadata(output_frame):
         raise ValueError(f'Could not parse smartstack output filename: {output_frame.filename}')
 
     header = output_frame.primary_hdu.meta
-    metadata = {'frame_basename': frame_basename, 'RLEVEL': 45}
+    metadata = {'frame_basename': frame_basename, 'RLEVEL': SMARTSTACK_REDUCTION_LEVEL}
     for key in THUMBNAIL_HEADER_KEYS:
         value = header.get(key)
         if value is not None and not (isinstance(value, str) and not value.strip()):
@@ -199,7 +203,8 @@ def run_preview(stackframes, runtime_context, moluid):
 
 def run_final(stackframes, runtime_context, moluid):
     output_frame = build_stacked_frame(stackframes, runtime_context, moluid)
-    output_products = output_frame.write(runtime_context)
+    write_context = Context({**vars(runtime_context), 'reduction_level': SMARTSTACK_REDUCTION_LEVEL})
+    output_products = output_frame.write(write_context)
     small_path, large_path = render_jpgs(output_frame, runtime_context)
     fits_path = os.path.join(output_products[0].filepath, output_products[0].filename)
     logger.info('Created final smartstack', image=output_frame, extra_tags={'moluid': moluid})

--- a/banzai/smartstack_products.py
+++ b/banzai/smartstack_products.py
@@ -2,11 +2,12 @@ import datetime
 import os
 
 import numpy as np
+from photutils.background import Background2D
 
 from banzai.context import Context
 from banzai.data import CCDData, HeaderOnly, combine_images
 from banzai.logs import get_logger
-from banzai.utils import date_utils, import_utils
+from banzai.utils import date_utils, import_utils, stats
 from banzai.utils.file_utils import make_jpg_filenames
 from banzai.utils.jpg_utils import save_jpg, stretch_for_display
 from banzai.utils.messaging import post_to_shipper_queue
@@ -15,6 +16,9 @@ from banzai.utils.messaging import post_to_shipper_queue
 logger = get_logger()
 
 STACK_NSIGMA_REJECT = 3.0
+BACKGROUND_NSIGMA_CLIP = 5.0
+BACKGROUND_BOX_SIZE = (32, 32)
+BACKGROUND_FILTER_SIZE = (3, 3)
 # Smartstack products are RLEVEL 45 by definition: the filename, the thumbnail metadata, and the
 # written FITS header all derive from this constant rather than the caller's reduction_level.
 SMARTSTACK_REDUCTION_LEVEL = 45
@@ -115,14 +119,36 @@ def apply_smartstack_metadata(output_frame, input_images, stackframes, moluid):
     if science_header is not primary_header:
         headers.append(science_header)
 
+    n_stacked = len(sorted_inputs)
+    keyword_scale_factors = {'SATURATE': n_stacked, 'MAXLIN': n_stacked, 'RDNOISE': np.sqrt(n_stacked)}
+    newest_image = sorted_inputs[-1][1]
+    utstop = newest_image['SCI'].meta.get('UTSTOP')
+    if utstop is None:
+        utstop = newest_image.primary_hdu.meta.get('UTSTOP')
+
+    background = Background2D(output_frame['SCI'].data, BACKGROUND_BOX_SIZE,
+                              filter_size=BACKGROUND_FILTER_SIZE).background
+    mean_background = stats.sigma_clipped_mean(background, BACKGROUND_NSIGMA_CLIP)
+    median_background = np.median(background)
+    std_background = stats.robust_standard_deviation(background)
+
     for header in headers:
         header['EXPTIME'] = (total_exptime, '[s] Total exposure time')
         header['DATE-OBS'] = (date_utils.date_obs_to_string(earliest_dateobs), '[UTC] Earliest observation time')
-        header['NCOMBINE'] = (len(sorted_inputs), 'Number of images combined')
+        header['NCOMBINE'] = (n_stacked, 'Number of images combined')
         header['MOLUID'] = (moluid, 'Observation request UID')
         header['DATE'] = (date_utils.date_obs_to_string(date_created), '[UTC] Date this FITS file was written')
         if 'MOLFRNUM' in header:
             del header['MOLFRNUM']
+        for keyword, scale_factor in keyword_scale_factors.items():
+            inherited_value = header.get(keyword)
+            if inherited_value is not None:
+                header[keyword] = inherited_value * scale_factor
+        if utstop is not None:
+            header['UTSTOP'] = utstop
+        header['L1MEAN'] = (mean_background, '[counts] Sigma clipped mean of frame background')
+        header['L1MEDIAN'] = (median_background, '[counts] Median of frame background')
+        header['L1SIGMA'] = (std_background, '[counts] Robust std dev of frame background')
         header.add_history('Images combined to create smartstack image:')
         for index, (_, image) in enumerate(sorted_inputs, start=1):
             header[f'IMCOM{index:03d}'] = (image.filename, 'Image combined to create smartstack')

--- a/banzai/smartstack_products.py
+++ b/banzai/smartstack_products.py
@@ -4,7 +4,7 @@ import os
 import numpy as np
 
 from banzai.context import Context
-from banzai.data import CCDData, HeaderOnly, combine_images
+from banzai.data import CCDData, HeaderOnly, combine_images, create_combination_output_hdu
 from banzai.logs import get_logger
 from banzai.utils import date_utils, import_utils
 from banzai.utils.background_utils import background_header_cards, estimate_background
@@ -61,18 +61,6 @@ def open_stackframe_images(stackframes, runtime_context):
     return images
 
 
-def _new_stack_output_hdu(science_hdu):
-    """Create a blank SCI destination whose data, mask, and uncertainty combine_images will fill."""
-    return type(science_hdu)(
-        data=np.zeros_like(science_hdu.data),
-        meta=science_hdu.meta.copy(),
-        name=science_hdu.name,
-        mask=np.zeros_like(science_hdu.mask),
-        uncertainty=np.zeros_like(science_hdu.uncertainty),
-        memmap=science_hdu.memmap,
-    )
-
-
 def init_smartstack_frame(first_image, output_filename):
     science_hdu = first_image['SCI']
     if not isinstance(science_hdu, CCDData):
@@ -83,7 +71,8 @@ def init_smartstack_frame(first_image, output_filename):
         if isinstance(hdu, HeaderOnly):
             hdu_list.append(HeaderOnly(meta=hdu.meta.copy(), name=hdu.name))
         elif hdu is science_hdu:
-            hdu_list.append(_new_stack_output_hdu(science_hdu))
+            hdu_list.append(create_combination_output_hdu(science_hdu, science_hdu.meta,
+                                                          memmap=science_hdu.memmap))
 
     hdu_order = first_image.hdu_order
     if hdu_list and isinstance(hdu_list[0], HeaderOnly):

--- a/banzai/smartstack_products.py
+++ b/banzai/smartstack_products.py
@@ -6,14 +6,13 @@ import numpy as np
 from banzai.data import CCDData, HeaderOnly, combine_images, science_hdu
 from banzai.logs import get_logger
 from banzai.utils import date_utils, import_utils
-from banzai.utils.file_utils import make_jpg_filenames, make_smartstack_filename
+from banzai.utils.file_utils import make_jpg_filenames
 from banzai.utils.jpg_utils import save_jpg, stretch_for_display
 from banzai.utils.messaging import post_to_shipper_queue
 
 
 logger = get_logger()
 
-SMARTSTACK_REDUCTION_LEVEL = 45
 STACK_NSIGMA_REJECT = 3.0
 
 
@@ -99,8 +98,10 @@ def build_stacked_frame(stackframes, runtime_context, moluid):
         raise ValueError('Cannot build a smartstack without stackframes')
     stackframes = sorted(stackframes, key=lambda stackframe: stackframe.stack_num)
     input_images = open_stackframe_images(stackframes, runtime_context)
-    output_filename = make_smartstack_filename(
-        input_images[0].filename, reduction_level=SMARTSTACK_REDUCTION_LEVEL)
+    base, rlevel, file_extension = input_images[0].filename.rpartition('-e09')
+    if rlevel != '-e09' or file_extension not in ('.fits', '.fits.fz'):
+        raise ValueError(f'Could not parse smartstack input filename: {input_images[0].filename}')
+    output_filename = f'{base}-e45{file_extension}'
     output_frame = init_smartstack_frame(input_images[0], output_filename)
     combine_images(input_images, output_frame, nsigma=STACK_NSIGMA_REJECT, method='sum')
     apply_smartstack_metadata(output_frame, input_images, stackframes, moluid)

--- a/banzai/smartstack_products.py
+++ b/banzai/smartstack_products.py
@@ -221,7 +221,6 @@ def run_preview(stackframes, runtime_context, moluid):
     output_frame = build_stacked_frame(stackframes, runtime_context, moluid)
     thumbnail_metadata = build_thumbnail_metadata(output_frame)
     small_path, large_path = render_jpgs(output_frame, runtime_context)
-    newest_stackframe = max(stackframes, key=lambda stackframe: stackframe.stack_num)
     post_to_shipper_queue(
         runtime_context.broker_url,
         runtime_context.SHIPPER_EXCHANGE,
@@ -229,7 +228,6 @@ def run_preview(stackframes, runtime_context, moluid):
         fits_path=None,
         small_thumbnail=small_path,
         large_thumbnail=large_path,
-        instrument_enqueue_timestamp=newest_stackframe.instrument_enqueue_timestamp,
         thumbnail_metadata=thumbnail_metadata,
     )
     logger.debug('Published smartstack preview', image=output_frame, extra_tags={'moluid': moluid})

--- a/banzai/smartstack_products.py
+++ b/banzai/smartstack_products.py
@@ -100,10 +100,7 @@ def build_stacked_frame(stackframes, runtime_context, moluid):
     stackframes = sorted(stackframes, key=lambda stackframe: stackframe.stack_num)
     input_images = open_stackframe_images(stackframes, runtime_context)
     output_filename = make_smartstack_filename(
-        input_images[0].filename,
-        input_images[-1].filename,
-        reduction_level=SMARTSTACK_REDUCTION_LEVEL,
-    )
+        input_images[0].filename, reduction_level=SMARTSTACK_REDUCTION_LEVEL)
     output_frame = init_smartstack_frame(input_images[0], output_filename)
     combine_images(input_images, output_frame, nsigma=STACK_NSIGMA_REJECT, method='sum')
     apply_smartstack_metadata(output_frame, input_images, stackframes, moluid)

--- a/banzai/smartstack_products.py
+++ b/banzai/smartstack_products.py
@@ -101,8 +101,7 @@ def build_stacked_frame(stackframes, runtime_context, moluid):
     input_images = open_stackframe_images(stackframes, runtime_context)
     output_filename = make_smartstack_filename(
         input_images[0].filename,
-        stackframes[0].stack_num,
-        stackframes[-1].stack_num,
+        input_images[-1].filename,
         reduction_level=SMARTSTACK_REDUCTION_LEVEL,
     )
     output_frame = init_smartstack_frame(input_images[0], output_filename)

--- a/banzai/smartstack_products.py
+++ b/banzai/smartstack_products.py
@@ -15,6 +15,37 @@ logger = get_logger()
 
 STACK_NSIGMA_REJECT = 3.0
 
+THUMBNAIL_HEADER_KEYS = (
+    'DATE-OBS',
+    'DAY-OBS',
+    'INSTRUME',
+    'SITEID',
+    'TELID',
+    'MOLUID',
+    'NCOMBINE',
+    'FRMTOTAL',
+    'PROPID',
+    'OBSTYPE',
+    'BLKUID',
+    'REQNUM',
+    'TRACKNUM',
+    'EXPTIME',
+    'OBJECT',
+    'FILTER',
+    'L1PUBDAT',
+)
+REQUIRED_THUMBNAIL_METADATA = (
+    'frame_basename',
+    'DATE-OBS',
+    'DAY-OBS',
+    'INSTRUME',
+    'SITEID',
+    'TELID',
+    'MOLUID',
+    'NCOMBINE',
+    'FRMTOTAL',
+)
+
 
 def open_stackframe_images(stackframes, runtime_context):
     frame_factory = import_utils.import_attribute(runtime_context.FRAME_FACTORY)()
@@ -109,6 +140,33 @@ def build_stacked_frame(stackframes, runtime_context, moluid):
     return output_frame
 
 
+def build_thumbnail_metadata(output_frame):
+    """Build the aggregate metadata submitted with a JPEG-only preview."""
+    frame_basename = output_frame.filename
+    for extension in ('.fits.fz', '.fits'):
+        if frame_basename.endswith(extension):
+            frame_basename = frame_basename[:-len(extension)]
+            break
+    else:
+        raise ValueError(f'Could not parse smartstack output filename: {output_frame.filename}')
+
+    header = output_frame.primary_hdu.meta
+    metadata = {'frame_basename': frame_basename, 'RLEVEL': 45}
+    for key in THUMBNAIL_HEADER_KEYS:
+        value = header.get(key)
+        if value is not None and not (isinstance(value, str) and not value.strip()):
+            metadata[key] = value
+
+    missing_keys = [
+        key for key in REQUIRED_THUMBNAIL_METADATA
+        if key not in metadata or metadata[key] is None
+        or (isinstance(metadata[key], str) and not metadata[key].strip())
+    ]
+    if missing_keys:
+        raise ValueError(f'Missing required smartstack thumbnail metadata: {", ".join(missing_keys)}')
+    return metadata
+
+
 def render_jpgs(output_frame, runtime_context):
     output_directory = output_frame.get_output_directory(runtime_context)
     os.makedirs(output_directory, exist_ok=True)
@@ -123,6 +181,7 @@ def render_jpgs(output_frame, runtime_context):
 
 def run_preview(stackframes, runtime_context, moluid):
     output_frame = build_stacked_frame(stackframes, runtime_context, moluid)
+    thumbnail_metadata = build_thumbnail_metadata(output_frame)
     small_path, large_path = render_jpgs(output_frame, runtime_context)
     newest_stackframe = max(stackframes, key=lambda stackframe: stackframe.stack_num)
     post_to_shipper_queue(
@@ -133,6 +192,7 @@ def run_preview(stackframes, runtime_context, moluid):
         small_thumbnail=small_path,
         large_thumbnail=large_path,
         instrument_enqueue_timestamp=newest_stackframe.instrument_enqueue_timestamp,
+        thumbnail_metadata=thumbnail_metadata,
     )
     logger.debug('Published smartstack preview', image=output_frame, extra_tags={'moluid': moluid})
 

--- a/banzai/smartstack_products.py
+++ b/banzai/smartstack_products.py
@@ -2,12 +2,12 @@ import datetime
 import os
 
 import numpy as np
-from photutils.background import Background2D
 
 from banzai.context import Context
 from banzai.data import CCDData, HeaderOnly, combine_images
 from banzai.logs import get_logger
-from banzai.utils import date_utils, import_utils, stats
+from banzai.utils import date_utils, import_utils
+from banzai.utils.background_utils import background_header_cards, estimate_background
 from banzai.utils.file_utils import make_jpg_filenames
 from banzai.utils.jpg_utils import save_jpg, stretch_for_display
 from banzai.utils.messaging import post_to_shipper_queue
@@ -16,11 +16,6 @@ from banzai.utils.messaging import post_to_shipper_queue
 logger = get_logger()
 
 STACK_NSIGMA_REJECT = 3.0
-BACKGROUND_NSIGMA_CLIP = 5.0
-BACKGROUND_BOX_SIZE = (32, 32)
-BACKGROUND_FILTER_SIZE = (3, 3)
-# Smartstack products are RLEVEL 45 by definition: the filename, the thumbnail metadata, and the
-# written FITS header all derive from this constant rather than the caller's reduction_level.
 SMARTSTACK_REDUCTION_LEVEL = 45
 
 THUMBNAIL_HEADER_KEYS = (
@@ -66,29 +61,29 @@ def open_stackframe_images(stackframes, runtime_context):
     return images
 
 
-def _zeroed_ccd_hdu(ccd_hdu):
-    return type(ccd_hdu)(
-        data=np.zeros_like(ccd_hdu.data),
-        meta=ccd_hdu.meta.copy(),
-        name=ccd_hdu.name,
-        mask=np.zeros_like(ccd_hdu.mask),
-        uncertainty=np.zeros_like(ccd_hdu.uncertainty),
-        memmap=ccd_hdu.memmap,
+def _new_stack_output_hdu(science_hdu):
+    """Create a blank SCI destination whose data, mask, and uncertainty combine_images will fill."""
+    return type(science_hdu)(
+        data=np.zeros_like(science_hdu.data),
+        meta=science_hdu.meta.copy(),
+        name=science_hdu.name,
+        mask=np.zeros_like(science_hdu.mask),
+        uncertainty=np.zeros_like(science_hdu.uncertainty),
+        memmap=science_hdu.memmap,
     )
 
 
 def init_smartstack_frame(first_image, output_filename):
+    science_hdu = first_image['SCI']
+    if not isinstance(science_hdu, CCDData):
+        raise ValueError('Smartstack inputs must contain a SCI CCDData HDU')
+
     hdu_list = []
-    copied_science_hdu = False
     for hdu in first_image._hdus:
         if isinstance(hdu, HeaderOnly):
             hdu_list.append(HeaderOnly(meta=hdu.meta.copy(), name=hdu.name))
-        elif isinstance(hdu, CCDData) and not copied_science_hdu:
-            hdu_list.append(_zeroed_ccd_hdu(hdu))
-            copied_science_hdu = True
-
-    if not copied_science_hdu:
-        raise ValueError('Smartstack inputs must contain at least one CCDData HDU')
+        elif hdu is science_hdu:
+            hdu_list.append(_new_stack_output_hdu(science_hdu))
 
     hdu_order = first_image.hdu_order
     if hdu_list and isinstance(hdu_list[0], HeaderOnly):
@@ -133,11 +128,7 @@ def apply_smartstack_metadata(output_frame, input_images, stackframes, moluid):
     # The inherited L1MEAN/L1MEDIAN/L1SIGMA describe the first input, not the stack. Remeasure with the
     # same background-map method as photometry.SourceDetector so e45 values are comparable to e09 ones
     # (raw-pixel stats would inflate L1SIGMA with pixel noise; the map measures background variation).
-    background = Background2D(output_frame['SCI'].data, BACKGROUND_BOX_SIZE,
-                              filter_size=BACKGROUND_FILTER_SIZE).background
-    mean_background = stats.sigma_clipped_mean(background, BACKGROUND_NSIGMA_CLIP)
-    median_background = np.median(background)
-    std_background = stats.robust_standard_deviation(background)
+    background_cards = background_header_cards(estimate_background(output_frame['SCI'].data))
 
     for header in headers:
         header['EXPTIME'] = (total_exptime, '[s] Total exposure time')
@@ -154,9 +145,8 @@ def apply_smartstack_metadata(output_frame, input_images, stackframes, moluid):
                 header[keyword] = inherited_value * scale_factor
         if utstop is not None:
             header['UTSTOP'] = utstop
-        header['L1MEAN'] = (mean_background, '[counts] Sigma clipped mean of frame background')
-        header['L1MEDIAN'] = (median_background, '[counts] Median of frame background')
-        header['L1SIGMA'] = (std_background, '[counts] Robust std dev of frame background')
+        for keyword, card in background_cards.items():
+            header[keyword] = card
         header.add_history('Images combined to create smartstack image:')
         for index, (_, image) in enumerate(sorted_inputs, start=1):
             header[f'IMCOM{index:03d}'] = (image.filename, 'Image combined to create smartstack')

--- a/banzai/tests/test_smartstack_products.py
+++ b/banzai/tests/test_smartstack_products.py
@@ -102,7 +102,6 @@ def test_build_stacked_frame_structure(products, monkeypatch):
 
     output_frame = products.build_stacked_frame(stackframes, FakeContext(), 'mol-1')
 
-    assert products.SMARTSTACK_REDUCTION_LEVEL == 45
     assert isinstance(output_frame.primary_hdu, HeaderOnly)
     assert len(output_frame.ccd_hdus) == 1
     assert np.all(output_frame.ccd_hdus[0].data == 5.0)
@@ -138,10 +137,11 @@ def test_metadata(products):
         assert 'Images combined to create smartstack image:' in header['HISTORY']
 
 
-def test_output_names_stay_fixed_as_stack_grows(products, monkeypatch):
+@pytest.mark.parametrize('file_extension', ['.fits', '.fits.fz'])
+def test_output_names_stay_fixed_as_stack_grows(products, monkeypatch, file_extension):
     images_by_stack_num = {
-        1: make_frame('/tmp/cpt1m010-fa16-20240706-0031-e09.fits', value=1.0),
-        2: make_frame('/tmp/cpt1m010-fa16-20240706-0033-e09.fits', value=1.0),
+        1: make_frame(f'/tmp/cpt1m010-fa16-20240706-0031-e09{file_extension}', value=1.0),
+        2: make_frame(f'/tmp/cpt1m010-fa16-20240706-0033-e09{file_extension}', value=1.0),
     }
     monkeypatch.setattr(
         products,
@@ -153,7 +153,7 @@ def test_output_names_stay_fixed_as_stack_grows(products, monkeypatch):
     preview_frame = products.build_stacked_frame([stackframe(1)], FakeContext(), 'mol-1')
     final_frame = products.build_stacked_frame([stackframe(2), stackframe(1)], FakeContext(), 'mol-1')
 
-    expected_filename = 'cpt1m010-fa16-20240706-0031-e45.fits'
+    expected_filename = f'cpt1m010-fa16-20240706-0031-e45{file_extension}'
     assert preview_frame.filename == final_frame.filename == expected_filename
     expected_jpgs = ('cpt1m010-fa16-20240706-0031-e45-small_thumbnail.jpg',
                      'cpt1m010-fa16-20240706-0031-e45-large_thumbnail.jpg')
@@ -163,6 +163,18 @@ def test_output_names_stay_fixed_as_stack_grows(products, monkeypatch):
 def test_build_stacked_frame_rejects_empty(products):
     with pytest.raises(ValueError):
         products.build_stacked_frame([], FakeContext(), 'mol-1')
+
+
+@pytest.mark.parametrize('filename', [
+    '/tmp/cpt1m010-fa16-20240706-0031-e08.fits',
+    '/tmp/cpt1m010-fa16-20240706-0031-e09.txt',
+])
+def test_build_stacked_frame_rejects_invalid_filename(products, monkeypatch, filename):
+    input_image = make_frame(filename)
+    monkeypatch.setattr(products, 'open_stackframe_images', lambda rows, context: [input_image])
+
+    with pytest.raises(ValueError, match='Could not parse smartstack input filename'):
+        products.build_stacked_frame([stackframe(1)], FakeContext(), 'mol-1')
 
 
 def test_run_final_returns_paths_and_writes(products, monkeypatch, tmp_path):

--- a/banzai/tests/test_smartstack_products.py
+++ b/banzai/tests/test_smartstack_products.py
@@ -1,4 +1,3 @@
-import importlib
 import os
 from types import SimpleNamespace
 from unittest.mock import MagicMock
@@ -8,6 +7,7 @@ import pytest
 from astropy.io import fits
 from astropy.io.fits import Header
 
+import banzai.smartstack_products as products
 from banzai.context import Context
 from banzai.data import CCDData, HeaderOnly
 from banzai.lco import LCOObservationFrame
@@ -27,11 +27,6 @@ class FakeFrameFactory:
         return self.images_by_path.get(file_info['path'])
 
 
-@pytest.fixture
-def products():
-    return importlib.import_module('banzai.smartstack_products')
-
-
 def stackframe(stack_num, filepath=None, instrument_enqueue_timestamp=None):
     if filepath is None:
         filepath = f'/tmp/cpt1m010-fa16-20240706-{stack_num:04d}-e09.fits'
@@ -47,44 +42,34 @@ def stackframe(stack_num, filepath=None, instrument_enqueue_timestamp=None):
 def make_frame(filename, value=1.0, exptime=10.0, date_obs='2024-07-06T00:00:00.000', molfrnum=1,
                frmtotal=3, frame_class=FakeLCOObservationFrame, saturate=65535.0, maxlin=60000.0,
                rdnoise=8.0):
-    utstop = date_obs.split('T')[1]
-    primary_header = Header({
+    common_header = {
         'OBSTYPE': 'EXPOSE',
-        'DAY-OBS': '20240706',
         'DATE-OBS': date_obs,
-        'DATE': date_obs,
         'EXPTIME': exptime,
         'PROPID': 'standard',
         'SITEID': 'cpt',
         'INSTRUME': 'fa16',
         'TELID': '1m0a',
-        'FILTER': 'rp',
-        'OBJECT': 'test target',
         'MOLFRNUM': molfrnum,
         'FRMTOTAL': frmtotal,
-        'UTSTOP': utstop,
+        'UTSTOP': date_obs.split('T')[1],
         'SATURATE': saturate,
         'MAXLIN': maxlin,
         'RDNOISE': rdnoise,
+    }
+    primary_header = Header({
+        **common_header,
+        'DAY-OBS': '20240706',
+        'DATE': date_obs,
+        'FILTER': 'rp',
+        'OBJECT': 'test target',
     })
     science_header = Header({
+        **common_header,
         'EXTNAME': 'SCI',
-        'OBSTYPE': 'EXPOSE',
-        'DATE-OBS': date_obs,
-        'EXPTIME': exptime,
-        'PROPID': 'standard',
-        'SITEID': 'cpt',
-        'INSTRUME': 'fa16',
-        'TELID': '1m0a',
         'CCDSUM': '1 1',
         'DETSEC': f'[1:{FRAME_SHAPE[1]},1:{FRAME_SHAPE[0]}]',
         'DATASEC': f'[1:{FRAME_SHAPE[1]},1:{FRAME_SHAPE[0]}]',
-        'MOLFRNUM': molfrnum,
-        'FRMTOTAL': frmtotal,
-        'UTSTOP': utstop,
-        'SATURATE': saturate,
-        'MAXLIN': maxlin,
-        'RDNOISE': rdnoise,
     })
     science = FakeCCDData(
         data=value * np.ones(FRAME_SHAPE, dtype=np.float32),
@@ -113,7 +98,7 @@ def fake_sum_combine(products):
     return combine_images
 
 
-def test_build_stacked_frame_structure(products, monkeypatch):
+def test_build_stacked_frame_structure(monkeypatch):
     input_images = [
         make_frame('/tmp/cpt1m010-fa16-20240706-0031-e09.fits', value=2.0),
         make_frame('/tmp/cpt1m010-fa16-20240706-0032-e09.fits', value=3.0),
@@ -134,7 +119,7 @@ def test_build_stacked_frame_structure(products, monkeypatch):
     assert np.all(input_images[0].ccd_hdus[0].data == 2.0)
 
 
-def test_metadata(products):
+def test_metadata():
     output_frame = make_frame('/tmp/cpt1m010-fa16-20240706-0031-e45.fits', value=7.0)
     input_images = [
         make_frame('/tmp/cpt1m010-fa16-20240706-0033-e09.fits', exptime=20.0,
@@ -167,7 +152,7 @@ def test_metadata(products):
 
 
 @pytest.mark.parametrize('file_extension', ['.fits', '.fits.fz'])
-def test_build_thumbnail_metadata(products, file_extension):
+def test_build_thumbnail_metadata(file_extension):
     output_frame = make_frame(f'/tmp/cpt1m010-fa16-20240706-0031-e45{file_extension}', exptime=30.0)
     for header in (output_frame.primary_hdu.meta, output_frame['SCI'].meta):
         header['DAY-OBS'] = '20240706'
@@ -197,12 +182,9 @@ def test_build_thumbnail_metadata(products, file_extension):
         'OBJECT': 'test target',
         'FILTER': 'rp',
     }
-    assert 'MOLFRNUM' not in metadata
-    assert 'UTSTOP' not in metadata
-    assert 'size' not in metadata
 
 
-def test_build_thumbnail_metadata_rejects_missing_required_primary_value(products):
+def test_build_thumbnail_metadata_rejects_missing_required_primary_value():
     output_frame = make_frame('/tmp/cpt1m010-fa16-20240706-0031-e45.fits')
     for header in (output_frame.primary_hdu.meta, output_frame['SCI'].meta):
         header['MOLUID'] = 'mol-1'
@@ -214,7 +196,7 @@ def test_build_thumbnail_metadata_rejects_missing_required_primary_value(product
 
 
 @pytest.mark.parametrize('file_extension', ['.fits', '.fits.fz'])
-def test_output_names_stay_fixed_as_stack_grows(products, monkeypatch, file_extension):
+def test_output_names_stay_fixed_as_stack_grows(monkeypatch, file_extension):
     images_by_stack_num = {
         1: make_frame(f'/tmp/cpt1m010-fa16-20240706-0031-e09{file_extension}', value=1.0),
         2: make_frame(f'/tmp/cpt1m010-fa16-20240706-0033-e09{file_extension}', value=1.0),
@@ -231,12 +213,9 @@ def test_output_names_stay_fixed_as_stack_grows(products, monkeypatch, file_exte
 
     expected_filename = f'cpt1m010-fa16-20240706-0031-e45{file_extension}'
     assert preview_frame.filename == final_frame.filename == expected_filename
-    expected_jpgs = ('cpt1m010-fa16-20240706-0031-e45-small_thumbnail.jpg',
-                     'cpt1m010-fa16-20240706-0031-e45-large_thumbnail.jpg')
-    assert make_jpg_filenames(preview_frame.filename) == make_jpg_filenames(final_frame.filename) == expected_jpgs
 
 
-def test_build_stacked_frame_rejects_empty(products):
+def test_build_stacked_frame_rejects_empty():
     with pytest.raises(ValueError):
         products.build_stacked_frame([], FakeContext(), 'mol-1')
 
@@ -245,7 +224,7 @@ def test_build_stacked_frame_rejects_empty(products):
     '/tmp/cpt1m010-fa16-20240706-0031-e08.fits',
     '/tmp/cpt1m010-fa16-20240706-0031-e09.txt',
 ])
-def test_build_stacked_frame_rejects_invalid_filename(products, monkeypatch, filename):
+def test_build_stacked_frame_rejects_invalid_filename(monkeypatch, filename):
     input_image = make_frame(filename)
     monkeypatch.setattr(products, 'open_stackframe_images', lambda rows, context: [input_image])
 
@@ -253,12 +232,14 @@ def test_build_stacked_frame_rejects_invalid_filename(products, monkeypatch, fil
         products.build_stacked_frame([stackframe(1)], FakeContext(), 'mol-1')
 
 
-def test_run_final_returns_paths_and_writes(products, monkeypatch, tmp_path):
+@pytest.mark.parametrize('written_suffix', ['', '.fz'], ids=['fits', 'fpack'])
+def test_run_final_returns_paths_and_writes(monkeypatch, tmp_path, written_suffix):
     output_frame = make_frame('/tmp/cpt1m010-fa16-20240706-0031-e45.fits', value=1.0)
     context = FakeContext(processed_path=str(tmp_path))
     output_dir = output_frame.get_output_directory(context)
+    written_filename = output_frame.filename + written_suffix
     output_frame.write = MagicMock(
-        return_value=[SimpleNamespace(filepath=str(output_dir), filename=output_frame.filename)]
+        return_value=[SimpleNamespace(filepath=str(output_dir), filename=written_filename)]
     )
     small_name, large_name = make_jpg_filenames(output_frame.filename)
     monkeypatch.setattr(products, 'build_stacked_frame', lambda rows, runtime_context, moluid: output_frame)
@@ -267,41 +248,18 @@ def test_run_final_returns_paths_and_writes(products, monkeypatch, tmp_path):
 
     fits_path, small_path, large_path = products.run_final([stackframe(31), stackframe(32)], context, 'mol-1')
 
-    output_dir = output_frame.get_output_directory(context)
-    assert fits_path == os.path.join(output_dir, output_frame.filename)
+    assert fits_path == os.path.join(output_dir, written_filename)
     assert small_path == os.path.join(output_dir, small_name)
     assert large_path == os.path.join(output_dir, large_name)
+    assert os.path.exists(small_path)
+    assert os.path.exists(large_path)
     output_frame.write.assert_called_once()
     (write_context,) = output_frame.write.call_args.args
     assert write_context.reduction_level == products.SMARTSTACK_REDUCTION_LEVEL
     assert write_context.processed_path == context.processed_path
-    assert os.path.exists(small_path)
-    assert os.path.exists(large_path)
 
 
-def test_run_final_fits_path_honors_write_output(products, monkeypatch, tmp_path):
-    output_frame = make_frame('/tmp/cpt1m010-fa16-20240706-0031-e45.fits', value=1.0)
-    context = FakeContext(processed_path=str(tmp_path))
-    output_dir = output_frame.get_output_directory(context)
-    output_frame.write = MagicMock(
-        return_value=[SimpleNamespace(filepath=str(output_dir), filename=output_frame.filename + '.fz')]
-    )
-    monkeypatch.setattr(products, 'build_stacked_frame', lambda rows, runtime_context, moluid: output_frame)
-    monkeypatch.setattr(products, 'stretch_for_display', lambda data: np.zeros(FRAME_SHAPE, dtype=np.uint8))
-    monkeypatch.setattr(products, 'save_jpg', lambda display, path, max_size: open(path, 'wb').close())
-
-    fits_path, small_path, large_path = products.run_final([stackframe(31), stackframe(32)], context, 'mol-1')
-
-    assert fits_path == os.path.join(output_dir, output_frame.filename + '.fz')
-    assert fits_path.endswith('.fits.fz')
-    output_frame.write.assert_called_once()
-    (write_context,) = output_frame.write.call_args.args
-    assert write_context.reduction_level == products.SMARTSTACK_REDUCTION_LEVEL
-    assert os.path.exists(small_path)
-    assert os.path.exists(large_path)
-
-
-def test_run_preview_publishes_null_fits(products, monkeypatch, tmp_path):
+def test_run_preview_publishes_null_fits(monkeypatch, tmp_path):
     output_frame = make_frame('/tmp/cpt1m010-fa16-20240706-0031-e45.fits', value=1.0)
     for header in (output_frame.primary_hdu.meta, output_frame['SCI'].meta):
         header['MOLUID'] = 'mol-1'
@@ -338,7 +296,7 @@ def test_run_preview_publishes_null_fits(products, monkeypatch, tmp_path):
     )
 
 
-def test_open_stackframe_images_raises_on_unopenable(products):
+def test_open_stackframe_images_raises_on_unopenable():
     context = FakeContext(FRAME_FACTORY=f'{__name__}.FakeFrameFactory')
     FakeFrameFactory.images_by_path = {'/tmp/good.fits': make_frame('/tmp/good.fits')}
 
@@ -346,7 +304,7 @@ def test_open_stackframe_images_raises_on_unopenable(products):
         products.open_stackframe_images([stackframe(1, '/tmp/good.fits'), stackframe(2, '/tmp/missing.fits')], context)
 
 
-def test_write_and_reopen_smoke(products, monkeypatch, tmp_path):
+def test_write_and_reopen_smoke(monkeypatch, tmp_path):
     input_images = [
         make_frame('/tmp/cpt1m010-fa16-20240706-0031-e09.fits', value=2.0, frame_class=LCOObservationFrame),
         make_frame('/tmp/cpt1m010-fa16-20240706-0032-e09.fits', value=3.0, frame_class=LCOObservationFrame),

--- a/banzai/tests/test_smartstack_products.py
+++ b/banzai/tests/test_smartstack_products.py
@@ -41,7 +41,7 @@ def stackframe(stack_num, filepath=None, instrument_enqueue_timestamp=None):
 
 
 def make_frame(filename, value=1.0, exptime=10.0, date_obs='2024-07-06T00:00:00.000', molfrnum=1,
-               frame_class=FakeLCOObservationFrame):
+               frmtotal=3, frame_class=FakeLCOObservationFrame):
     primary_header = Header({
         'OBSTYPE': 'EXPOSE',
         'DAY-OBS': '20240706',
@@ -51,7 +51,11 @@ def make_frame(filename, value=1.0, exptime=10.0, date_obs='2024-07-06T00:00:00.
         'PROPID': 'standard',
         'SITEID': 'cpt',
         'INSTRUME': 'fa16',
+        'TELID': '1m0a',
+        'FILTER': 'rp',
+        'OBJECT': 'test target',
         'MOLFRNUM': molfrnum,
+        'FRMTOTAL': frmtotal,
     })
     science_header = Header({
         'EXTNAME': 'SCI',
@@ -59,10 +63,14 @@ def make_frame(filename, value=1.0, exptime=10.0, date_obs='2024-07-06T00:00:00.
         'DATE-OBS': date_obs,
         'EXPTIME': exptime,
         'PROPID': 'standard',
+        'SITEID': 'cpt',
+        'INSTRUME': 'fa16',
+        'TELID': '1m0a',
         'CCDSUM': '1 1',
         'DETSEC': '[1:3,1:2]',
         'DATASEC': '[1:3,1:2]',
         'MOLFRNUM': molfrnum,
+        'FRMTOTAL': frmtotal,
     })
     science = FakeCCDData(
         data=value * np.ones((2, 3), dtype=np.float32),
@@ -135,6 +143,53 @@ def test_metadata(products):
         assert header['IMCOM001'] == 'cpt1m010-fa16-20240706-0031-e09.fits'
         assert header['IMCOM002'] == 'cpt1m010-fa16-20240706-0033-e09.fits'
         assert 'Images combined to create smartstack image:' in header['HISTORY']
+
+
+@pytest.mark.parametrize('file_extension', ['.fits', '.fits.fz'])
+def test_build_thumbnail_metadata(products, file_extension):
+    output_frame = make_frame(f'/tmp/cpt1m010-fa16-20240706-0031-e45{file_extension}', exptime=30.0)
+    for header in (output_frame.primary_hdu.meta, output_frame['SCI'].meta):
+        header['DAY-OBS'] = '20240706'
+        header['MOLUID'] = 'mol-1'
+        header['NCOMBINE'] = 2
+        header['RLEVEL'] = 9
+        header['MOLFRNUM'] = 1
+        header['UTSTOP'] = '00:00:10.000'
+    output_frame['SCI'].meta['SITEID'] = 'ogg'
+
+    metadata = products.build_thumbnail_metadata(output_frame)
+
+    assert metadata == {
+        'frame_basename': 'cpt1m010-fa16-20240706-0031-e45',
+        'RLEVEL': 45,
+        'DATE-OBS': '2024-07-06T00:00:00.000',
+        'DAY-OBS': '20240706',
+        'INSTRUME': 'fa16',
+        'SITEID': 'cpt',
+        'TELID': '1m0a',
+        'MOLUID': 'mol-1',
+        'NCOMBINE': 2,
+        'FRMTOTAL': 3,
+        'PROPID': 'standard',
+        'OBSTYPE': 'EXPOSE',
+        'EXPTIME': 30.0,
+        'OBJECT': 'test target',
+        'FILTER': 'rp',
+    }
+    assert 'MOLFRNUM' not in metadata
+    assert 'UTSTOP' not in metadata
+    assert 'size' not in metadata
+
+
+def test_build_thumbnail_metadata_rejects_missing_required_primary_value(products):
+    output_frame = make_frame('/tmp/cpt1m010-fa16-20240706-0031-e45.fits')
+    for header in (output_frame.primary_hdu.meta, output_frame['SCI'].meta):
+        header['MOLUID'] = 'mol-1'
+        header['NCOMBINE'] = 1
+    output_frame.primary_hdu.meta['TELID'] = '  '
+
+    with pytest.raises(ValueError, match='TELID'):
+        products.build_thumbnail_metadata(output_frame)
 
 
 @pytest.mark.parametrize('file_extension', ['.fits', '.fits.fz'])
@@ -222,6 +277,9 @@ def test_run_final_fits_path_honors_write_output(products, monkeypatch, tmp_path
 
 def test_run_preview_publishes_null_fits(products, monkeypatch, tmp_path):
     output_frame = make_frame('/tmp/cpt1m010-fa16-20240706-0031-e45.fits', value=1.0)
+    for header in (output_frame.primary_hdu.meta, output_frame['SCI'].meta):
+        header['MOLUID'] = 'mol-1'
+        header['NCOMBINE'] = 3
     output_frame.write = MagicMock(return_value=[])
     publish = MagicMock()
     context = FakeContext(
@@ -250,6 +308,7 @@ def test_run_preview_publishes_null_fits(products, monkeypatch, tmp_path):
         small_thumbnail='/tmp/small.jpg',
         large_thumbnail='/tmp/large.jpg',
         instrument_enqueue_timestamp=333,
+        thumbnail_metadata=products.build_thumbnail_metadata(output_frame),
     )
 
 
@@ -286,4 +345,11 @@ def test_write_and_reopen_smoke(products, monkeypatch, tmp_path):
         assert 'BPM' in hdul
         assert 'ERR' in hdul
         assert hdul[0].header['RLEVEL'] == 45
+        for header in (hdul[0].header, hdul['SCI'].header):
+            assert header['NCOMBINE'] == 2
+            assert header['MOLUID'] == 'mol-1'
+            assert 'MOLFRNUM' not in header
+            assert header['IMCOM001'] == 'cpt1m010-fa16-20240706-0031-e09.fits'
+            assert header['IMCOM002'] == 'cpt1m010-fa16-20240706-0032-e09.fits'
+            assert 'IMCOM003' not in header
         assert np.all(hdul['SCI'].data == 5.0)

--- a/banzai/tests/test_smartstack_products.py
+++ b/banzai/tests/test_smartstack_products.py
@@ -139,14 +139,18 @@ def test_metadata(products):
 
 
 def test_output_filename_is_range_name(products, monkeypatch):
-    input_images = [make_frame('/tmp/cpt1m010-fa16-20240706-0031-e09.fits', value=1.0)]
-    stackframes = [stackframe(33), stackframe(31), stackframe(32)]
+    # The range comes from the first/last input file numbers, not stack positions,
+    # so two same-night stacks from one camera cannot collide.
+    input_images = [make_frame('/tmp/cpt1m010-fa16-20240706-0031-e09.fits', value=1.0),
+                    make_frame('/tmp/cpt1m010-fa16-20240706-0033-e09.fits', value=1.0)]
+    stackframes = [stackframe(2), stackframe(1)]
     monkeypatch.setattr(products, 'open_stackframe_images', lambda rows, context: input_images)
     monkeypatch.setattr(products, 'combine_images', fake_sum_combine(products))
 
     output_frame = products.build_stacked_frame(stackframes, FakeContext(), 'mol-1')
 
-    assert output_frame.filename == make_smartstack_filename(input_images[0].filename, 31, 33)
+    assert output_frame.filename == 'cpt1m010-fa16-20240706-0031-0033-e45.fits'
+    assert output_frame.filename == make_smartstack_filename(input_images[0].filename, input_images[-1].filename)
 
 
 def test_build_stacked_frame_rejects_empty(products):

--- a/banzai/tests/test_smartstack_products.py
+++ b/banzai/tests/test_smartstack_products.py
@@ -27,15 +27,12 @@ class FakeFrameFactory:
         return self.images_by_path.get(file_info['path'])
 
 
-def stackframe(stack_num, filepath=None, instrument_enqueue_timestamp=None):
+def stackframe(stack_num, filepath=None):
     if filepath is None:
         filepath = f'/tmp/cpt1m010-fa16-20240706-{stack_num:04d}-e09.fits'
-    if instrument_enqueue_timestamp is None:
-        instrument_enqueue_timestamp = stack_num * 1000
     return SimpleNamespace(
         filepath=filepath,
         stack_num=stack_num,
-        instrument_enqueue_timestamp=instrument_enqueue_timestamp,
     )
 
 
@@ -272,11 +269,7 @@ def test_run_preview_publishes_null_fits(monkeypatch, tmp_path):
         SHIPPER_EXCHANGE='ship_files',
         SHIPPER_QUEUE_NAME='ship',
     )
-    rows = [
-        stackframe(31, instrument_enqueue_timestamp=111),
-        stackframe(33, instrument_enqueue_timestamp=333),
-        stackframe(32, instrument_enqueue_timestamp=222),
-    ]
+    rows = [stackframe(31), stackframe(32), stackframe(33)]
     monkeypatch.setattr(products, 'build_stacked_frame', lambda stackframes, runtime_context, moluid: output_frame)
     monkeypatch.setattr(products, 'render_jpgs', lambda frame, runtime_context: ('/tmp/small.jpg', '/tmp/large.jpg'))
     monkeypatch.setattr(products, 'post_to_shipper_queue', publish)
@@ -291,7 +284,6 @@ def test_run_preview_publishes_null_fits(monkeypatch, tmp_path):
         fits_path=None,
         small_thumbnail='/tmp/small.jpg',
         large_thumbnail='/tmp/large.jpg',
-        instrument_enqueue_timestamp=333,
         thumbnail_metadata=products.build_thumbnail_metadata(output_frame),
     )
 

--- a/banzai/tests/test_smartstack_products.py
+++ b/banzai/tests/test_smartstack_products.py
@@ -250,7 +250,10 @@ def test_run_final_returns_paths_and_writes(products, monkeypatch, tmp_path):
     assert fits_path == os.path.join(output_dir, output_frame.filename)
     assert small_path == os.path.join(output_dir, small_name)
     assert large_path == os.path.join(output_dir, large_name)
-    output_frame.write.assert_called_once_with(context)
+    output_frame.write.assert_called_once()
+    (write_context,) = output_frame.write.call_args.args
+    assert write_context.reduction_level == products.SMARTSTACK_REDUCTION_LEVEL
+    assert write_context.processed_path == context.processed_path
     assert os.path.exists(small_path)
     assert os.path.exists(large_path)
 
@@ -270,7 +273,9 @@ def test_run_final_fits_path_honors_write_output(products, monkeypatch, tmp_path
 
     assert fits_path == os.path.join(output_dir, output_frame.filename + '.fz')
     assert fits_path.endswith('.fits.fz')
-    output_frame.write.assert_called_once_with(context)
+    output_frame.write.assert_called_once()
+    (write_context,) = output_frame.write.call_args.args
+    assert write_context.reduction_level == products.SMARTSTACK_REDUCTION_LEVEL
     assert os.path.exists(small_path)
     assert os.path.exists(large_path)
 
@@ -326,19 +331,20 @@ def test_write_and_reopen_smoke(products, monkeypatch, tmp_path):
         make_frame('/tmp/cpt1m010-fa16-20240706-0032-e09.fits', value=3.0, frame_class=LCOObservationFrame),
     ]
     stackframes = [stackframe(31, '/tmp/31.fits'), stackframe(32, '/tmp/32.fits')]
+    # Deliberately wrong reduction_level: run_final must stamp RLEVEL 45 regardless of the caller's context.
     context = Context(vars(FakeContext(
         processed_path=str(tmp_path),
-        reduction_level=45,
+        reduction_level=91,
         fpack=False,
         post_to_archive=False,
         no_file_cache=False,
     )))
     monkeypatch.setattr(products, 'open_stackframe_images', lambda rows, runtime_context: input_images)
+    monkeypatch.setattr(products, 'stretch_for_display', lambda data: np.zeros((2, 3), dtype=np.uint8))
+    monkeypatch.setattr(products, 'save_jpg', lambda display, path, max_size: open(path, 'wb').close())
     monkeypatch.setattr('banzai.lco.dbs.save_processed_image', lambda filename, md5, db_address: None)
 
-    output_frame = products.build_stacked_frame(stackframes, context, 'mol-1')
-    output_frame.write(context)
-    fits_path = os.path.join(output_frame.get_output_directory(context), output_frame.filename)
+    fits_path, _, _ = products.run_final(stackframes, context, 'mol-1')
 
     with fits.open(fits_path) as hdul:
         assert 'SCI' in hdul

--- a/banzai/tests/test_smartstack_products.py
+++ b/banzai/tests/test_smartstack_products.py
@@ -13,7 +13,7 @@ from banzai.data import CCDData, HeaderOnly
 from banzai.lco import LCOObservationFrame
 from banzai.tests.utils import FakeCCDData, FakeContext, FakeInstrument, FakeLCOObservationFrame
 from banzai.utils import date_utils
-from banzai.utils.file_utils import make_jpg_filenames, make_smartstack_filename
+from banzai.utils.file_utils import make_jpg_filenames
 
 
 class FakeFrameFactory:
@@ -114,7 +114,7 @@ def test_build_stacked_frame_structure(products, monkeypatch):
 
 
 def test_metadata(products):
-    output_frame = make_frame('/tmp/cpt1m010-fa16-20240706-0031-0033-e45.fits', value=0.0)
+    output_frame = make_frame('/tmp/cpt1m010-fa16-20240706-0031-e45.fits', value=0.0)
     input_images = [
         make_frame('/tmp/cpt1m010-fa16-20240706-0033-e09.fits', exptime=20.0,
                    date_obs='2024-07-06T00:01:00.000'),
@@ -138,19 +138,26 @@ def test_metadata(products):
         assert 'Images combined to create smartstack image:' in header['HISTORY']
 
 
-def test_output_filename_is_range_name(products, monkeypatch):
-    # The range comes from the first/last input file numbers, not stack positions,
-    # so two same-night stacks from one camera cannot collide.
-    input_images = [make_frame('/tmp/cpt1m010-fa16-20240706-0031-e09.fits', value=1.0),
-                    make_frame('/tmp/cpt1m010-fa16-20240706-0033-e09.fits', value=1.0)]
-    stackframes = [stackframe(2), stackframe(1)]
-    monkeypatch.setattr(products, 'open_stackframe_images', lambda rows, context: input_images)
+def test_output_names_stay_fixed_as_stack_grows(products, monkeypatch):
+    images_by_stack_num = {
+        1: make_frame('/tmp/cpt1m010-fa16-20240706-0031-e09.fits', value=1.0),
+        2: make_frame('/tmp/cpt1m010-fa16-20240706-0033-e09.fits', value=1.0),
+    }
+    monkeypatch.setattr(
+        products,
+        'open_stackframe_images',
+        lambda rows, context: [images_by_stack_num[row.stack_num] for row in rows],
+    )
     monkeypatch.setattr(products, 'combine_images', fake_sum_combine(products))
 
-    output_frame = products.build_stacked_frame(stackframes, FakeContext(), 'mol-1')
+    preview_frame = products.build_stacked_frame([stackframe(1)], FakeContext(), 'mol-1')
+    final_frame = products.build_stacked_frame([stackframe(2), stackframe(1)], FakeContext(), 'mol-1')
 
-    assert output_frame.filename == 'cpt1m010-fa16-20240706-0031-0033-e45.fits'
-    assert output_frame.filename == make_smartstack_filename(input_images[0].filename, input_images[-1].filename)
+    expected_filename = 'cpt1m010-fa16-20240706-0031-e45.fits'
+    assert preview_frame.filename == final_frame.filename == expected_filename
+    expected_jpgs = ('cpt1m010-fa16-20240706-0031-e45-small_thumbnail.jpg',
+                     'cpt1m010-fa16-20240706-0031-e45-large_thumbnail.jpg')
+    assert make_jpg_filenames(preview_frame.filename) == make_jpg_filenames(final_frame.filename) == expected_jpgs
 
 
 def test_build_stacked_frame_rejects_empty(products):
@@ -159,7 +166,7 @@ def test_build_stacked_frame_rejects_empty(products):
 
 
 def test_run_final_returns_paths_and_writes(products, monkeypatch, tmp_path):
-    output_frame = make_frame('/tmp/cpt1m010-fa16-20240706-0031-0032-e45.fits', value=1.0)
+    output_frame = make_frame('/tmp/cpt1m010-fa16-20240706-0031-e45.fits', value=1.0)
     context = FakeContext(processed_path=str(tmp_path))
     output_dir = output_frame.get_output_directory(context)
     output_frame.write = MagicMock(
@@ -182,7 +189,7 @@ def test_run_final_returns_paths_and_writes(products, monkeypatch, tmp_path):
 
 
 def test_run_final_fits_path_honors_write_output(products, monkeypatch, tmp_path):
-    output_frame = make_frame('/tmp/cpt1m010-fa16-20240706-0031-0032-e45.fits', value=1.0)
+    output_frame = make_frame('/tmp/cpt1m010-fa16-20240706-0031-e45.fits', value=1.0)
     context = FakeContext(processed_path=str(tmp_path))
     output_dir = output_frame.get_output_directory(context)
     output_frame.write = MagicMock(
@@ -202,7 +209,7 @@ def test_run_final_fits_path_honors_write_output(products, monkeypatch, tmp_path
 
 
 def test_run_preview_publishes_null_fits(products, monkeypatch, tmp_path):
-    output_frame = make_frame('/tmp/cpt1m010-fa16-20240706-0031-0032-e45.fits', value=1.0)
+    output_frame = make_frame('/tmp/cpt1m010-fa16-20240706-0031-e45.fits', value=1.0)
     output_frame.write = MagicMock(return_value=[])
     publish = MagicMock()
     context = FakeContext(

--- a/banzai/tests/test_smartstack_products.py
+++ b/banzai/tests/test_smartstack_products.py
@@ -1,0 +1,266 @@
+import importlib
+import os
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import numpy as np
+import pytest
+from astropy.io import fits
+from astropy.io.fits import Header
+
+from banzai.context import Context
+from banzai.data import CCDData, HeaderOnly
+from banzai.lco import LCOObservationFrame
+from banzai.tests.utils import FakeCCDData, FakeContext, FakeInstrument, FakeLCOObservationFrame
+from banzai.utils import date_utils
+from banzai.utils.file_utils import make_jpg_filenames, make_smartstack_filename
+
+
+class FakeFrameFactory:
+    images_by_path = {}
+
+    def open(self, file_info, runtime_context):
+        return self.images_by_path.get(file_info['path'])
+
+
+@pytest.fixture
+def products():
+    return importlib.import_module('banzai.smartstack_products')
+
+
+def stackframe(stack_num, filepath=None, instrument_enqueue_timestamp=None):
+    if filepath is None:
+        filepath = f'/tmp/cpt1m010-fa16-20240706-{stack_num:04d}-e09.fits'
+    if instrument_enqueue_timestamp is None:
+        instrument_enqueue_timestamp = stack_num * 1000
+    return SimpleNamespace(
+        filepath=filepath,
+        stack_num=stack_num,
+        instrument_enqueue_timestamp=instrument_enqueue_timestamp,
+    )
+
+
+def make_frame(filename, value=1.0, exptime=10.0, date_obs='2024-07-06T00:00:00.000', molfrnum=1,
+               frame_class=FakeLCOObservationFrame):
+    primary_header = Header({
+        'OBSTYPE': 'EXPOSE',
+        'DAY-OBS': '20240706',
+        'DATE-OBS': date_obs,
+        'DATE': date_obs,
+        'EXPTIME': exptime,
+        'PROPID': 'standard',
+        'SITEID': 'cpt',
+        'INSTRUME': 'fa16',
+        'MOLFRNUM': molfrnum,
+    })
+    science_header = Header({
+        'EXTNAME': 'SCI',
+        'OBSTYPE': 'EXPOSE',
+        'DATE-OBS': date_obs,
+        'EXPTIME': exptime,
+        'PROPID': 'standard',
+        'CCDSUM': '1 1',
+        'DETSEC': '[1:3,1:2]',
+        'DATASEC': '[1:3,1:2]',
+        'MOLFRNUM': molfrnum,
+    })
+    science = FakeCCDData(
+        data=value * np.ones((2, 3), dtype=np.float32),
+        mask=np.zeros((2, 3), dtype=np.uint8),
+        uncertainty=np.ones((2, 3), dtype=np.float32),
+        meta=science_header,
+        name='SCI',
+        memmap=False,
+    )
+    frame = frame_class(
+        hdu_list=[HeaderOnly(meta=primary_header, name=''), science],
+        file_path=filename,
+        hdu_order=['SCI', 'BPM', 'ERR'],
+    )
+    frame.instrument = FakeInstrument(site='cpt', camera='fa16')
+    return frame
+
+
+def fake_sum_combine(products):
+    def combine_images(images, output_frame, nsigma, method):
+        assert nsigma == products.STACK_NSIGMA_REJECT
+        assert method == 'sum'
+        output_frame.ccd_hdus[0].data[:] = sum(image.ccd_hdus[0].data for image in images)
+        return output_frame
+
+    return combine_images
+
+
+def test_build_stacked_frame_structure(products, monkeypatch):
+    input_images = [
+        make_frame('/tmp/cpt1m010-fa16-20240706-0031-e09.fits', value=2.0),
+        make_frame('/tmp/cpt1m010-fa16-20240706-0032-e09.fits', value=3.0),
+    ]
+    stackframes = [stackframe(31, '/tmp/31.fits'), stackframe(32, '/tmp/32.fits')]
+    monkeypatch.setattr(products, 'open_stackframe_images', lambda rows, context: input_images)
+    monkeypatch.setattr(products, 'combine_images', fake_sum_combine(products))
+
+    output_frame = products.build_stacked_frame(stackframes, FakeContext(), 'mol-1')
+
+    assert products.SMARTSTACK_REDUCTION_LEVEL == 45
+    assert isinstance(output_frame.primary_hdu, HeaderOnly)
+    assert len(output_frame.ccd_hdus) == 1
+    assert np.all(output_frame.ccd_hdus[0].data == 5.0)
+    assert np.all(output_frame.ccd_hdus[0].mask == 0)
+    assert np.all(output_frame.ccd_hdus[0].uncertainty == 0.0)
+    assert output_frame.hdu_order == ['', 'SCI', 'BPM', 'ERR']
+    assert output_frame.instrument is input_images[0].instrument
+    assert np.all(input_images[0].ccd_hdus[0].data == 2.0)
+
+
+def test_metadata(products):
+    output_frame = make_frame('/tmp/cpt1m010-fa16-20240706-0031-0033-e45.fits', value=0.0)
+    input_images = [
+        make_frame('/tmp/cpt1m010-fa16-20240706-0033-e09.fits', exptime=20.0,
+                   date_obs='2024-07-06T00:01:00.000'),
+        make_frame('/tmp/cpt1m010-fa16-20240706-0031-e09.fits', exptime=10.0,
+                   date_obs='2024-07-06T00:00:00.000'),
+    ]
+    stackframes = [stackframe(33), stackframe(31)]
+
+    products.apply_smartstack_metadata(output_frame, input_images, stackframes, 'mol-1')
+
+    for header in (output_frame.primary_hdu.meta, output_frame.ccd_hdus[0].meta):
+        assert header['EXPTIME'] == 30.0
+        assert header.comments['EXPTIME'] == '[s] Total exposure time'
+        assert header['DATE-OBS'] == date_utils.date_obs_to_string(input_images[1].dateobs)
+        assert header['NCOMBINE'] == 2
+        assert header['MOLUID'] == 'mol-1'
+        assert 'DATE' in header
+        assert 'MOLFRNUM' not in header
+        assert header['IMCOM001'] == 'cpt1m010-fa16-20240706-0031-e09.fits'
+        assert header['IMCOM002'] == 'cpt1m010-fa16-20240706-0033-e09.fits'
+        assert 'Images combined to create smartstack image:' in header['HISTORY']
+
+
+def test_output_filename_is_range_name(products, monkeypatch):
+    input_images = [make_frame('/tmp/cpt1m010-fa16-20240706-0031-e09.fits', value=1.0)]
+    stackframes = [stackframe(33), stackframe(31), stackframe(32)]
+    monkeypatch.setattr(products, 'open_stackframe_images', lambda rows, context: input_images)
+    monkeypatch.setattr(products, 'combine_images', fake_sum_combine(products))
+
+    output_frame = products.build_stacked_frame(stackframes, FakeContext(), 'mol-1')
+
+    assert output_frame.filename == make_smartstack_filename(input_images[0].filename, 31, 33)
+
+
+def test_build_stacked_frame_rejects_empty(products):
+    with pytest.raises(ValueError):
+        products.build_stacked_frame([], FakeContext(), 'mol-1')
+
+
+def test_run_final_returns_paths_and_writes(products, monkeypatch, tmp_path):
+    output_frame = make_frame('/tmp/cpt1m010-fa16-20240706-0031-0032-e45.fits', value=1.0)
+    context = FakeContext(processed_path=str(tmp_path))
+    output_dir = output_frame.get_output_directory(context)
+    output_frame.write = MagicMock(
+        return_value=[SimpleNamespace(filepath=str(output_dir), filename=output_frame.filename)]
+    )
+    small_name, large_name = make_jpg_filenames(output_frame.filename)
+    monkeypatch.setattr(products, 'build_stacked_frame', lambda rows, runtime_context, moluid: output_frame)
+    monkeypatch.setattr(products, 'stretch_for_display', lambda data: np.zeros((2, 3), dtype=np.uint8))
+    monkeypatch.setattr(products, 'save_jpg', lambda display, path, max_size: open(path, 'wb').close())
+
+    fits_path, small_path, large_path = products.run_final([stackframe(31), stackframe(32)], context, 'mol-1')
+
+    output_dir = output_frame.get_output_directory(context)
+    assert fits_path == os.path.join(output_dir, output_frame.filename)
+    assert small_path == os.path.join(output_dir, small_name)
+    assert large_path == os.path.join(output_dir, large_name)
+    output_frame.write.assert_called_once_with(context)
+    assert os.path.exists(small_path)
+    assert os.path.exists(large_path)
+
+
+def test_run_final_fits_path_honors_write_output(products, monkeypatch, tmp_path):
+    output_frame = make_frame('/tmp/cpt1m010-fa16-20240706-0031-0032-e45.fits', value=1.0)
+    context = FakeContext(processed_path=str(tmp_path))
+    output_dir = output_frame.get_output_directory(context)
+    output_frame.write = MagicMock(
+        return_value=[SimpleNamespace(filepath=str(output_dir), filename=output_frame.filename + '.fz')]
+    )
+    monkeypatch.setattr(products, 'build_stacked_frame', lambda rows, runtime_context, moluid: output_frame)
+    monkeypatch.setattr(products, 'stretch_for_display', lambda data: np.zeros((2, 3), dtype=np.uint8))
+    monkeypatch.setattr(products, 'save_jpg', lambda display, path, max_size: open(path, 'wb').close())
+
+    fits_path, small_path, large_path = products.run_final([stackframe(31), stackframe(32)], context, 'mol-1')
+
+    assert fits_path == os.path.join(output_dir, output_frame.filename + '.fz')
+    assert fits_path.endswith('.fits.fz')
+    output_frame.write.assert_called_once_with(context)
+    assert os.path.exists(small_path)
+    assert os.path.exists(large_path)
+
+
+def test_run_preview_publishes_null_fits(products, monkeypatch, tmp_path):
+    output_frame = make_frame('/tmp/cpt1m010-fa16-20240706-0031-0032-e45.fits', value=1.0)
+    output_frame.write = MagicMock(return_value=[])
+    publish = MagicMock()
+    context = FakeContext(
+        processed_path=str(tmp_path),
+        broker_url='amqp://broker',
+        SHIPPER_EXCHANGE='ship_files',
+        SHIPPER_QUEUE_NAME='ship',
+    )
+    rows = [
+        stackframe(31, instrument_enqueue_timestamp=111),
+        stackframe(33, instrument_enqueue_timestamp=333),
+        stackframe(32, instrument_enqueue_timestamp=222),
+    ]
+    monkeypatch.setattr(products, 'build_stacked_frame', lambda stackframes, runtime_context, moluid: output_frame)
+    monkeypatch.setattr(products, 'render_jpgs', lambda frame, runtime_context: ('/tmp/small.jpg', '/tmp/large.jpg'))
+    monkeypatch.setattr(products, 'post_to_shipper_queue', publish)
+
+    products.run_preview(rows, context, 'mol-1')
+
+    output_frame.write.assert_not_called()
+    publish.assert_called_once_with(
+        context.broker_url,
+        context.SHIPPER_EXCHANGE,
+        context.SHIPPER_QUEUE_NAME,
+        fits_path=None,
+        small_thumbnail='/tmp/small.jpg',
+        large_thumbnail='/tmp/large.jpg',
+        instrument_enqueue_timestamp=333,
+    )
+
+
+def test_open_stackframe_images_raises_on_unopenable(products):
+    context = FakeContext(FRAME_FACTORY=f'{__name__}.FakeFrameFactory')
+    FakeFrameFactory.images_by_path = {'/tmp/good.fits': make_frame('/tmp/good.fits')}
+
+    with pytest.raises(RuntimeError, match='/tmp/missing.fits'):
+        products.open_stackframe_images([stackframe(1, '/tmp/good.fits'), stackframe(2, '/tmp/missing.fits')], context)
+
+
+def test_write_and_reopen_smoke(products, monkeypatch, tmp_path):
+    input_images = [
+        make_frame('/tmp/cpt1m010-fa16-20240706-0031-e09.fits', value=2.0, frame_class=LCOObservationFrame),
+        make_frame('/tmp/cpt1m010-fa16-20240706-0032-e09.fits', value=3.0, frame_class=LCOObservationFrame),
+    ]
+    stackframes = [stackframe(31, '/tmp/31.fits'), stackframe(32, '/tmp/32.fits')]
+    context = Context(vars(FakeContext(
+        processed_path=str(tmp_path),
+        reduction_level=45,
+        fpack=False,
+        post_to_archive=False,
+        no_file_cache=False,
+    )))
+    monkeypatch.setattr(products, 'open_stackframe_images', lambda rows, runtime_context: input_images)
+    monkeypatch.setattr('banzai.lco.dbs.save_processed_image', lambda filename, md5, db_address: None)
+
+    output_frame = products.build_stacked_frame(stackframes, context, 'mol-1')
+    output_frame.write(context)
+    fits_path = os.path.join(output_frame.get_output_directory(context), output_frame.filename)
+
+    with fits.open(fits_path) as hdul:
+        assert 'SCI' in hdul
+        assert 'BPM' in hdul
+        assert 'ERR' in hdul
+        assert hdul[0].header['RLEVEL'] == 45
+        assert np.all(hdul['SCI'].data == 5.0)

--- a/banzai/tests/test_smartstack_products.py
+++ b/banzai/tests/test_smartstack_products.py
@@ -82,11 +82,11 @@ def make_frame(filename, value=1.0, exptime=10.0, date_obs='2024-07-06T00:00:00.
 
 
 def fake_sum_combine(products):
-    def combine_images(images, output_frame, nsigma, method):
+    def combine_images(images, output_image, nsigma, method):
         assert nsigma == products.STACK_NSIGMA_REJECT
         assert method == 'sum'
-        output_frame.ccd_hdus[0].data[:] = sum(image.ccd_hdus[0].data for image in images)
-        return output_frame
+        output_image.data[:] = sum(image.data for image in images)
+        return output_image
 
     return combine_images
 

--- a/banzai/tests/test_smartstack_products.py
+++ b/banzai/tests/test_smartstack_products.py
@@ -16,6 +16,10 @@ from banzai.utils import date_utils
 from banzai.utils.file_utils import make_jpg_filenames
 
 
+# Large enough for the (32, 32) background mesh that apply_smartstack_metadata measures L1 stats on.
+FRAME_SHAPE = (64, 64)
+
+
 class FakeFrameFactory:
     images_by_path = {}
 
@@ -41,7 +45,9 @@ def stackframe(stack_num, filepath=None, instrument_enqueue_timestamp=None):
 
 
 def make_frame(filename, value=1.0, exptime=10.0, date_obs='2024-07-06T00:00:00.000', molfrnum=1,
-               frmtotal=3, frame_class=FakeLCOObservationFrame):
+               frmtotal=3, frame_class=FakeLCOObservationFrame, saturate=65535.0, maxlin=60000.0,
+               rdnoise=8.0):
+    utstop = date_obs.split('T')[1]
     primary_header = Header({
         'OBSTYPE': 'EXPOSE',
         'DAY-OBS': '20240706',
@@ -56,6 +62,10 @@ def make_frame(filename, value=1.0, exptime=10.0, date_obs='2024-07-06T00:00:00.
         'OBJECT': 'test target',
         'MOLFRNUM': molfrnum,
         'FRMTOTAL': frmtotal,
+        'UTSTOP': utstop,
+        'SATURATE': saturate,
+        'MAXLIN': maxlin,
+        'RDNOISE': rdnoise,
     })
     science_header = Header({
         'EXTNAME': 'SCI',
@@ -67,15 +77,19 @@ def make_frame(filename, value=1.0, exptime=10.0, date_obs='2024-07-06T00:00:00.
         'INSTRUME': 'fa16',
         'TELID': '1m0a',
         'CCDSUM': '1 1',
-        'DETSEC': '[1:3,1:2]',
-        'DATASEC': '[1:3,1:2]',
+        'DETSEC': f'[1:{FRAME_SHAPE[1]},1:{FRAME_SHAPE[0]}]',
+        'DATASEC': f'[1:{FRAME_SHAPE[1]},1:{FRAME_SHAPE[0]}]',
         'MOLFRNUM': molfrnum,
         'FRMTOTAL': frmtotal,
+        'UTSTOP': utstop,
+        'SATURATE': saturate,
+        'MAXLIN': maxlin,
+        'RDNOISE': rdnoise,
     })
     science = FakeCCDData(
-        data=value * np.ones((2, 3), dtype=np.float32),
-        mask=np.zeros((2, 3), dtype=np.uint8),
-        uncertainty=np.ones((2, 3), dtype=np.float32),
+        data=value * np.ones(FRAME_SHAPE, dtype=np.float32),
+        mask=np.zeros(FRAME_SHAPE, dtype=np.uint8),
+        uncertainty=np.ones(FRAME_SHAPE, dtype=np.float32),
         meta=science_header,
         name='SCI',
         memmap=False,
@@ -121,7 +135,7 @@ def test_build_stacked_frame_structure(products, monkeypatch):
 
 
 def test_metadata(products):
-    output_frame = make_frame('/tmp/cpt1m010-fa16-20240706-0031-e45.fits', value=0.0)
+    output_frame = make_frame('/tmp/cpt1m010-fa16-20240706-0031-e45.fits', value=7.0)
     input_images = [
         make_frame('/tmp/cpt1m010-fa16-20240706-0033-e09.fits', exptime=20.0,
                    date_obs='2024-07-06T00:01:00.000'),
@@ -133,6 +147,13 @@ def test_metadata(products):
     products.apply_smartstack_metadata(output_frame, input_images, stackframes, 'mol-1')
 
     for header in (output_frame.primary_hdu.meta, output_frame.ccd_hdus[0].meta):
+        assert header['SATURATE'] == pytest.approx(2.0 * 65535.0)
+        assert header['MAXLIN'] == pytest.approx(2.0 * 60000.0)
+        assert header['RDNOISE'] == pytest.approx(8.0 * np.sqrt(2.0))
+        assert header['UTSTOP'] == '00:01:00.000'
+        assert header['L1MEAN'] == pytest.approx(7.0)
+        assert header['L1MEDIAN'] == pytest.approx(7.0)
+        assert header['L1SIGMA'] == pytest.approx(0.0)
         assert header['EXPTIME'] == 30.0
         assert header.comments['EXPTIME'] == '[s] Total exposure time'
         assert header['DATE-OBS'] == date_utils.date_obs_to_string(input_images[1].dateobs)
@@ -241,7 +262,7 @@ def test_run_final_returns_paths_and_writes(products, monkeypatch, tmp_path):
     )
     small_name, large_name = make_jpg_filenames(output_frame.filename)
     monkeypatch.setattr(products, 'build_stacked_frame', lambda rows, runtime_context, moluid: output_frame)
-    monkeypatch.setattr(products, 'stretch_for_display', lambda data: np.zeros((2, 3), dtype=np.uint8))
+    monkeypatch.setattr(products, 'stretch_for_display', lambda data: np.zeros(FRAME_SHAPE, dtype=np.uint8))
     monkeypatch.setattr(products, 'save_jpg', lambda display, path, max_size: open(path, 'wb').close())
 
     fits_path, small_path, large_path = products.run_final([stackframe(31), stackframe(32)], context, 'mol-1')
@@ -266,7 +287,7 @@ def test_run_final_fits_path_honors_write_output(products, monkeypatch, tmp_path
         return_value=[SimpleNamespace(filepath=str(output_dir), filename=output_frame.filename + '.fz')]
     )
     monkeypatch.setattr(products, 'build_stacked_frame', lambda rows, runtime_context, moluid: output_frame)
-    monkeypatch.setattr(products, 'stretch_for_display', lambda data: np.zeros((2, 3), dtype=np.uint8))
+    monkeypatch.setattr(products, 'stretch_for_display', lambda data: np.zeros(FRAME_SHAPE, dtype=np.uint8))
     monkeypatch.setattr(products, 'save_jpg', lambda display, path, max_size: open(path, 'wb').close())
 
     fits_path, small_path, large_path = products.run_final([stackframe(31), stackframe(32)], context, 'mol-1')
@@ -340,7 +361,7 @@ def test_write_and_reopen_smoke(products, monkeypatch, tmp_path):
         no_file_cache=False,
     )))
     monkeypatch.setattr(products, 'open_stackframe_images', lambda rows, runtime_context: input_images)
-    monkeypatch.setattr(products, 'stretch_for_display', lambda data: np.zeros((2, 3), dtype=np.uint8))
+    monkeypatch.setattr(products, 'stretch_for_display', lambda data: np.zeros(FRAME_SHAPE, dtype=np.uint8))
     monkeypatch.setattr(products, 'save_jpg', lambda display, path, max_size: open(path, 'wb').close())
     monkeypatch.setattr('banzai.lco.dbs.save_processed_image', lambda filename, md5, db_address: None)
 
@@ -358,4 +379,10 @@ def test_write_and_reopen_smoke(products, monkeypatch, tmp_path):
             assert header['IMCOM001'] == 'cpt1m010-fa16-20240706-0031-e09.fits'
             assert header['IMCOM002'] == 'cpt1m010-fa16-20240706-0032-e09.fits'
             assert 'IMCOM003' not in header
+            assert header['SATURATE'] == pytest.approx(2.0 * 65535.0)
+            assert header['MAXLIN'] == pytest.approx(2.0 * 60000.0)
+            assert header['RDNOISE'] == pytest.approx(8.0 * np.sqrt(2.0))
+            assert header['L1MEAN'] == pytest.approx(5.0)
+            assert header['L1MEDIAN'] == pytest.approx(5.0)
+            assert header['L1SIGMA'] == pytest.approx(0.0)
         assert np.all(hdul['SCI'].data == 5.0)

--- a/banzai/utils/background_utils.py
+++ b/banzai/utils/background_utils.py
@@ -1,0 +1,27 @@
+import numpy as np
+from photutils.background import Background2D
+
+from banzai.utils import stats
+
+
+_BACKGROUND_BOX_SIZE = (32, 32)
+_BACKGROUND_FILTER_SIZE = (3, 3)
+_BACKGROUND_NSIGMA_CLIP = 5.0
+
+
+def estimate_background(data):
+    """Estimate the standard low-resolution background map."""
+    # Estimate each 32x32-pixel box with Background2D's default SExtractor-style mode estimator,
+    # then median-filter the low-resolution mesh with a 3x3-box window.
+    return Background2D(data, _BACKGROUND_BOX_SIZE, filter_size=_BACKGROUND_FILTER_SIZE).background
+
+
+def background_header_cards(background):
+    """Build the L1 background-statistic FITS header cards."""
+    return {
+        'L1MEAN': (stats.sigma_clipped_mean(background, _BACKGROUND_NSIGMA_CLIP),
+                   '[counts] Sigma clipped mean of frame background'),
+        'L1MEDIAN': (np.median(background), '[counts] Median of frame background'),
+        'L1SIGMA': (stats.robust_standard_deviation(background),
+                    '[counts] Robust std dev of frame background'),
+    }


### PR DESCRIPTION
## Summary

This is PR 5 of 8 completing the v1 banzai implementation of Smartstacking at site.

PR1 (#469): combine math
PR2 (#470): JPEG utilities
PR3 (#471): DB updates  
PR4 (#473): shipper contract                     
PR5 (#474): smartstack data products  &emsp;&emsp;&emsp;&emsp;    <-- you are here
PR6 (#475): stack worker polling
PR7 (#476): e2e tests, compose cleanup
PR8 (#477): logging

```text
PR1 combine math ───────┐
PR2 JPEG utilities ─────┤
PR3 DB updates ─────────┼──> PR5 data products --> PR6 stack workers --> PR7 E2E --> PR8 logs/docs
PR4 shipper contract ───┘
```

PRs 1–4 provide the independent foundations for combining images, rendering JPEGs, storing stack state, and shipper integration (this PR). This PR brings them together into the product layer:

> ordered reduced `e09` stackframes → preview JPEGs or a final `e45` FITS product

PR6 will own the lifecycle decisions (stack worker behavior) that call this layer.

Note on merging: this should be merged into main only after PR1-4 are merged. Right now the base is set to simulate that so the diffs are easy to read, but the base should be changed to main before it's actually merged.

## What the changes do:

- Opens every persisted stackframe; fails rather than silently building from fewer inputs.
- Sorts members by `stack_num`.
- Creates a fresh output frame without modifying an input.
- Calls the image stacking code from PR1
- Derives the stack filename from the lowest-numbered available member by replacing `e09` with `e45`.
- Renders 300-pixel and 900-pixel JPEG derivatives using PR2’s utilities.

The final FITS records aggregate and provenance metadata in both the primary and `SCI` headers, including total `EXPTIME`, earliest `DATE-OBS`, `NCOMBINE`, `MOLUID`, and ordered `IMCOMnnn` inputs. It also removes per-exposure `MOLFRNUM`, scales stack-dependent detector values, and remeasures the combined-image background statistics.

## Header changes in stacked products:

While most fits headers are copied over from the stackframes, some are recalculated. I think the procedures make sense, but they're definitely worth a close review. 

- EXPTIME: sum of all input exposure times (matches the renormalized-sum flux scale).
- DATE-OBS: earliest input's observation start time.
- UTSTOP: copied from the newest input, so DATE-OBS/UTSTOP bracket the stack's full time span.
- SATURATE: inherited value × N (number of inputs); exact upper bound for trustworthy pixel values on the N-frame flux scale.
- MAXLIN: inherited value × N; same argument for the linearity limit.
- RDNOISE: inherited value × √N; read-noise variances add across a sum.
- L1MEAN / L1MEDIAN / L1SIGMA: remeasured on the stacked SCI using the same Background2D background-map method as SourceDetector, so they're comparable to e09 values.

## Preview and final paths

`run_preview()`:

- Builds the current stack in memory.
- Writes JPEGs but no FITS product.
- Publishes through PR4 with `fits: null` and aggregate thumbnail metadata.

`run_final()`:

- Writes the `e45` FITS and both JPEGs.
- Returns the actual written paths.
- Does not publish or change database state; PR6 owns that ordering.

## Scope

The PR-local implementation is `banzai/smartstack_products.py` and its focused tests. The combine, JPEG, database, and publisher layers visible in the cumulative branch are inherited from PR1–4.

This PR builds products but does not poll for work or manage lifecycle state. Tests cover output structure, metadata and provenance, stable naming, invalid inputs, preview publication, and a real FITS write/reopen path.