### PR TITLE
Smartstack: stack worker and supervisor

### DIFF
--- a/banzai/main.py
+++ b/banzai/main.py
@@ -26,7 +26,7 @@ from banzai.query import archive_get
 from banzai.utils import date_utils, stage_utils, import_utils, image_utils, fits_utils, file_utils
 from banzai.scheduling import (app, process_image, process_stackframe, requeue_missing_frames,
                                schedule_calibration_stacking)
-from banzai.stacking import validate_message
+from banzai import stacking
 from banzai.data import DataProduct
 from celery.schedules import crontab
 import celery
@@ -280,7 +280,7 @@ class StackframeListener(BanzaiQueueListener):
                          extra_tags={'error': str(e), 'body': repr(body)[:1000]})
             message.ack()
             return
-        if not validate_message(body):
+        if not stacking.validate_message(body):
             logger.error('Invalid message received, missing required fields',
                          extra_tags={'body': body})
             message.ack()

--- a/banzai/main.py
+++ b/banzai/main.py
@@ -305,6 +305,29 @@ def run_stackframe_worker():
     )
 
 
+def run_stacking_supervisor():
+    """Entry point for the smart-stacking supervisor."""
+    runtime_context = parse_args(
+        settings,
+        extra_console_arguments=[
+            {'args': ['--site-id'],
+             'kwargs': {'dest': 'site_id', 'required': True, 'help': 'Site identifier (e.g. lsc, ogg)'}},
+            {'args': ['--stack-retention-days'],
+             'kwargs': {'dest': 'stack_retention_days', 'type': int,
+                        'default': int(os.getenv('STACK_RETENTION_DAYS', 30)),
+                        'help': 'Days to retain terminal stacks before cleanup (default: 30)'}},
+            {'args': ['--stack-timeout-minutes'],
+             'kwargs': {'dest': 'stack_timeout_minutes', 'type': int,
+                        'default': int(os.getenv('STACK_TIMEOUT_MINUTES', 20)),
+                        'help': 'Minutes without a new stackframe before a partial stack is finalized (default: 20)'}},
+            {'args': ['--instrument-types'],
+             'kwargs': {'dest': 'instrument_types', 'default': os.getenv('INSTRUMENT_TYPES', '*'),
+                        'help': 'Comma-separated instrument types to stack, or * for all (default: *)'}},
+        ],
+    )
+    stacking.run_supervisor(runtime_context)
+
+
 def mark_frame(mark_as):
     parser = argparse.ArgumentParser(description="Set the is_bad flag to mark the frame as {mark_as}"
                                                  "for a calibration frame in the database ".format(mark_as=mark_as))

--- a/banzai/stacking.py
+++ b/banzai/stacking.py
@@ -1,9 +1,8 @@
-"""Smart stacking: per-camera polling worker + crash-only supervisor.
+"""Smartstack polling workers and their supervisor.
 
-The worker is stateless: every few seconds it polls the ``stacks`` table for one camera and
-does the obvious thing for each active stack (finalize when complete/timed out, otherwise
-render an incremental preview). All lifecycle state — backoff timers, attempt counts, preview
-progress — lives in the ``stacks`` row, never in process memory.
+Each camera has a worker that polls active stacks, renders previews as frames arrive, and
+finalizes stacks when they complete or time out. Progress and retry state are stored in the
+database so a restarted worker can continue where the previous process stopped.
 """
 import datetime
 import multiprocessing
@@ -48,10 +47,9 @@ def check_stack_complete(stackframes, frmtotal):
 
 
 def stack_has_timed_out(stack_row, timeout_minutes, now=None):
-    """Return True if no stackframe has arrived for longer than timeout_minutes.
+    """Return True when the time since the most recent stackframe exceeds timeout_minutes.
 
-    The clock is cadence-based: it resets on every arrival (``last_stackframe_at``), so a long
-    total exposure never times out mid-stream — only a genuine gap in arrivals does.
+    ``last_stackframe_at`` is updated whenever a reduced stackframe arrives.
     """
     if now is None:
         now = datetime.datetime.utcnow()
@@ -59,22 +57,12 @@ def stack_has_timed_out(stack_row, timeout_minutes, now=None):
 
 
 def finalize_stack(runtime_context, stack_row, stackframes, status):
-    """Produce and ship the final e45 product for a terminal stack.
+    """Create and publish final products for a complete or timed-out stack.
 
-    The order is **claim -> write -> publish -> mark**, and each step is ordered deliberately:
-
-    - **Claim first.** ``claim_finalize_attempt`` bumps the attempt counter and arms the backoff
-      timer *before* any work runs, so a violent crash mid-finalize (OOM-kill, segfault) has
-      already burned an attempt. That is what bounds a poison stack: after the backoff ladder it
-      is marked ``error`` instead of crash-looping forever.
-    - **Publish before mark.** The shipper is told about the products before the stack is recorded
-      terminal, so a stack can never look complete without the shipper having been notified. A
-      crash between publish and mark just leaves the stack active; the poll retries and re-ships.
-      The shipper is idempotent on identical file paths, so at-least-once duplicates are harmless
-      — a lost final product would not be.
-
-    On any exception we only log. The claim already recorded the attempt, so there is nothing else
-    to record; the poll retries once ``next_attempt_at`` has passed.
+    Claim the attempt before generating products so later failures count toward the retry limit.
+    Publish the products before marking the stack terminal so terminal state is recorded only
+    after the shipper has been notified. If generation or publishing fails, leave the stack active
+    and retry after ``next_attempt_at``. Mark the stack as error when its attempt budget is exhausted.
     """
     moluid = stack_row.moluid
     if stack_row.finalize_attempts >= MAX_FINALIZE_ATTEMPTS:
@@ -135,10 +123,11 @@ def process_camera_tick(runtime_context, camera):
 
 
 def run_worker_loop(camera, runtime_context_dict, poll_interval=5):
-    """Poll one camera forever. Any exception is caught and logged so this loop cannot die from it.
+    """Continuously process active stacks for one camera.
 
-    Only a violent death (OOM-kill, segfault) can end this process, and the supervisor relies on
-    that: those are exactly the cases where a from-scratch restart is the right response.
+    Each pass finalizes or previews eligible stacks and periodically removes expired stack records.
+    Errors during a pass are logged, then the worker waits ``poll_interval`` seconds before trying
+    again.
     """
     runtime_context = Context(runtime_context_dict)
     logger.info('Starting stacking worker', extra_tags={'camera': camera})
@@ -146,7 +135,7 @@ def run_worker_loop(camera, runtime_context_dict, poll_interval=5):
     while True:
         try:
             process_camera_tick(runtime_context, camera)
-            # Retention is measured in days; scanning for expired stacks once an hour is plenty.
+            # Retention is configured in days, so run cleanup hourly instead of on every poll.
             if time.monotonic() - last_cleanup > CLEANUP_INTERVAL_SECONDS:
                 dbs.cleanup_old_stacks(runtime_context.db_address, runtime_context.stack_retention_days)
                 last_cleanup = time.monotonic()
@@ -156,29 +145,21 @@ def run_worker_loop(camera, runtime_context_dict, poll_interval=5):
 
 
 def run_supervisor(runtime_context):
-    """Spawn one worker process per camera and let Docker handle every death — crash-only by design.
+    """Start one polling worker for each selected camera.
 
-    Why this is a ~15-line supervisor and not a monitor-and-restart loop:
+    This design keeps supervision simple by relying on the container restart policy for worker
+    lifecycle management. The supervisor starts all workers and waits for one to exit. It then
+    exits with status 1 so the container can restart, rediscover cameras, and start a new set of
+    workers. The same restart path is used when no cameras match the configured filters.
 
-    - **Workers only die violently.** ``run_worker_loop`` catches every exception, so a child can
-      only exit via OOM-kill or segfault. Those are precisely the failures where restarting from
-      scratch is correct — and because workers are **stateless** (all lifecycle state lives in the
-      ``stacks`` table), a restart loses nothing.
-    - **Docker replaces the monitor.** ``restart: always`` on the compose service replaces ~80
-      lines of health-check/restart machinery. A side benefit: every restart re-runs camera
-      discovery, so a camera added after startup is picked up on the next restart.
-    - **Claim-first attempts are what make this safe.** A poison stack (deterministic OOM on one
-      stack's data) has already burned a finalize attempt when it kills the worker (see
-      ``finalize_stack``). After the backoff ladder — a handful of container restarts over bounded
-      minutes — the poll marks that stack ``error`` and all cameras resume permanently, with no
-      operator intervention. Without claim-first, a poison stack would crash-loop forever under
-      *any* process model.
-    - **Accepted trade-off.** When one camera's worker dies violently, this process exits and Docker
-      restarts the whole container, so every camera's worker briefly restarts too. That costs a few
-      seconds of polling downtime and, because workers are stateless, nothing else.
+    Restarting the container also restarts workers that were still healthy. This is the trade-off
+    for avoiding a separate per-worker restart loop. Stack progress is stored in the database, so
+    replacement workers continue from the persisted state.
 
-    This function exits non-zero on any child death (and on an empty camera list) so ``restart:
-    always`` brings the container back.
+    Before generating final products, ``finalize_stack`` records the attempt and its backoff. If a
+    worker exits after that claim, the replacement process retains the attempt count and waits
+    until ``next_attempt_at`` before retrying. Once the attempt limit is reached, the stack is
+    marked ``error`` instead of being finalized again.
     """
     instrument_types = ([t.strip() for t in runtime_context.instrument_types.split(',')]
                         if runtime_context.instrument_types != '*' else ['*'])

--- a/banzai/stacking.py
+++ b/banzai/stacking.py
@@ -35,15 +35,9 @@ def validate_message(body):
     return all(field in body for field in REQUIRED_MESSAGE_FIELDS)
 
 
-def check_stack_complete(stackframes, frmtotal):
-    """Return True if the stack is ready to finalize.
-
-    Stackframe rows are written only after reduction succeeds, so a stack is complete when all
-    expected rows are present or the instrument signalled is_last.
-    """
-    all_arrived = len(stackframes) == frmtotal
-    has_last = any(stackframe.is_last for stackframe in stackframes)
-    return bool(stackframes) and (all_arrived or has_last)
+def check_stack_complete(stackframes):
+    """Return True when the instrument signalled the final stackframe."""
+    return any(stackframe.is_last for stackframe in stackframes)
 
 
 def stack_has_timed_out(stack_row, timeout_minutes, now=None):
@@ -95,9 +89,9 @@ def process_camera_tick(runtime_context, camera):
     for stack in dbs.get_active_stacks(runtime_context.db_address, camera):
         stackframes = dbs.get_stackframes(runtime_context.db_address, stack.moluid)
 
-        # Complete wins over timeout: a stack that has all its frames finalizes as 'complete'
-        # even if it also happens to be past the cadence timeout.
-        if check_stack_complete(stackframes, stack.frmtotal):
+        # Complete wins over timeout: a stack with the final-frame signal finalizes as
+        # 'complete' even if it also happens to be past the cadence timeout.
+        if check_stack_complete(stackframes):
             terminal_status = 'complete'
         elif stack_has_timed_out(stack, runtime_context.stack_timeout_minutes, now=now):
             terminal_status = 'timeout'

--- a/banzai/stacking.py
+++ b/banzai/stacking.py
@@ -145,7 +145,7 @@ def run_worker_loop(camera, runtime_context_dict, poll_interval=5):
     """
     runtime_context = Context(runtime_context_dict)
     logger.info('Starting stacking worker', extra_tags={'camera': camera})
-    last_cleanup = 0.0
+    last_cleanup = time.monotonic() - CLEANUP_INTERVAL_SECONDS
     while True:
         try:
             process_camera_tick(runtime_context, camera)

--- a/banzai/stacking.py
+++ b/banzai/stacking.py
@@ -8,11 +8,10 @@ progress — lives in the ``stacks`` row, never in process memory.
 import datetime
 import multiprocessing
 import multiprocessing.connection
-import os
 import sys
 import time
 
-from banzai import dbs, main, settings, smartstack_products
+from banzai import dbs, smartstack_products
 from banzai.context import Context
 from banzai.logs import get_logger
 from banzai.utils.messaging import post_to_shipper_queue
@@ -156,7 +155,7 @@ def run_worker_loop(camera, runtime_context_dict, poll_interval=5):
         time.sleep(poll_interval)
 
 
-def run_supervisor():
+def run_supervisor(runtime_context):
     """Spawn one worker process per camera and let Docker handle every death — crash-only by design.
 
     Why this is a ~15-line supervisor and not a monitor-and-restart loop:
@@ -181,25 +180,6 @@ def run_supervisor():
     This function exits non-zero on any child death (and on an empty camera list) so ``restart:
     always`` brings the container back.
     """
-    runtime_context = main.parse_args(
-        settings,
-        extra_console_arguments=[
-            {'args': ['--site-id'],
-             'kwargs': {'dest': 'site_id', 'required': True, 'help': 'Site identifier (e.g. lsc, ogg)'}},
-            {'args': ['--stack-retention-days'],
-             'kwargs': {'dest': 'stack_retention_days', 'type': int,
-                        'default': int(os.getenv('STACK_RETENTION_DAYS', 30)),
-                        'help': 'Days to retain terminal stacks before cleanup (default: 30)'}},
-            {'args': ['--stack-timeout-minutes'],
-             'kwargs': {'dest': 'stack_timeout_minutes', 'type': int,
-                        'default': int(os.getenv('STACK_TIMEOUT_MINUTES', 20)),
-                        'help': 'Minutes without a new stackframe before a partial stack is finalized (default: 20)'}},
-            {'args': ['--instrument-types'],
-             'kwargs': {'dest': 'instrument_types', 'default': os.getenv('INSTRUMENT_TYPES', '*'),
-                        'help': 'Comma-separated instrument types to stack, or * for all (default: *)'}},
-        ],
-    )
-
     instrument_types = ([t.strip() for t in runtime_context.instrument_types.split(',')]
                         if runtime_context.instrument_types != '*' else ['*'])
     instruments = dbs.get_instruments_at_site(runtime_context.site_id, runtime_context.db_address)

--- a/banzai/stacking.py
+++ b/banzai/stacking.py
@@ -88,7 +88,6 @@ def finalize_stack(runtime_context, stack_row, stackframes, status):
     try:
         fits_path, small_thumbnail, large_thumbnail = smartstack_products.run_final(
             stackframes, runtime_context, moluid)
-        newest_stackframe = max(stackframes, key=lambda stackframe: stackframe.stack_num)
         post_to_shipper_queue(
             runtime_context.broker_url,
             runtime_context.SHIPPER_EXCHANGE,
@@ -96,7 +95,6 @@ def finalize_stack(runtime_context, stack_row, stackframes, status):
             fits_path=fits_path,
             small_thumbnail=small_thumbnail,
             large_thumbnail=large_thumbnail,
-            instrument_enqueue_timestamp=newest_stackframe.instrument_enqueue_timestamp,
         )
         dbs.mark_stack_terminal(runtime_context.db_address, moluid, status)
         logger.info('Finalized smartstack', extra_tags={'moluid': moluid, 'status': status})

--- a/banzai/stacking.py
+++ b/banzai/stacking.py
@@ -123,7 +123,11 @@ def process_camera_tick(runtime_context, camera):
             if stack.next_attempt_at is not None and now < stack.next_attempt_at:
                 continue  # Still inside the backoff window from a previous failed attempt.
             finalize_stack(runtime_context, stack, stackframes, terminal_status)
-        elif runtime_context.SMARTSTACK_PREVIEWS and len(stackframes) > stack.last_preview_count:
+        # Reductions finish concurrently; wait for frame 1 so every preview reuses its basename.
+        elif (runtime_context.SMARTSTACK_PREVIEWS
+              and stackframes
+              and stackframes[0].stack_num == 1
+              and len(stackframes) > stack.last_preview_count):
             try:
                 smartstack_products.run_preview(stackframes, runtime_context, stack.moluid)
                 dbs.set_preview_count(runtime_context.db_address, stack.moluid, len(stackframes))

--- a/banzai/stacking.py
+++ b/banzai/stacking.py
@@ -1,13 +1,21 @@
-"""Smart stacking: worker, supervisor, and helper functions."""
-import argparse
+"""Smart stacking: per-camera polling worker + crash-only supervisor.
+
+The worker is stateless: every few seconds it polls the ``stacks`` table for one camera and
+does the obvious thing for each active stack (finalize when complete/timed out, otherwise
+render an incremental preview). All lifecycle state — backoff timers, attempt counts, preview
+progress — lives in the ``stacks`` row, never in process memory.
+"""
+import datetime
 import multiprocessing
-import signal
+import multiprocessing.connection
+import os
+import sys
 import time
 
-import redis as redis_lib
-
-from banzai import dbs
+from banzai import dbs, main, settings, smartstack_products
+from banzai.context import Context
 from banzai.logs import get_logger
+from banzai.utils.messaging import post_to_shipper_queue
 
 logger = get_logger()
 
@@ -18,188 +26,197 @@ logger = get_logger()
 
 REQUIRED_MESSAGE_FIELDS = ('fits_file', 'last_frame')
 
+# Backoff between finalize attempts; after the ladder is exhausted the stack is marked 'error'.
+FINALIZE_BACKOFF_SECONDS = [60, 300, 900, 3600]
+MAX_FINALIZE_ATTEMPTS = len(FINALIZE_BACKOFF_SECONDS) + 1
+CLEANUP_INTERVAL_SECONDS = 3600
+
 
 def validate_message(body):
     """Check that body contains fits_file and last_frame."""
     return all(field in body for field in REQUIRED_MESSAGE_FIELDS)
 
 
-def check_stack_complete(subframes, frmtotal):
+def check_stack_complete(stackframes, frmtotal):
     """Return True if the stack is ready to finalize.
 
-    Subframe rows are written only after reduction succeeds, so a stack is
-    complete when all expected rows are present or the instrument signalled
-    is_last.
+    Stackframe rows are written only after reduction succeeds, so a stack is complete when all
+    expected rows are present or the instrument signalled is_last.
     """
-    all_arrived = len(subframes) == frmtotal
-    has_last = any(s.is_last for s in subframes)
-    return bool(subframes) and (all_arrived or has_last)
+    all_arrived = len(stackframes) == frmtotal
+    has_last = any(stackframe.is_last for stackframe in stackframes)
+    return bool(stackframes) and (all_arrived or has_last)
 
 
-# ---------------------------------------------------------------------------
-# Notifications
-# ---------------------------------------------------------------------------
+def stack_has_timed_out(stack_row, timeout_minutes, now=None):
+    """Return True if no stackframe has arrived for longer than timeout_minutes.
 
-REDIS_KEY_PREFIX = 'stack:notify:'
-ENQUEUE_NOTIFICATION_SCRIPT = """
-local existing_score = redis.call('ZSCORE', KEYS[1], ARGV[1])
-if existing_score then
-    return 0
-end
-
-local sequence = redis.call('INCR', KEYS[2])
-redis.call('ZADD', KEYS[1], sequence, ARGV[1])
-return 1
-"""
+    The clock is cadence-based: it resets on every arrival (``last_stackframe_at``), so a long
+    total exposure never times out mid-stream — only a genuine gap in arrivals does.
+    """
+    if now is None:
+        now = datetime.datetime.utcnow()
+    return (now - stack_row.last_stackframe_at) > datetime.timedelta(minutes=timeout_minutes)
 
 
-def _notification_key(camera):
-    return f'{REDIS_KEY_PREFIX}{camera}'
+def finalize_stack(runtime_context, stack_row, stackframes, status):
+    """Produce and ship the final e45 product for a terminal stack.
+
+    The order is **claim -> write -> publish -> mark**, and each step is ordered deliberately:
+
+    - **Claim first.** ``claim_finalize_attempt`` bumps the attempt counter and arms the backoff
+      timer *before* any work runs, so a violent crash mid-finalize (OOM-kill, segfault) has
+      already burned an attempt. That is what bounds a poison stack: after the backoff ladder it
+      is marked ``error`` instead of crash-looping forever.
+    - **Publish before mark.** The shipper is told about the products before the stack is recorded
+      terminal, so a stack can never look complete without the shipper having been notified. A
+      crash between publish and mark just leaves the stack active; the poll retries and re-ships.
+      The shipper is idempotent on identical file paths, so at-least-once duplicates are harmless
+      — a lost final product would not be.
+
+    On any exception we only log. The claim already recorded the attempt, so there is nothing else
+    to record; the poll retries once ``next_attempt_at`` has passed.
+    """
+    moluid = stack_row.moluid
+    if stack_row.finalize_attempts >= MAX_FINALIZE_ATTEMPTS:
+        dbs.mark_stack_terminal(runtime_context.db_address, moluid, 'error')
+        logger.error('Smartstack exhausted finalize attempts; marking error',
+                     extra_tags={'moluid': moluid, 'finalize_attempts': stack_row.finalize_attempts})
+        return
+
+    dbs.claim_finalize_attempt(runtime_context.db_address, moluid, FINALIZE_BACKOFF_SECONDS)
+    try:
+        fits_path, small_thumbnail, large_thumbnail = smartstack_products.run_final(
+            stackframes, runtime_context, moluid)
+        newest_stackframe = max(stackframes, key=lambda stackframe: stackframe.stack_num)
+        post_to_shipper_queue(
+            runtime_context.broker_url,
+            runtime_context.SHIPPER_EXCHANGE,
+            runtime_context.SHIPPER_QUEUE_NAME,
+            fits_path=fits_path,
+            small_thumbnail=small_thumbnail,
+            large_thumbnail=large_thumbnail,
+            instrument_enqueue_timestamp=newest_stackframe.instrument_enqueue_timestamp,
+        )
+        dbs.mark_stack_terminal(runtime_context.db_address, moluid, status)
+        logger.info('Finalized smartstack', extra_tags={'moluid': moluid, 'status': status})
+    except Exception:
+        logger.error('Failed to finalize smartstack', exc_info=True, extra_tags={'moluid': moluid})
 
 
-def _notification_sequence_key(camera):
-    return f'{_notification_key(camera)}:sequence'
+def process_camera_tick(runtime_context, camera):
+    """Do one poll pass for a camera: finalize terminal stacks, otherwise preview growing ones."""
+    now = datetime.datetime.utcnow()
+    for stack in dbs.get_active_stacks(runtime_context.db_address, camera):
+        stackframes = dbs.get_stackframes(runtime_context.db_address, stack.moluid)
+
+        # Complete wins over timeout: a stack that has all its frames finalizes as 'complete'
+        # even if it also happens to be past the cadence timeout.
+        if check_stack_complete(stackframes, stack.frmtotal):
+            terminal_status = 'complete'
+        elif stack_has_timed_out(stack, runtime_context.stack_timeout_minutes, now=now):
+            terminal_status = 'timeout'
+        else:
+            terminal_status = None
+
+        if terminal_status is not None:
+            if stack.next_attempt_at is not None and now < stack.next_attempt_at:
+                continue  # Still inside the backoff window from a previous failed attempt.
+            finalize_stack(runtime_context, stack, stackframes, terminal_status)
+        elif runtime_context.SMARTSTACK_PREVIEWS and len(stackframes) > stack.last_preview_count:
+            try:
+                smartstack_products.run_preview(stackframes, runtime_context, stack.moluid)
+                dbs.set_preview_count(runtime_context.db_address, stack.moluid, len(stackframes))
+            except Exception:
+                # Do not advance the preview count on failure so the next tick retries it.
+                logger.warning('Failed to render smartstack preview', exc_info=True,
+                               extra_tags={'moluid': stack.moluid})
 
 
-def push_notification(redis_client, camera, moluid):
-    """Add a moluid to a camera's FIFO notification set unless it is already pending."""
-    return redis_client.eval(
-        ENQUEUE_NOTIFICATION_SCRIPT,
-        2,
-        _notification_key(camera),
-        _notification_sequence_key(camera),
-        moluid,
-    )
+def run_worker_loop(camera, runtime_context_dict, poll_interval=5):
+    """Poll one camera forever. Any exception is caught and logged so this loop cannot die from it.
 
-
-def pop_notification(redis_client, camera):
-    """Pop and return the oldest pending moluid for a camera."""
-    pending = redis_client.zpopmin(_notification_key(camera), count=1)
-    if not pending:
-        return None
-    moluid = pending[0][0]
-    return moluid.decode() if isinstance(moluid, bytes) else moluid
-
-
-# ---------------------------------------------------------------------------
-# Worker
-# ---------------------------------------------------------------------------
-
-def run_worker_loop(camera, db_address, redis_url, retention_days=30, poll_interval=5):
-    """Main loop: process notifications, query DB, check completion, finalize."""
-    redis_client = redis_lib.Redis.from_url(redis_url)
+    Only a violent death (OOM-kill, segfault) can end this process, and the supervisor relies on
+    that: those are exactly the cases where a from-scratch restart is the right response.
+    """
+    runtime_context = Context(runtime_context_dict)
+    logger.info('Starting stacking worker', extra_tags={'camera': camera})
+    last_cleanup = 0.0
     while True:
         try:
-            process_notifications(db_address, redis_client, camera)
-            dbs.cleanup_old_subframes(db_address, retention_days)
-            time.sleep(poll_interval)
-        except Exception as e:
-            logger.error(f'Error in stacking worker loop: {e}', extra_tags={'camera': camera})
-            time.sleep(poll_interval)
-
-
-def process_notifications(db_address, redis_client, camera):
-    """Process pending moluids one at a time in notification order."""
-    while True:
-        moluid = pop_notification(redis_client, camera)
-        if moluid is None:
-            return
-        subframes = dbs.get_subframes(db_address, moluid)
-        if not subframes:
-            continue
-        if not any(subframe.status == 'active' for subframe in subframes):
-            continue
-        frmtotal = subframes[0].frmtotal
-        if check_stack_complete(subframes, frmtotal):
-            finalize_stack(db_address, moluid, status='complete')
-
-
-def finalize_stack(db_address, moluid, status='complete'):
-    """Mark stack complete and log mock stacking/JPEG/ingester operations."""
-    dbs.mark_stack_complete(db_address, moluid, status=status)
-    logger.debug(f'Mock stacking complete for {moluid}', extra_tags={'moluid': moluid})
-    logger.debug(f'Mock JPEG generation for {moluid}', extra_tags={'moluid': moluid})
-    logger.debug(f'Mock ingester upload for {moluid}', extra_tags={'moluid': moluid})
-
-
-# ---------------------------------------------------------------------------
-# Supervisor
-# ---------------------------------------------------------------------------
-
-class StackingSupervisor:
-    def __init__(self, site_id, db_address, redis_url, retention_days=30):
-        self.site_id = site_id
-        self.db_address = db_address
-        self.redis_url = redis_url
-        self.retention_days = retention_days
-        self.workers = {}
-
-    def _worker_args(self, camera):
-        return (camera, self.db_address, self.redis_url, self.retention_days)
-
-    def start(self):
-        """Discover cameras and spawn one worker process per camera."""
-        cameras = [inst.camera for inst in dbs.get_instruments_at_site(self.site_id, self.db_address)]
-        for camera in cameras:
-            proc = multiprocessing.Process(
-                target=run_worker_loop,
-                args=self._worker_args(camera),
-                name=f'stacking-worker-{camera}',
-            )
-            proc.start()
-            self.workers[camera] = proc
-            logger.info(f'Started stacking worker for camera {camera}')
-
-    def monitor(self, check_interval=10):
-        """Check worker health and restart crashed workers."""
-        while True:
-            for camera, proc in list(self.workers.items()):
-                if not proc.is_alive():
-                    logger.warning(f'Worker for {camera} died, restarting')
-                    new_proc = multiprocessing.Process(
-                        target=run_worker_loop,
-                        args=self._worker_args(camera),
-                        name=f'stacking-worker-{camera}',
-                    )
-                    new_proc.start()
-                    self.workers[camera] = new_proc
-            time.sleep(check_interval)
-
-    def shutdown(self):
-        """Graceful shutdown of all workers."""
-        for camera, proc in self.workers.items():
-            proc.terminate()
-            proc.join(timeout=10)
-            logger.info(f'Stopped stacking worker for camera {camera}')
-        self.workers.clear()
-
-
-def _stacking_worker_arg_parser():
-    parser = argparse.ArgumentParser(description='Run the smart stacking supervisor.')
-    parser.add_argument('--site-id', dest='site_id', required=True,
-                        help='Site identifier (e.g. lsc, ogg)')
-    parser.add_argument('--db-address', dest='db_address', required=True,
-                        help='Database connection string')
-    parser.add_argument('--redis-url', dest='redis_url', required=True,
-                        help='Redis URL')
-    parser.add_argument('--stack-retention-days', dest='stack_retention_days', type=int, default=30,
-                        help='Days to retain completed stacks (default: 30)')
-    return parser
+            process_camera_tick(runtime_context, camera)
+            # Retention is measured in days; scanning for expired stacks once an hour is plenty.
+            if time.monotonic() - last_cleanup > CLEANUP_INTERVAL_SECONDS:
+                dbs.cleanup_old_stacks(runtime_context.db_address, runtime_context.stack_retention_days)
+                last_cleanup = time.monotonic()
+        except Exception:
+            logger.error('Error in stacking worker loop', exc_info=True, extra_tags={'camera': camera})
+        time.sleep(poll_interval)
 
 
 def run_supervisor():
-    """Entry point for the stacking supervisor."""
-    args = _stacking_worker_arg_parser().parse_args()
+    """Spawn one worker process per camera and let Docker handle every death — crash-only by design.
 
-    supervisor = StackingSupervisor(args.site_id, args.db_address, args.redis_url,
-                                    retention_days=args.stack_retention_days)
+    Why this is a ~15-line supervisor and not a monitor-and-restart loop:
 
-    def handle_signal(signum, frame):
-        supervisor.shutdown()
-        raise SystemExit(0)
+    - **Workers only die violently.** ``run_worker_loop`` catches every exception, so a child can
+      only exit via OOM-kill or segfault. Those are precisely the failures where restarting from
+      scratch is correct — and because workers are **stateless** (all lifecycle state lives in the
+      ``stacks`` table), a restart loses nothing.
+    - **Docker replaces the monitor.** ``restart: always`` on the compose service replaces ~80
+      lines of health-check/restart machinery. A side benefit: every restart re-runs camera
+      discovery, so a camera added after startup is picked up on the next restart.
+    - **Claim-first attempts are what make this safe.** A poison stack (deterministic OOM on one
+      stack's data) has already burned a finalize attempt when it kills the worker (see
+      ``finalize_stack``). After the backoff ladder — a handful of container restarts over bounded
+      minutes — the poll marks that stack ``error`` and all cameras resume permanently, with no
+      operator intervention. Without claim-first, a poison stack would crash-loop forever under
+      *any* process model.
+    - **Accepted trade-off.** When one camera's worker dies violently, this process exits and Docker
+      restarts the whole container, so every camera's worker briefly restarts too. That costs a few
+      seconds of polling downtime and, because workers are stateless, nothing else.
 
-    signal.signal(signal.SIGTERM, handle_signal)
-    signal.signal(signal.SIGINT, handle_signal)
+    This function exits non-zero on any child death (and on an empty camera list) so ``restart:
+    always`` brings the container back.
+    """
+    runtime_context = main.parse_args(
+        settings,
+        extra_console_arguments=[
+            {'args': ['--site-id'],
+             'kwargs': {'dest': 'site_id', 'required': True, 'help': 'Site identifier (e.g. lsc, ogg)'}},
+            {'args': ['--stack-retention-days'],
+             'kwargs': {'dest': 'stack_retention_days', 'type': int,
+                        'default': int(os.getenv('STACK_RETENTION_DAYS', 30)),
+                        'help': 'Days to retain terminal stacks before cleanup (default: 30)'}},
+            {'args': ['--stack-timeout-minutes'],
+             'kwargs': {'dest': 'stack_timeout_minutes', 'type': int,
+                        'default': int(os.getenv('STACK_TIMEOUT_MINUTES', 20)),
+                        'help': 'Minutes without a new stackframe before a partial stack is finalized (default: 20)'}},
+            {'args': ['--instrument-types'],
+             'kwargs': {'dest': 'instrument_types', 'default': os.getenv('INSTRUMENT_TYPES', '*'),
+                        'help': 'Comma-separated instrument types to stack, or * for all (default: *)'}},
+        ],
+    )
 
-    supervisor.start()
-    supervisor.monitor()
+    instrument_types = ([t.strip() for t in runtime_context.instrument_types.split(',')]
+                        if runtime_context.instrument_types != '*' else ['*'])
+    instruments = dbs.get_instruments_at_site(runtime_context.site_id, runtime_context.db_address)
+    if instrument_types != ['*']:
+        instruments = [instrument for instrument in instruments if instrument.type in instrument_types]
+    cameras = [instrument.camera for instrument in instruments]
+    if not cameras:
+        logger.error('No cameras found at site; exiting so Docker restarts the container',
+                     extra_tags={'site_id': runtime_context.site_id})
+        sys.exit(1)
+
+    runtime_context_dict = vars(runtime_context)
+    processes = [multiprocessing.Process(target=run_worker_loop, args=(camera, runtime_context_dict), daemon=True)
+                 for camera in cameras]
+    for process in processes:
+        process.start()
+    logger.info('Started stacking workers',
+                extra_tags={'site_id': runtime_context.site_id, 'camera_count': len(processes)})
+
+    multiprocessing.connection.wait([process.sentinel for process in processes])
+    logger.error('A stacking worker exited; exiting so Docker restarts the container')
+    sys.exit(1)

--- a/banzai/tests/test_smart_stacking.py
+++ b/banzai/tests/test_smart_stacking.py
@@ -1,6 +1,7 @@
 """Unit tests for the smart stacking feature."""
 import datetime
 import json
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -10,7 +11,9 @@ from celery.exceptions import Retry
 from sqlalchemy import text
 
 from banzai import dbs, scheduling
-from banzai.stacking import check_stack_complete, run_worker_loop, StackingSupervisor
+from banzai.stacking import (check_stack_complete, stack_has_timed_out, finalize_stack,
+                             process_camera_tick, run_worker_loop, run_supervisor,
+                             FINALIZE_BACKOFF_SECONDS, MAX_FINALIZE_ATTEMPTS)
 from banzai.scheduling import process_stackframe
 from banzai.main import StackframeListener
 
@@ -659,23 +662,265 @@ class TestProcessStackframe:
 
 
 # ---------------------------------------------------------------------------
-# Supervisor
+# Worker: finalize / preview / timeout helpers
 # ---------------------------------------------------------------------------
 
-class TestSupervisor:
+def _runtime_context(**overrides):
+    """Fake runtime context exposing exactly the attributes the worker reads."""
+    defaults = dict(
+        db_address='sqlite:///fake.db',
+        broker_url='amqp://localhost:5672',
+        SHIPPER_EXCHANGE='ship_files',
+        SHIPPER_QUEUE_NAME='ship',
+        SMARTSTACK_PREVIEWS=True,
+        stack_timeout_minutes=20,
+        stack_retention_days=30,
+    )
+    defaults.update(overrides)
+    return SimpleNamespace(**defaults)
 
-    @patch('banzai.stacking.dbs.get_instruments_at_site',
-           return_value=[MagicMock(camera='cam1'), MagicMock(camera='cam2'), MagicMock(camera='cam3')])
-    @patch('banzai.stacking.multiprocessing.Process')
-    def test_stacking_supervisor_spawns_per_camera(self, mock_process_cls, mock_discover):
-        supervisor = StackingSupervisor(
-            site_id='tst',
-            db_address='sqlite:///fake.db',
-            redis_url='redis://localhost:6379',
+
+def _stack(moluid='mol-w', frmtotal=3, finalize_attempts=0, next_attempt_at=None,
+           last_preview_count=0, last_stackframe_at=None):
+    if last_stackframe_at is None:
+        last_stackframe_at = datetime.datetime.utcnow()
+    return SimpleNamespace(
+        moluid=moluid, camera='cam1', frmtotal=frmtotal, status='active',
+        finalize_attempts=finalize_attempts, next_attempt_at=next_attempt_at,
+        last_preview_count=last_preview_count, last_stackframe_at=last_stackframe_at,
+    )
+
+
+def _frame(stack_num, is_last=False, instrument_enqueue_timestamp=None, filepath=None):
+    return SimpleNamespace(
+        stack_num=stack_num, is_last=is_last,
+        instrument_enqueue_timestamp=instrument_enqueue_timestamp,
+        filepath=filepath or f'/data/f{stack_num}.fits',
+    )
+
+
+class TestFinalizeStack:
+
+    def test_finalize_claims_before_work(self):
+        """The attempt is claimed first, then run_final -> publish -> mark_terminal, in that order."""
+        rc = _runtime_context()
+        stack = _stack(finalize_attempts=0, next_attempt_at=None)
+        stackframes = [_frame(1, instrument_enqueue_timestamp=111),
+                       _frame(2, is_last=True, instrument_enqueue_timestamp=222)]
+        with patch('banzai.stacking.dbs') as mock_dbs, \
+             patch('banzai.stacking.smartstack_products') as mock_products, \
+             patch('banzai.stacking.post_to_shipper_queue') as mock_publish:
+            mock_products.run_final.return_value = ('/o/e45.fits', '/o/small.jpg', '/o/large.jpg')
+            manager = MagicMock()
+            manager.attach_mock(mock_dbs.claim_finalize_attempt, 'claim')
+            manager.attach_mock(mock_products.run_final, 'run_final')
+            manager.attach_mock(mock_publish, 'publish')
+            manager.attach_mock(mock_dbs.mark_stack_terminal, 'mark_terminal')
+
+            finalize_stack(rc, stack, stackframes, 'complete')
+
+        assert [call[0] for call in manager.mock_calls] == ['claim', 'run_final', 'publish', 'mark_terminal']
+        mock_dbs.claim_finalize_attempt.assert_called_once_with(rc.db_address, stack.moluid, FINALIZE_BACKOFF_SECONDS)
+        mock_publish.assert_called_once_with(
+            rc.broker_url, rc.SHIPPER_EXCHANGE, rc.SHIPPER_QUEUE_NAME,
+            fits_path='/o/e45.fits', small_thumbnail='/o/small.jpg', large_thumbnail='/o/large.jpg',
+            instrument_enqueue_timestamp=222,
         )
-        supervisor.start()
-        assert mock_process_cls.call_count == 3
-        assert mock_process_cls.return_value.start.call_count == 3
+        mock_dbs.mark_stack_terminal.assert_called_once_with(rc.db_address, stack.moluid, 'complete')
+
+    def test_finalize_failure_leaves_stack_active(self):
+        """run_final raising: attempt already burned by claim, but no mark_terminal and no exception escapes."""
+        rc = _runtime_context()
+        stack = _stack()
+        stackframes = [_frame(1, instrument_enqueue_timestamp=111)]
+        with patch('banzai.stacking.dbs') as mock_dbs, \
+             patch('banzai.stacking.smartstack_products') as mock_products, \
+             patch('banzai.stacking.post_to_shipper_queue') as mock_publish:
+            mock_products.run_final.side_effect = RuntimeError('stack blew up')
+
+            finalize_stack(rc, stack, stackframes, 'complete')
+
+        mock_dbs.claim_finalize_attempt.assert_called_once()
+        mock_publish.assert_not_called()
+        mock_dbs.mark_stack_terminal.assert_not_called()
+
+    def test_publish_failure_leaves_stack_active(self):
+        """post_to_shipper_queue raising: the stack is not marked terminal (publish-before-mark)."""
+        rc = _runtime_context()
+        stack = _stack()
+        stackframes = [_frame(1, instrument_enqueue_timestamp=111)]
+        with patch('banzai.stacking.dbs') as mock_dbs, \
+             patch('banzai.stacking.smartstack_products') as mock_products, \
+             patch('banzai.stacking.post_to_shipper_queue') as mock_publish:
+            mock_products.run_final.return_value = ('/o/e45.fits', '/o/small.jpg', '/o/large.jpg')
+            mock_publish.side_effect = RuntimeError('broker down')
+
+            finalize_stack(rc, stack, stackframes, 'complete')
+
+        mock_dbs.claim_finalize_attempt.assert_called_once()
+        mock_products.run_final.assert_called_once()
+        mock_dbs.mark_stack_terminal.assert_not_called()
+
+    def test_exhausted_attempts_marks_error(self):
+        """At/over MAX attempts, the stack is marked 'error' without claiming or doing any work."""
+        rc = _runtime_context()
+        stack = _stack(finalize_attempts=MAX_FINALIZE_ATTEMPTS, next_attempt_at=None)
+        stackframes = [_frame(1, instrument_enqueue_timestamp=111)]
+        with patch('banzai.stacking.dbs') as mock_dbs, \
+             patch('banzai.stacking.smartstack_products') as mock_products, \
+             patch('banzai.stacking.post_to_shipper_queue') as mock_publish:
+
+            finalize_stack(rc, stack, stackframes, 'complete')
+
+        mock_dbs.mark_stack_terminal.assert_called_once_with(rc.db_address, stack.moluid, 'error')
+        mock_dbs.claim_finalize_attempt.assert_not_called()
+        mock_products.run_final.assert_not_called()
+        mock_publish.assert_not_called()
+
+
+class TestStackTimedOut:
+
+    def test_stack_has_timed_out_boundary(self):
+        now = datetime.datetime(2024, 6, 15, 12, 0, 0)
+        stale = _stack(last_stackframe_at=now - datetime.timedelta(minutes=21))
+        fresh = _stack(last_stackframe_at=now - datetime.timedelta(minutes=19))
+        assert stack_has_timed_out(stale, 20, now=now) is True
+        assert stack_has_timed_out(fresh, 20, now=now) is False
+
+
+class TestProcessCameraTick:
+
+    def test_backoff_window_respected(self):
+        """A terminal stack whose next_attempt_at is in the future is not finalized this tick."""
+        rc = _runtime_context()
+        now = datetime.datetime.utcnow()
+        stack = _stack(frmtotal=3, finalize_attempts=1, next_attempt_at=now + datetime.timedelta(minutes=5))
+        stackframes = [_frame(i, is_last=(i == 3)) for i in (1, 2, 3)]
+        with patch('banzai.stacking.dbs') as mock_dbs, \
+             patch('banzai.stacking.finalize_stack') as mock_finalize, \
+             patch('banzai.stacking.smartstack_products') as mock_products:
+            mock_dbs.get_active_stacks.return_value = [stack]
+            mock_dbs.get_stackframes.return_value = stackframes
+
+            process_camera_tick(rc, 'cam1')
+
+        mock_finalize.assert_not_called()
+        mock_products.run_preview.assert_not_called()
+
+    def test_timeout_finalizes_partial(self):
+        """A partial stack past the cadence timeout is finalized with status 'timeout'."""
+        rc = _runtime_context(stack_timeout_minutes=20)
+        stack = _stack(frmtotal=5, last_stackframe_at=datetime.datetime.utcnow() - datetime.timedelta(minutes=21))
+        stackframes = [_frame(1), _frame(2)]
+        with patch('banzai.stacking.dbs') as mock_dbs, \
+             patch('banzai.stacking.finalize_stack') as mock_finalize:
+            mock_dbs.get_active_stacks.return_value = [stack]
+            mock_dbs.get_stackframes.return_value = stackframes
+
+            process_camera_tick(rc, 'cam1')
+
+        mock_finalize.assert_called_once_with(rc, stack, stackframes, 'timeout')
+
+    def test_fresh_stackframe_resets_timeout_clock(self):
+        """A fresh arrival keeps the stack active: no timeout finalize."""
+        rc = _runtime_context(stack_timeout_minutes=20, SMARTSTACK_PREVIEWS=False)
+        stack = _stack(frmtotal=5, last_stackframe_at=datetime.datetime.utcnow() - datetime.timedelta(minutes=5))
+        stackframes = [_frame(1), _frame(2)]
+        with patch('banzai.stacking.dbs') as mock_dbs, \
+             patch('banzai.stacking.finalize_stack') as mock_finalize:
+            mock_dbs.get_active_stacks.return_value = [stack]
+            mock_dbs.get_stackframes.return_value = stackframes
+
+            process_camera_tick(rc, 'cam1')
+
+        mock_finalize.assert_not_called()
+
+    def test_complete_wins_over_timeout(self):
+        """A stack that is both complete and past the timeout finalizes as 'complete'."""
+        rc = _runtime_context(stack_timeout_minutes=20)
+        stack = _stack(frmtotal=3, last_stackframe_at=datetime.datetime.utcnow() - datetime.timedelta(minutes=30))
+        stackframes = [_frame(i, is_last=(i == 3)) for i in (1, 2, 3)]
+        with patch('banzai.stacking.dbs') as mock_dbs, \
+             patch('banzai.stacking.finalize_stack') as mock_finalize:
+            mock_dbs.get_active_stacks.return_value = [stack]
+            mock_dbs.get_stackframes.return_value = stackframes
+
+            process_camera_tick(rc, 'cam1')
+
+        mock_finalize.assert_called_once_with(rc, stack, stackframes, 'complete')
+
+    def test_complete_stack_never_previews(self):
+        """A complete stack takes the finalize path even if the preview count would grow."""
+        rc = _runtime_context(SMARTSTACK_PREVIEWS=True)
+        stack = _stack(frmtotal=3, last_preview_count=0)
+        stackframes = [_frame(i, is_last=(i == 3)) for i in (1, 2, 3)]
+        with patch('banzai.stacking.dbs') as mock_dbs, \
+             patch('banzai.stacking.finalize_stack') as mock_finalize, \
+             patch('banzai.stacking.smartstack_products') as mock_products:
+            mock_dbs.get_active_stacks.return_value = [stack]
+            mock_dbs.get_stackframes.return_value = stackframes
+
+            process_camera_tick(rc, 'cam1')
+
+        mock_finalize.assert_called_once_with(rc, stack, stackframes, 'complete')
+        mock_products.run_preview.assert_not_called()
+        mock_dbs.set_preview_count.assert_not_called()
+
+    def test_preview_only_when_count_grew(self):
+        """Only stacks whose stackframe count exceeds last_preview_count get a new preview."""
+        rc = _runtime_context(SMARTSTACK_PREVIEWS=True)
+        grown = _stack(moluid='grown', frmtotal=5, last_preview_count=2)
+        same = _stack(moluid='same', frmtotal=5, last_preview_count=3)
+        frames_by_mol = {
+            'grown': [_frame(1), _frame(2), _frame(3)],
+            'same': [_frame(1), _frame(2), _frame(3)],
+        }
+        with patch('banzai.stacking.dbs') as mock_dbs, \
+             patch('banzai.stacking.finalize_stack') as mock_finalize, \
+             patch('banzai.stacking.smartstack_products') as mock_products:
+            mock_dbs.get_active_stacks.return_value = [grown, same]
+            mock_dbs.get_stackframes.side_effect = lambda db_address, moluid: frames_by_mol[moluid]
+
+            process_camera_tick(rc, 'cam1')
+
+        mock_finalize.assert_not_called()
+        mock_products.run_preview.assert_called_once_with(frames_by_mol['grown'], rc, 'grown')
+        mock_dbs.set_preview_count.assert_called_once_with(rc.db_address, 'grown', 3)
+
+    def test_preview_failure_does_not_update_count(self):
+        """If run_preview raises, the preview count is not advanced and the tick keeps going."""
+        rc = _runtime_context(SMARTSTACK_PREVIEWS=True)
+        stack = _stack(frmtotal=5, last_preview_count=2)
+        stackframes = [_frame(1), _frame(2), _frame(3)]
+        with patch('banzai.stacking.dbs') as mock_dbs, \
+             patch('banzai.stacking.finalize_stack') as mock_finalize, \
+             patch('banzai.stacking.smartstack_products') as mock_products:
+            mock_dbs.get_active_stacks.return_value = [stack]
+            mock_dbs.get_stackframes.return_value = stackframes
+            mock_products.run_preview.side_effect = RuntimeError('render failed')
+
+            process_camera_tick(rc, 'cam1')
+
+        mock_products.run_preview.assert_called_once()
+        mock_dbs.set_preview_count.assert_not_called()
+        mock_finalize.assert_not_called()
+
+    def test_previews_disabled_kill_switch(self):
+        """With SMARTSTACK_PREVIEWS off, a growing active stack renders no preview."""
+        rc = _runtime_context(SMARTSTACK_PREVIEWS=False)
+        stack = _stack(frmtotal=5, last_preview_count=0)
+        stackframes = [_frame(1), _frame(2), _frame(3)]
+        with patch('banzai.stacking.dbs') as mock_dbs, \
+             patch('banzai.stacking.finalize_stack') as mock_finalize, \
+             patch('banzai.stacking.smartstack_products') as mock_products:
+            mock_dbs.get_active_stacks.return_value = [stack]
+            mock_dbs.get_stackframes.return_value = stackframes
+
+            process_camera_tick(rc, 'cam1')
+
+        mock_products.run_preview.assert_not_called()
+        mock_dbs.set_preview_count.assert_not_called()
+        mock_finalize.assert_not_called()
 
 
 # ---------------------------------------------------------------------------
@@ -684,16 +929,94 @@ class TestSupervisor:
 
 class TestWorkerLoopResilience:
 
-    @patch('banzai.stacking.redis_lib.Redis.from_url')
+    @patch('banzai.stacking.dbs.cleanup_old_stacks')
     @patch('banzai.stacking.time.sleep')
-    @patch('banzai.stacking.process_notifications')
-    def test_run_worker_loop_continues_after_exception(self, mock_process, mock_sleep, mock_redis_cls):
-        """run_worker_loop must not crash when process_notifications raises; it should log and continue."""
-        # First call raises, second call raises KeyboardInterrupt to escape the infinite loop.
-        mock_process.side_effect = [Exception('boom'), KeyboardInterrupt]
+    @patch('banzai.stacking.process_camera_tick')
+    def test_run_worker_loop_continues_after_exception(self, mock_tick, mock_sleep, mock_cleanup):
+        """run_worker_loop must not die when process_camera_tick raises; it logs and keeps polling."""
+        # First tick raises a normal Exception (caught); second raises KeyboardInterrupt to escape the loop.
+        mock_tick.side_effect = [Exception('boom'), KeyboardInterrupt]
+        runtime_context_dict = {'db_address': 'sqlite:///fake.db', 'stack_retention_days': 30}
         with pytest.raises(KeyboardInterrupt):
-            run_worker_loop('cam1', 'sqlite:///fake.db', 'redis://localhost:6379', poll_interval=0)
-        # process_notifications was called twice: once raised Exception, once raised KeyboardInterrupt.
-        assert mock_process.call_count == 2
-        # sleep should have been called once (after the transient Exception, before continuing).
+            run_worker_loop('cam1', runtime_context_dict, poll_interval=0)
+        assert mock_tick.call_count == 2
+        # sleep runs once: after the caught Exception. The KeyboardInterrupt escapes before the second sleep.
         mock_sleep.assert_called_once_with(0)
+
+    @patch('banzai.stacking.dbs.cleanup_old_stacks')
+    @patch('banzai.stacking.time.sleep')
+    @patch('banzai.stacking.process_camera_tick')
+    def test_run_worker_loop_throttles_cleanup(self, mock_tick, mock_sleep, mock_cleanup):
+        """cleanup_old_stacks runs on the first tick, then is throttled within the hour window."""
+        # Two clean ticks, then KeyboardInterrupt to escape. time.monotonic is left real.
+        mock_tick.side_effect = [None, None, KeyboardInterrupt]
+        runtime_context_dict = {'db_address': 'sqlite:///fake.db', 'stack_retention_days': 30}
+        with pytest.raises(KeyboardInterrupt):
+            run_worker_loop('cam1', runtime_context_dict, poll_interval=0)
+        assert mock_tick.call_count == 3
+        # First tick triggers cleanup; the second is inside the hour window, so it does not.
+        mock_cleanup.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Supervisor
+# ---------------------------------------------------------------------------
+
+class TestSupervisor:
+
+    @patch('banzai.stacking.sys.exit', side_effect=SystemExit(1))
+    @patch('banzai.stacking.multiprocessing.connection.wait')
+    @patch('banzai.stacking.multiprocessing.Process')
+    @patch('banzai.stacking.dbs.get_instruments_at_site',
+           return_value=[SimpleNamespace(camera='cam1'), SimpleNamespace(camera='cam2'),
+                         SimpleNamespace(camera='cam3')])
+    @patch('banzai.stacking.main.parse_args')
+    def test_run_supervisor_spawns_process_per_camera(self, mock_parse, mock_instruments,
+                                                      mock_process_cls, mock_wait, mock_exit):
+        mock_parse.return_value = SimpleNamespace(
+            site_id='tst', db_address='sqlite:///fake.db',
+            stack_retention_days=30, stack_timeout_minutes=20, instrument_types='*',
+        )
+        with pytest.raises(SystemExit):
+            run_supervisor()
+
+        assert mock_process_cls.call_count == 3
+        assert mock_process_cls.return_value.start.call_count == 3
+        mock_wait.assert_called_once()
+        mock_exit.assert_called_once_with(1)
+
+    @patch('banzai.stacking.sys.exit', side_effect=SystemExit(1))
+    @patch('banzai.stacking.multiprocessing.Process')
+    @patch('banzai.stacking.dbs.get_instruments_at_site', return_value=[])
+    @patch('banzai.stacking.main.parse_args')
+    def test_run_supervisor_exits_when_no_cameras(self, mock_parse, mock_instruments,
+                                                  mock_process_cls, mock_exit):
+        mock_parse.return_value = SimpleNamespace(
+            site_id='tst', db_address='sqlite:///fake.db',
+            stack_retention_days=30, stack_timeout_minutes=20, instrument_types='*',
+        )
+        with pytest.raises(SystemExit):
+            run_supervisor()
+
+        mock_process_cls.assert_not_called()
+        mock_exit.assert_called_once_with(1)
+
+    @patch('banzai.stacking.sys.exit', side_effect=SystemExit(1))
+    @patch('banzai.stacking.multiprocessing.connection.wait')
+    @patch('banzai.stacking.multiprocessing.Process')
+    @patch('banzai.stacking.dbs.get_instruments_at_site',
+           return_value=[SimpleNamespace(camera='cam1', type='1m0-SciCam-Sinistro'),
+                         SimpleNamespace(camera='cam2', type='1m0-SciCam-Sinistro'),
+                         SimpleNamespace(camera='cam3', type='NRES')])
+    @patch('banzai.stacking.main.parse_args')
+    def test_run_supervisor_filters_by_instrument_type(self, mock_parse, mock_instruments,
+                                                       mock_process_cls, mock_wait, mock_exit):
+        mock_parse.return_value = SimpleNamespace(
+            site_id='tst', db_address='sqlite:///fake.db',
+            stack_retention_days=30, stack_timeout_minutes=20,
+            instrument_types='1m0-SciCam-Sinistro',
+        )
+        with pytest.raises(SystemExit):
+            run_supervisor()
+
+        assert mock_process_cls.call_count == 2

--- a/banzai/tests/test_smart_stacking.py
+++ b/banzai/tests/test_smart_stacking.py
@@ -726,7 +726,7 @@ class TestFinalizeStack:
         mock_dbs.mark_stack_terminal.assert_called_once_with(rc.db_address, stack.moluid, 'complete')
 
     def test_finalize_failure_leaves_stack_active(self):
-        """run_final raising: attempt already burned by claim, but no mark_terminal and no exception escapes."""
+        """A run_final error leaves the claimed stack active for retry."""
         rc = _runtime_context()
         stack = _stack()
         stackframes = [_frame(1)]
@@ -742,7 +742,7 @@ class TestFinalizeStack:
         mock_dbs.mark_stack_terminal.assert_not_called()
 
     def test_publish_failure_leaves_stack_active(self):
-        """post_to_shipper_queue raising: the stack is not marked terminal (publish-before-mark)."""
+        """A publishing error leaves the stack active for retry."""
         rc = _runtime_context()
         stack = _stack()
         stackframes = [_frame(1)]
@@ -759,7 +759,7 @@ class TestFinalizeStack:
         mock_dbs.mark_stack_terminal.assert_not_called()
 
     def test_exhausted_attempts_marks_error(self):
-        """At/over MAX attempts, the stack is marked 'error' without claiming or doing any work."""
+        """An exhausted attempt budget marks the stack as error without generating products."""
         rc = _runtime_context()
         stack = _stack(finalize_attempts=MAX_FINALIZE_ATTEMPTS, next_attempt_at=None)
         stackframes = [_frame(1)]
@@ -947,14 +947,13 @@ class TestWorkerLoopResilience:
     @patch('banzai.stacking.time.sleep')
     @patch('banzai.stacking.process_camera_tick')
     def test_run_worker_loop_continues_after_exception(self, mock_tick, mock_sleep, mock_cleanup):
-        """run_worker_loop must not die when process_camera_tick raises; it logs and keeps polling."""
+        """A tick error does not stop the polling loop."""
         # First tick raises a normal Exception (caught); second raises KeyboardInterrupt to escape the loop.
         mock_tick.side_effect = [Exception('boom'), KeyboardInterrupt]
         runtime_context_dict = {'db_address': 'sqlite:///fake.db', 'stack_retention_days': 30}
         with pytest.raises(KeyboardInterrupt):
             run_worker_loop('cam1', runtime_context_dict, poll_interval=0)
         assert mock_tick.call_count == 2
-        # sleep runs once: after the caught Exception. The KeyboardInterrupt escapes before the second sleep.
         mock_sleep.assert_called_once_with(0)
 
     @patch('banzai.stacking.time.monotonic')
@@ -964,10 +963,8 @@ class TestWorkerLoopResilience:
     def test_run_worker_loop_throttles_cleanup(self, mock_tick, mock_sleep, mock_cleanup,
                                                mock_monotonic):
         """cleanup_old_stacks runs on the first tick, then is throttled within the hour window."""
-        # Two clean ticks, then KeyboardInterrupt to escape. Scripted clock: the first tick sees an
-        # interval past the hour window (cleanup fires), the second tick lands inside it (throttled).
-        # A function-based side_effect keeps returning the final value so extra monotonic calls
-        # (comparison + reassignment) can never exhaust it.
+        # The first tick is past the cleanup interval; later clock reads remain within it.
+        # The fallback prevents additional monotonic calls from exhausting the mock clock.
         clock = [0.0, 3601.0, 3601.0]
         mock_monotonic.side_effect = lambda: clock.pop(0) if clock else 3602.0
         mock_tick.side_effect = [None, None, KeyboardInterrupt]
@@ -975,7 +972,6 @@ class TestWorkerLoopResilience:
         with pytest.raises(KeyboardInterrupt):
             run_worker_loop('cam1', runtime_context_dict, poll_interval=0)
         assert mock_tick.call_count == 3
-        # First tick triggers cleanup; the second is inside the hour window, so it does not.
         mock_cleanup.assert_called_once()
 
 

--- a/banzai/tests/test_smart_stacking.py
+++ b/banzai/tests/test_smart_stacking.py
@@ -293,8 +293,8 @@ class TestConcurrentStacks:
         stackframes_b = dbs.get_stackframes(db_address, 'mol-B')
         assert len(stackframes_a) == 3
         assert len(stackframes_b) == 2
-        assert check_stack_complete(stackframes_a, frmtotal=3) is True
-        assert check_stack_complete(stackframes_b, frmtotal=5) is False
+        assert check_stack_complete(stackframes_a) is True
+        assert check_stack_complete(stackframes_b) is False
 
 
 # ---------------------------------------------------------------------------
@@ -310,23 +310,16 @@ class TestCheckStackComplete:
         f.is_last = is_last
         return f
 
-    def test_check_stack_complete_all_stackframes_arrived(self):
+    def test_check_stack_complete_without_is_last(self):
         stackframes = [self._stackframe() for _ in range(3)]
-        assert check_stack_complete(stackframes, frmtotal=3) is True
+        assert check_stack_complete(stackframes) is False
 
-    def test_check_stack_complete_partial_without_is_last(self):
-        stackframes = [self._stackframe() for _ in range(3)]
-        assert check_stack_complete(stackframes, frmtotal=5) is False
-
-    def test_check_stack_complete_partial_with_is_last(self):
+    def test_check_stack_complete_with_is_last(self):
         stackframes = [self._stackframe() for _ in range(2)] + [self._stackframe(is_last=True)]
-        assert check_stack_complete(stackframes, frmtotal=5) is True
+        assert check_stack_complete(stackframes) is True
 
     def test_check_stack_complete_empty_stackframes(self):
-        assert check_stack_complete([], frmtotal=5) is False
-
-    def test_check_stack_complete_empty_stackframes_with_zero_total(self):
-        assert check_stack_complete([], frmtotal=0) is False
+        assert check_stack_complete([]) is False
 
 
 # ---------------------------------------------------------------------------

--- a/banzai/tests/test_smart_stacking.py
+++ b/banzai/tests/test_smart_stacking.py
@@ -691,10 +691,9 @@ def _stack(moluid='mol-w', frmtotal=3, finalize_attempts=0, next_attempt_at=None
     )
 
 
-def _frame(stack_num, is_last=False, instrument_enqueue_timestamp=None, filepath=None):
+def _frame(stack_num, is_last=False, filepath=None):
     return SimpleNamespace(
         stack_num=stack_num, is_last=is_last,
-        instrument_enqueue_timestamp=instrument_enqueue_timestamp,
         filepath=filepath or f'/data/f{stack_num}.fits',
     )
 
@@ -705,8 +704,7 @@ class TestFinalizeStack:
         """The attempt is claimed first, then run_final -> publish -> mark_terminal, in that order."""
         rc = _runtime_context()
         stack = _stack(finalize_attempts=0, next_attempt_at=None)
-        stackframes = [_frame(1, instrument_enqueue_timestamp=111),
-                       _frame(2, is_last=True, instrument_enqueue_timestamp=222)]
+        stackframes = [_frame(1), _frame(2, is_last=True)]
         with patch('banzai.stacking.dbs') as mock_dbs, \
              patch('banzai.stacking.smartstack_products') as mock_products, \
              patch('banzai.stacking.post_to_shipper_queue') as mock_publish:
@@ -724,7 +722,6 @@ class TestFinalizeStack:
         mock_publish.assert_called_once_with(
             rc.broker_url, rc.SHIPPER_EXCHANGE, rc.SHIPPER_QUEUE_NAME,
             fits_path='/o/e45.fits', small_thumbnail='/o/small.jpg', large_thumbnail='/o/large.jpg',
-            instrument_enqueue_timestamp=222,
         )
         mock_dbs.mark_stack_terminal.assert_called_once_with(rc.db_address, stack.moluid, 'complete')
 
@@ -732,7 +729,7 @@ class TestFinalizeStack:
         """run_final raising: attempt already burned by claim, but no mark_terminal and no exception escapes."""
         rc = _runtime_context()
         stack = _stack()
-        stackframes = [_frame(1, instrument_enqueue_timestamp=111)]
+        stackframes = [_frame(1)]
         with patch('banzai.stacking.dbs') as mock_dbs, \
              patch('banzai.stacking.smartstack_products') as mock_products, \
              patch('banzai.stacking.post_to_shipper_queue') as mock_publish:
@@ -748,7 +745,7 @@ class TestFinalizeStack:
         """post_to_shipper_queue raising: the stack is not marked terminal (publish-before-mark)."""
         rc = _runtime_context()
         stack = _stack()
-        stackframes = [_frame(1, instrument_enqueue_timestamp=111)]
+        stackframes = [_frame(1)]
         with patch('banzai.stacking.dbs') as mock_dbs, \
              patch('banzai.stacking.smartstack_products') as mock_products, \
              patch('banzai.stacking.post_to_shipper_queue') as mock_publish:
@@ -765,7 +762,7 @@ class TestFinalizeStack:
         """At/over MAX attempts, the stack is marked 'error' without claiming or doing any work."""
         rc = _runtime_context()
         stack = _stack(finalize_attempts=MAX_FINALIZE_ATTEMPTS, next_attempt_at=None)
-        stackframes = [_frame(1, instrument_enqueue_timestamp=111)]
+        stackframes = [_frame(1)]
         with patch('banzai.stacking.dbs') as mock_dbs, \
              patch('banzai.stacking.smartstack_products') as mock_products, \
              patch('banzai.stacking.post_to_shipper_queue') as mock_publish:

--- a/banzai/tests/test_smart_stacking.py
+++ b/banzai/tests/test_smart_stacking.py
@@ -960,12 +960,19 @@ class TestWorkerLoopResilience:
         # sleep runs once: after the caught Exception. The KeyboardInterrupt escapes before the second sleep.
         mock_sleep.assert_called_once_with(0)
 
+    @patch('banzai.stacking.time.monotonic')
     @patch('banzai.stacking.dbs.cleanup_old_stacks')
     @patch('banzai.stacking.time.sleep')
     @patch('banzai.stacking.process_camera_tick')
-    def test_run_worker_loop_throttles_cleanup(self, mock_tick, mock_sleep, mock_cleanup):
+    def test_run_worker_loop_throttles_cleanup(self, mock_tick, mock_sleep, mock_cleanup,
+                                               mock_monotonic):
         """cleanup_old_stacks runs on the first tick, then is throttled within the hour window."""
-        # Two clean ticks, then KeyboardInterrupt to escape. time.monotonic is left real.
+        # Two clean ticks, then KeyboardInterrupt to escape. Scripted clock: the first tick sees an
+        # interval past the hour window (cleanup fires), the second tick lands inside it (throttled).
+        # A function-based side_effect keeps returning the final value so extra monotonic calls
+        # (comparison + reassignment) can never exhaust it.
+        clock = [0.0, 3601.0, 3601.0]
+        mock_monotonic.side_effect = lambda: clock.pop(0) if clock else 3602.0
         mock_tick.side_effect = [None, None, KeyboardInterrupt]
         runtime_context_dict = {'db_address': 'sqlite:///fake.db', 'stack_retention_days': 30}
         with pytest.raises(KeyboardInterrupt):

--- a/banzai/tests/test_smart_stacking.py
+++ b/banzai/tests/test_smart_stacking.py
@@ -15,7 +15,7 @@ from banzai.stacking import (check_stack_complete, stack_has_timed_out, finalize
                              process_camera_tick, run_worker_loop, run_supervisor,
                              FINALIZE_BACKOFF_SECONDS, MAX_FINALIZE_ATTEMPTS)
 from banzai.scheduling import process_stackframe
-from banzai.main import StackframeListener
+from banzai.main import StackframeListener, run_stacking_supervisor
 
 pytestmark = pytest.mark.smart_stacking
 
@@ -983,6 +983,27 @@ class TestWorkerLoopResilience:
 # Supervisor
 # ---------------------------------------------------------------------------
 
+class TestSupervisorEntrypoint:
+
+    @patch('banzai.main.stacking.run_supervisor')
+    @patch('banzai.main.parse_args')
+    def test_run_stacking_supervisor_parses_and_forwards_context(self, mock_parse_args,
+                                                                 mock_run_supervisor):
+        runtime_context = SimpleNamespace(marker='complete context')
+        mock_parse_args.return_value = runtime_context
+
+        run_stacking_supervisor()
+
+        mock_run_supervisor.assert_called_once_with(runtime_context)
+        extra_arguments = mock_parse_args.call_args.kwargs['extra_console_arguments']
+        assert [argument['args'][0] for argument in extra_arguments] == [
+            '--site-id',
+            '--stack-retention-days',
+            '--stack-timeout-minutes',
+            '--instrument-types',
+        ]
+
+
 class TestSupervisor:
 
     @patch('banzai.stacking.sys.exit', side_effect=SystemExit(1))
@@ -991,15 +1012,14 @@ class TestSupervisor:
     @patch('banzai.stacking.dbs.get_instruments_at_site',
            return_value=[SimpleNamespace(camera='cam1'), SimpleNamespace(camera='cam2'),
                          SimpleNamespace(camera='cam3')])
-    @patch('banzai.stacking.main.parse_args')
-    def test_run_supervisor_spawns_process_per_camera(self, mock_parse, mock_instruments,
-                                                      mock_process_cls, mock_wait, mock_exit):
-        mock_parse.return_value = SimpleNamespace(
+    def test_run_supervisor_spawns_process_per_camera(self, mock_instruments, mock_process_cls,
+                                                      mock_wait, mock_exit):
+        runtime_context = SimpleNamespace(
             site_id='tst', db_address='sqlite:///fake.db',
             stack_retention_days=30, stack_timeout_minutes=20, instrument_types='*',
         )
         with pytest.raises(SystemExit):
-            run_supervisor()
+            run_supervisor(runtime_context)
 
         assert mock_process_cls.call_count == 3
         assert mock_process_cls.return_value.start.call_count == 3
@@ -1009,15 +1029,14 @@ class TestSupervisor:
     @patch('banzai.stacking.sys.exit', side_effect=SystemExit(1))
     @patch('banzai.stacking.multiprocessing.Process')
     @patch('banzai.stacking.dbs.get_instruments_at_site', return_value=[])
-    @patch('banzai.stacking.main.parse_args')
-    def test_run_supervisor_exits_when_no_cameras(self, mock_parse, mock_instruments,
-                                                  mock_process_cls, mock_exit):
-        mock_parse.return_value = SimpleNamespace(
+    def test_run_supervisor_exits_when_no_cameras(self, mock_instruments, mock_process_cls,
+                                                  mock_exit):
+        runtime_context = SimpleNamespace(
             site_id='tst', db_address='sqlite:///fake.db',
             stack_retention_days=30, stack_timeout_minutes=20, instrument_types='*',
         )
         with pytest.raises(SystemExit):
-            run_supervisor()
+            run_supervisor(runtime_context)
 
         mock_process_cls.assert_not_called()
         mock_exit.assert_called_once_with(1)
@@ -1029,15 +1048,14 @@ class TestSupervisor:
            return_value=[SimpleNamespace(camera='cam1', type='1m0-SciCam-Sinistro'),
                          SimpleNamespace(camera='cam2', type='1m0-SciCam-Sinistro'),
                          SimpleNamespace(camera='cam3', type='NRES')])
-    @patch('banzai.stacking.main.parse_args')
-    def test_run_supervisor_filters_by_instrument_type(self, mock_parse, mock_instruments,
-                                                       mock_process_cls, mock_wait, mock_exit):
-        mock_parse.return_value = SimpleNamespace(
+    def test_run_supervisor_filters_by_instrument_type(self, mock_instruments, mock_process_cls,
+                                                       mock_wait, mock_exit):
+        runtime_context = SimpleNamespace(
             site_id='tst', db_address='sqlite:///fake.db',
             stack_retention_days=30, stack_timeout_minutes=20,
             instrument_types='1m0-SciCam-Sinistro',
         )
         with pytest.raises(SystemExit):
-            run_supervisor()
+            run_supervisor(runtime_context)
 
         assert mock_process_cls.call_count == 2

--- a/banzai/tests/test_smart_stacking.py
+++ b/banzai/tests/test_smart_stacking.py
@@ -887,6 +887,23 @@ class TestProcessCameraTick:
         mock_products.run_preview.assert_called_once_with(frames_by_mol['grown'], rc, 'grown')
         mock_dbs.set_preview_count.assert_called_once_with(rc.db_address, 'grown', 3)
 
+    def test_preview_waits_for_stackframe_one(self):
+        """Do not publish a preview whose basename could change when stackframe 1 arrives."""
+        rc = _runtime_context(SMARTSTACK_PREVIEWS=True)
+        stack = _stack(frmtotal=3, last_preview_count=0)
+        stackframes = [_frame(2)]
+        with patch('banzai.stacking.dbs') as mock_dbs, \
+             patch('banzai.stacking.finalize_stack') as mock_finalize, \
+             patch('banzai.stacking.smartstack_products') as mock_products:
+            mock_dbs.get_active_stacks.return_value = [stack]
+            mock_dbs.get_stackframes.return_value = stackframes
+
+            process_camera_tick(rc, 'cam1')
+
+        mock_finalize.assert_not_called()
+        mock_products.run_preview.assert_not_called()
+        mock_dbs.set_preview_count.assert_not_called()
+
     def test_preview_failure_does_not_update_count(self):
         """If run_preview raises, the preview count is not advanced and the tick keeps going."""
         rc = _runtime_context(SMARTSTACK_PREVIEWS=True)

--- a/docker-compose-site.yml
+++ b/docker-compose-site.yml
@@ -202,16 +202,27 @@ services:
     depends_on:
       banzai-cache-init:
         condition: service_completed_successfully
+    volumes:
+      - ${HOST_REDUCED_DIR}:${HOST_REDUCED_DIR}
     environment:
+      - DB_ADDRESS=${DB_ADDRESS}
       - STACK_QUEUE_NAME=${STACK_QUEUE_NAME:-banzai_stack_queue}
+      - SHIPPER_EXCHANGE=${SHIPPER_EXCHANGE:-ship_files}
+      - SHIPPER_QUEUE_NAME=${SHIPPER_QUEUE_NAME:-ship}
+      - SMARTSTACK_PREVIEWS=${SMARTSTACK_PREVIEWS:-true}
+      - DATA_ROOT=${HOST_REDUCED_DIR}
     command: [
       "banzai_stacking_supervisor",
       "--site-id=${SITE_ID}",
+      "--instrument-types=${INSTRUMENT_TYPES:-*}",
       "--db-address=${DB_ADDRESS}",
-      "--redis-url=${REDIS_URL}",
-      "--stack-retention-days=${STACK_RETENTION_DAYS:-30}"
+      "--broker-url=${RABBITMQ_URL}",
+      "--processed-path=${HOST_REDUCED_DIR}",
+      "--rlevel=45",
+      "--stack-retention-days=${STACK_RETENTION_DAYS:-30}",
+      "--stack-timeout-minutes=${STACK_TIMEOUT_MINUTES:-20}"
     ]
-    restart: unless-stopped
+    restart: always
 
 volumes:
   site-pgdata:

--- a/docker-compose-site.yml
+++ b/docker-compose-site.yml
@@ -218,7 +218,6 @@ services:
       "--db-address=${DB_ADDRESS}",
       "--broker-url=${RABBITMQ_URL}",
       "--processed-path=${HOST_REDUCED_DIR}",
-      "--rlevel=45",
       "--stack-retention-days=${STACK_RETENTION_DAYS:-30}",
       "--stack-timeout-minutes=${STACK_TIMEOUT_MINUTES:-20}"
     ]

--- a/docs/smartstacking_architecture.md
+++ b/docs/smartstacking_architecture.md
@@ -207,7 +207,7 @@ one or more raw e00 subframes
 |-------------------|-------------|----------------|
 | `banzai-subframe-listener` | `banzai.main:run_subframe_worker` | Consume and validate RabbitMQ messages; dispatch Celery tasks. Despite the CLI name, this is the listener process. |
 | `banzai-subframe-worker` | Celery worker consuming `SUBFRAME_TASK_QUEUE_NAME` | Reduce the FITS file, upsert the reduced row, and send a notification. |
-| `banzai-stacking-supervisor` | `banzai.stacking:run_supervisor` | Discover cameras at startup, start one child per camera, and restart children that exit. |
+| `banzai-stacking-supervisor` | `banzai.main:run_stacking_supervisor` | Discover cameras at startup, start one child per camera, and restart children that exit. |
 | `stacking-worker-{camera}` | `banzai.stacking:run_worker_loop` | Process unique notifications in FIFO order, query stack state, mark complete groups, and run retention cleanup. |
 
 Camera discovery uses `dbs.get_instruments_at_site(site_id, db_address)` once

--- a/docs/smartstacking_architecture.md
+++ b/docs/smartstacking_architecture.md
@@ -173,15 +173,11 @@ flowchart TD
 
 ### 4. Decide whether the group is complete
 
-`check_stack_complete` returns true when the group is non-empty and either:
-
-- `len(subframes) == FRMTOTAL`, or
-- any row has `is_last == true`.
-
-This is an exact count check, not an "at least" check. The database uniqueness
-constraint prevents duplicate `(MOLUID, MOLFRNUM)` rows, but the predicate does
-not independently verify that frame numbers are contiguous or that all rows
-agree on `FRMTOTAL`.
+`check_stack_complete` returns true when any row has `is_last == true`. This is
+the producer's authoritative end-of-sequence signal. `FRMTOTAL` remains the
+expected group size for metadata and progress; it does not decide completion.
+The predicate trusts the producer and does not independently verify that prior
+frame numbers are contiguous.
 
 ### 5. "Finalize" the group
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,7 +115,7 @@ banzai_create_db = "banzai.main:create_db"
 banzai_create_local_db = "banzai.main:create_local_db"
 banzai_download_worker = "banzai.cache.download_worker:run_download_worker_daemon"
 banzai_cache_init = "banzai.cache.init:run_initialization"
-banzai_stacking_supervisor = "banzai.stacking:run_supervisor"
+banzai_stacking_supervisor = "banzai.main:run_stacking_supervisor"
 banzai_stackframe_worker = "banzai.main:run_stackframe_worker"
 
 [tool.coverage.run]

--- a/scripts/queue_stackframes.py
+++ b/scripts/queue_stackframes.py
@@ -4,7 +4,7 @@ Send raw FITS stackframes to banzai_stack_queue for site-deployment stacking.
 
 Used with docker-compose-site.yml. The banzai-stackframe-listener consumes from
 this queue, reduces each stackframe, and the stacking supervisor produces a
-stacked frame once all stackframes in a MOLUID group arrive.
+stacked frame when the final stackframe in a MOLUID group is signalled.
 
 Each FITS file's SCI header must contain:
     MOLUID   - observation group identifier

--- a/site-banzai-env.default
+++ b/site-banzai-env.default
@@ -10,7 +10,7 @@ HOST_CALS_DIR=/mnt/data/calibrations         # Cached calibration files
 HOST_REDUCED_DIR=/mnt/data/reduced           # Pipeline output (reduced frames)
 
 # Message brokers (override to point at existing site infrastructure)
-REDIS_URL=redis://host.docker.internal:6379/0
+REDIS_URL=redis://host.docker.internal:6379/0   # Celery broker only — smartstacking no longer uses Redis
 RABBITMQ_URL=amqp://host.docker.internal:5672
 FITS_EXCHANGE=fits_files
 PIPELINE_QUEUE_NAME=banzai_pipeline
@@ -24,10 +24,13 @@ OMP_NUM_THREADS=2
 DOWNLOAD_WORKER_POLL_INTERVAL=10
 
 # Smart stacking
-STACK_TIMEOUT_MINUTES=20                # Minutes since the first raw frame is received before creating the final stack (even if not all frames are present)
-                                        # TODO: what if total stack exposure is >20min? Need to fix this.
+STACK_TIMEOUT_MINUTES=20                # Minutes of silence (no new reduced stackframe arriving) before a partial stack is finalized.
+                                        # Cadence-based: the clock resets on every arrival, so a long total exposure never times out mid-stream.
 STACK_RETENTION_DAYS=30                 # Number of days to retain stack frame data after stacking has completed
 STACK_QUEUE_NAME=banzai_stack_queue     # RabbitMQ queue that contains incoming raw images to stack
+SHIPPER_EXCHANGE=ship_files             # Fanout exchange the site shipper consumes smartstack products from
+SHIPPER_QUEUE_NAME=ship                 # Durable queue bound to SHIPPER_EXCHANGE for smartstack product messages
+SMARTSTACK_PREVIEWS=true                # Render an incremental JPEG preview on each arrival (false = final products only)
 
 # Database
 DB_ADDRESS=postgresql+psycopg://banzai@postgresql:5432/banzai_local

--- a/site-banzai-env.default
+++ b/site-banzai-env.default
@@ -10,7 +10,7 @@ HOST_CALS_DIR=/mnt/data/calibrations         # Cached calibration files
 HOST_REDUCED_DIR=/mnt/data/reduced           # Pipeline output (reduced frames)
 
 # Message brokers (override to point at existing site infrastructure)
-REDIS_URL=redis://host.docker.internal:6379/0   # Celery broker only — smartstacking no longer uses Redis
+REDIS_URL=redis://host.docker.internal:6379/0   # used for Celery task broker
 RABBITMQ_URL=amqp://host.docker.internal:5672
 FITS_EXCHANGE=fits_files
 PIPELINE_QUEUE_NAME=banzai_pipeline
@@ -24,11 +24,11 @@ OMP_NUM_THREADS=2
 DOWNLOAD_WORKER_POLL_INTERVAL=10
 
 # Smart stacking
-STACK_TIMEOUT_MINUTES=20                # Minutes of silence (no new reduced stackframe arriving) before a partial stack is finalized.
-                                        # Cadence-based: the clock resets on every arrival, so a long total exposure never times out mid-stream.
+STACK_TIMEOUT_MINUTES=20                # Minutes without a reduced stackframe before finalizing a partial stack.
+                                        # The timer resets whenever another reduced frame arrives.
 STACK_RETENTION_DAYS=30                 # Number of days to retain stack frame data after stacking has completed
 STACK_QUEUE_NAME=banzai_stack_queue     # RabbitMQ queue that contains incoming raw images to stack
-SHIPPER_EXCHANGE=ship_files             # Fanout exchange the site shipper consumes smartstack products from
+SHIPPER_EXCHANGE=ship_files             # Fanout exchange used to notify the site shipper of new Smartstack products
 SHIPPER_QUEUE_NAME=ship                 # Durable queue bound to SHIPPER_EXCHANGE for smartstack product messages
 SMARTSTACK_PREVIEWS=true                # Render an incremental JPEG preview on each arrival (false = final products only)
 


### PR DESCRIPTION
## Summary

This is PR 6 of 8 completing the v1 banzai implementation of Smartstacking at site.

PR1 (#469): combine math
PR2 (#470): JPEG utilities
PR3 (#471): DB updates   
PR4 (#473): shipper contract                     
PR5 (#474): smartstack data products
PR6 (#475): stack worker polling   &emsp;&emsp;&emsp;&emsp;    <-- you are here
PR7 (#476): e2e tests, compose cleanup
PR8 (#477): logging

```text
PR1 combine math ───────┐
PR2 JPEG utilities ─────┤
PR3 DB updates ─────────┼──> PR5 data products --> PR6 stack workers --> PR7 E2E --> PR8 logs/docs
PR4 shipper contract ───┘
```

PRs 1–4 provide the independent foundations for combining images, rendering JPEGs, storing stack state, and shipper integration (this PR). PR5 builds the data products, this PR adds the polling worker, crash-only supervisor, and site deployment configuration. PR7 adds cross-service E2E and recovery proof; PR8 adds structured lifecycle telemetry and final documentation.

## Stack Worker Lifecycle behavior

The runtime starts one stateless polling process per camera. Each poll:

- Loads active stacks and their ordered members from PostgreSQL.
- Finalizes a stack when all expected members have arrived or an `is_last` member is present.
- Gives completion priority when a stack is both complete and past its timeout.
- Defines timeout as silence since the latest accepted reduced member.
- Produces a partial final product when an incomplete stack times out.
- Renders previews only when enabled, membership has grown, and logical frame 1 is present so product names remain stable.

A failed preview does not advance the stored preview count, allowing a later poll to retry it.

## Finalization and retries

Finalization follows a deliberate order:

```text
claim attempt → write products → publish paths → mark terminal
```

The attempt and backoff are persisted before product work begins. A build or publish failure therefore leaves the stack active for a bounded retry, while exhausted attempts end in `error`.

Publishing happens before the terminal database update. A failure between those steps can produce a duplicate notification with identical paths, but cannot leave a stack marked complete without having notified the shipper.

## Process recovery

Ordinary exceptions are contained inside each worker loop. If a child dies violently—for example from an OOM kill—the supervisor exits and Docker restarts the service.

Because all lifecycle, retry, and preview state lives in PostgreSQL, workers restart without reconstructing process-local state. Claiming before product work also prevents a consistently failing stack from causing an endless restart loop.

## Scope

This PR adds the polling worker, crash-only supervisor, and site deployment configuration. PR7 adds cross-service E2E and recovery proof; PR8 adds structured lifecycle telemetry and final documentation.

Focused tests cover completion and timeout precedence, preview gating, finalization ordering, retries, publish failures, attempt exhaustion, worker-loop resilience, and supervisor behavior.