### PR TITLE
Smartstack: logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,6 +70,7 @@ distribute-*.tar.gz
 .settings
 .envrc
 justfile
+scratch
 
 # Local Banzai Setup
 site-banzai-env

--- a/banzai/scheduling.py
+++ b/banzai/scheduling.py
@@ -354,6 +354,14 @@ def process_stackframe(self, body: dict, runtime_context: dict):
                                     'smartstack_filepath': reduced_path,
                                     'smartstack_status': 'timeout'})
             return
+        if stack_created:
+            logger.info('Smartstack created', extra_tags={'smartstack_event': 'created',
+                                                          'moluid': header['MOLUID'], 'camera': camera,
+                                                          'frmtotal': header['FRMTOTAL']})
+        logger.info('Reduced stackframe', extra_tags={'smartstack_event': 'frame_reduced',
+                                                      'moluid': header['MOLUID'], 'camera': camera,
+                                                      'stack_num': header['MOLFRNUM'],
+                                                      'filepath': reduced_path})
 
     except Retry:
         raise

--- a/banzai/scheduling.py
+++ b/banzai/scheduling.py
@@ -356,12 +356,14 @@ def process_stackframe(self, body: dict, runtime_context: dict):
             return
         if stack_created:
             logger.info('Smartstack created', extra_tags={'smartstack_event': 'created',
-                                                          'moluid': header['MOLUID'], 'camera': camera,
-                                                          'frmtotal': header['FRMTOTAL']})
+                                                          'smartstack_moluid': header['MOLUID'],
+                                                          'smartstack_camera': camera,
+                                                          'smartstack_frmtotal': header['FRMTOTAL']})
         logger.info('Reduced stackframe', extra_tags={'smartstack_event': 'frame_reduced',
-                                                      'moluid': header['MOLUID'], 'camera': camera,
-                                                      'stack_num': header['MOLFRNUM'],
-                                                      'filepath': reduced_path})
+                                                      'smartstack_moluid': header['MOLUID'],
+                                                      'smartstack_camera': camera,
+                                                      'smartstack_stack_num': header['MOLFRNUM'],
+                                                      'smartstack_filepath': reduced_path})
 
     except Retry:
         raise

--- a/banzai/stacking.py
+++ b/banzai/stacking.py
@@ -68,7 +68,8 @@ def finalize_stack(runtime_context, stack_row, stackframes, status):
     if stack_row.finalize_attempts >= MAX_FINALIZE_ATTEMPTS:
         dbs.mark_stack_terminal(runtime_context.db_address, moluid, 'error')
         logger.error('Smartstack exhausted finalize attempts; marking error',
-                     extra_tags={'moluid': moluid, 'finalize_attempts': stack_row.finalize_attempts})
+                     extra_tags={'moluid': moluid, 'camera': stack_row.camera,
+                                 'finalize_attempts': stack_row.finalize_attempts})
         return
 
     dbs.claim_finalize_attempt(runtime_context.db_address, moluid, FINALIZE_BACKOFF_SECONDS)
@@ -84,9 +85,11 @@ def finalize_stack(runtime_context, stack_row, stackframes, status):
             large_thumbnail=large_thumbnail,
         )
         dbs.mark_stack_terminal(runtime_context.db_address, moluid, status)
-        logger.info('Finalized smartstack', extra_tags={'moluid': moluid, 'status': status})
+        logger.info('Finalized smartstack', extra_tags={'smartstack_event': 'finalized', 'moluid': moluid,
+                                                        'camera': stack_row.camera, 'status': status})
     except Exception:
-        logger.error('Failed to finalize smartstack', exc_info=True, extra_tags={'moluid': moluid})
+        logger.error('Failed to finalize smartstack', exc_info=True,
+                     extra_tags={'moluid': moluid, 'camera': stack_row.camera})
 
 
 def process_camera_tick(runtime_context, camera):

--- a/banzai/stacking.py
+++ b/banzai/stacking.py
@@ -68,11 +68,14 @@ def finalize_stack(runtime_context, stack_row, stackframes, status):
     if stack_row.finalize_attempts >= MAX_FINALIZE_ATTEMPTS:
         dbs.mark_stack_terminal(runtime_context.db_address, moluid, 'error')
         logger.error('Smartstack exhausted finalize attempts; marking error',
-                     extra_tags={'moluid': moluid, 'camera': stack_row.camera,
-                                 'finalize_attempts': stack_row.finalize_attempts})
+                     extra_tags={'smartstack_event': 'terminal',
+                                 'smartstack_status': 'error',
+                                 'smartstack_moluid': moluid,
+                                 'smartstack_camera': stack_row.camera,
+                                 'smartstack_finalize_attempt': stack_row.finalize_attempts})
         return
 
-    dbs.claim_finalize_attempt(runtime_context.db_address, moluid, FINALIZE_BACKOFF_SECONDS)
+    finalize_attempt = dbs.claim_finalize_attempt(runtime_context.db_address, moluid, FINALIZE_BACKOFF_SECONDS)
     try:
         fits_path, small_thumbnail, large_thumbnail = smartstack_products.run_final(
             stackframes, runtime_context, moluid)
@@ -85,11 +88,18 @@ def finalize_stack(runtime_context, stack_row, stackframes, status):
             large_thumbnail=large_thumbnail,
         )
         dbs.mark_stack_terminal(runtime_context.db_address, moluid, status)
-        logger.info('Finalized smartstack', extra_tags={'smartstack_event': 'finalized', 'moluid': moluid,
-                                                        'camera': stack_row.camera, 'status': status})
+        logger.info('Finalized smartstack', extra_tags={'smartstack_event': 'terminal',
+                                                        'smartstack_status': status,
+                                                        'smartstack_moluid': moluid,
+                                                        'smartstack_camera': stack_row.camera,
+                                                        'smartstack_finalize_attempt': finalize_attempt})
     except Exception:
         logger.error('Failed to finalize smartstack', exc_info=True,
-                     extra_tags={'moluid': moluid, 'camera': stack_row.camera})
+                     extra_tags={'smartstack_event': 'finalize_failed',
+                                 'smartstack_target_status': status,
+                                 'smartstack_moluid': moluid,
+                                 'smartstack_camera': stack_row.camera,
+                                 'smartstack_finalize_attempt': finalize_attempt})
 
 
 def process_camera_tick(runtime_context, camera):

--- a/banzai/tests/test_smart_stacking.py
+++ b/banzai/tests/test_smart_stacking.py
@@ -609,10 +609,24 @@ class TestProcessStackframe:
         with patch('banzai.scheduling.fits_utils.get_primary_header', return_value=header):
             process_stackframe(body, runtime_context)
 
-        events = [call.kwargs.get('extra_tags', {}).get('smartstack_event')
-                  for call in mock_logger.info.call_args_list]
-        assert ('created' in events) is expect_created_log
-        assert 'frame_reduced' in events
+        created_tags = {
+            'smartstack_event': 'created',
+            'smartstack_moluid': 'mol-xyz',
+            'smartstack_camera': 'cam1',
+            'smartstack_frmtotal': 5,
+        }
+        frame_tags = {
+            'smartstack_event': 'frame_reduced',
+            'smartstack_moluid': 'mol-xyz',
+            'smartstack_camera': 'cam1',
+            'smartstack_stack_num': 1,
+            'smartstack_filepath': '/data/processed/frame-e09.fits',
+        }
+        if expect_created_log:
+            mock_logger.info.assert_any_call('Smartstack created', extra_tags=created_tags)
+        else:
+            assert not any(call.args == ('Smartstack created',) for call in mock_logger.info.call_args_list)
+        mock_logger.info.assert_any_call('Reduced stackframe', extra_tags=frame_tags)
 
     @patch('banzai.scheduling.stage_utils.run_pipeline_stages')
     def test_process_stackframe_upserts_only_after_reduction(self, mock_run_stages, db_address, monkeypatch):
@@ -717,14 +731,17 @@ def _frame(stack_num, is_last=False, filepath=None):
 
 class TestFinalizeStack:
 
-    def test_finalize_claims_before_work(self):
+    @pytest.mark.parametrize('status', ['complete', 'timeout'])
+    def test_finalize_claims_before_work_and_logs_terminal(self, status):
         """The attempt is claimed first, then run_final -> publish -> mark_terminal, in that order."""
         rc = _runtime_context()
         stack = _stack(finalize_attempts=0, next_attempt_at=None)
         stackframes = [_frame(1), _frame(2, is_last=True)]
         with patch('banzai.stacking.dbs') as mock_dbs, \
              patch('banzai.stacking.smartstack_products') as mock_products, \
-             patch('banzai.stacking.post_to_shipper_queue') as mock_publish:
+             patch('banzai.stacking.post_to_shipper_queue') as mock_publish, \
+             patch('banzai.stacking.logger') as mock_logger:
+            mock_dbs.claim_finalize_attempt.return_value = 1
             mock_products.run_final.return_value = ('/o/e45.fits', '/o/small.jpg', '/o/large.jpg')
             manager = MagicMock()
             manager.attach_mock(mock_dbs.claim_finalize_attempt, 'claim')
@@ -732,7 +749,7 @@ class TestFinalizeStack:
             manager.attach_mock(mock_publish, 'publish')
             manager.attach_mock(mock_dbs.mark_stack_terminal, 'mark_terminal')
 
-            finalize_stack(rc, stack, stackframes, 'complete')
+            finalize_stack(rc, stack, stackframes, status)
 
         assert [call[0] for call in manager.mock_calls] == ['claim', 'run_final', 'publish', 'mark_terminal']
         mock_dbs.claim_finalize_attempt.assert_called_once_with(rc.db_address, stack.moluid, FINALIZE_BACKOFF_SECONDS)
@@ -740,7 +757,17 @@ class TestFinalizeStack:
             rc.broker_url, rc.SHIPPER_EXCHANGE, rc.SHIPPER_QUEUE_NAME,
             fits_path='/o/e45.fits', small_thumbnail='/o/small.jpg', large_thumbnail='/o/large.jpg',
         )
-        mock_dbs.mark_stack_terminal.assert_called_once_with(rc.db_address, stack.moluid, 'complete')
+        mock_dbs.mark_stack_terminal.assert_called_once_with(rc.db_address, stack.moluid, status)
+        mock_logger.info.assert_called_once_with(
+            'Finalized smartstack',
+            extra_tags={
+                'smartstack_event': 'terminal',
+                'smartstack_status': status,
+                'smartstack_moluid': stack.moluid,
+                'smartstack_camera': stack.camera,
+                'smartstack_finalize_attempt': 1,
+            },
+        )
 
     def test_finalize_failure_leaves_stack_active(self):
         """A run_final error leaves the claimed stack active for retry."""
@@ -749,7 +776,9 @@ class TestFinalizeStack:
         stackframes = [_frame(1)]
         with patch('banzai.stacking.dbs') as mock_dbs, \
              patch('banzai.stacking.smartstack_products') as mock_products, \
-             patch('banzai.stacking.post_to_shipper_queue') as mock_publish:
+             patch('banzai.stacking.post_to_shipper_queue') as mock_publish, \
+             patch('banzai.stacking.logger') as mock_logger:
+            mock_dbs.claim_finalize_attempt.return_value = 2
             mock_products.run_final.side_effect = RuntimeError('stack blew up')
 
             finalize_stack(rc, stack, stackframes, 'complete')
@@ -757,6 +786,17 @@ class TestFinalizeStack:
         mock_dbs.claim_finalize_attempt.assert_called_once()
         mock_publish.assert_not_called()
         mock_dbs.mark_stack_terminal.assert_not_called()
+        mock_logger.error.assert_called_once_with(
+            'Failed to finalize smartstack',
+            exc_info=True,
+            extra_tags={
+                'smartstack_event': 'finalize_failed',
+                'smartstack_target_status': 'complete',
+                'smartstack_moluid': stack.moluid,
+                'smartstack_camera': stack.camera,
+                'smartstack_finalize_attempt': 2,
+            },
+        )
 
     def test_publish_failure_leaves_stack_active(self):
         """A publishing error leaves the stack active for retry."""
@@ -782,7 +822,8 @@ class TestFinalizeStack:
         stackframes = [_frame(1)]
         with patch('banzai.stacking.dbs') as mock_dbs, \
              patch('banzai.stacking.smartstack_products') as mock_products, \
-             patch('banzai.stacking.post_to_shipper_queue') as mock_publish:
+             patch('banzai.stacking.post_to_shipper_queue') as mock_publish, \
+             patch('banzai.stacking.logger') as mock_logger:
 
             finalize_stack(rc, stack, stackframes, 'complete')
 
@@ -790,6 +831,16 @@ class TestFinalizeStack:
         mock_dbs.claim_finalize_attempt.assert_not_called()
         mock_products.run_final.assert_not_called()
         mock_publish.assert_not_called()
+        mock_logger.error.assert_called_once_with(
+            'Smartstack exhausted finalize attempts; marking error',
+            extra_tags={
+                'smartstack_event': 'terminal',
+                'smartstack_status': 'error',
+                'smartstack_moluid': stack.moluid,
+                'smartstack_camera': stack.camera,
+                'smartstack_finalize_attempt': MAX_FINALIZE_ATTEMPTS,
+            },
+        )
 
 
 class TestStackTimedOut:

--- a/banzai/tests/test_smart_stacking.py
+++ b/banzai/tests/test_smart_stacking.py
@@ -590,44 +590,6 @@ class TestProcessStackframe:
         )
         redis_module.Redis.from_url.assert_not_called()
 
-    @pytest.mark.parametrize('stack_created, expect_created_log', [
-        (True, True),
-        (False, False),
-    ])
-    @patch('banzai.scheduling.logger')
-    @patch('banzai.scheduling.stage_utils.run_pipeline_stages')
-    def test_process_stackframe_logs_lifecycle_events(self, mock_run_stages, mock_logger, stack_created,
-                                                      expect_created_log, db_address, monkeypatch):
-        mock_run_stages.return_value = [self._make_mock_image()]
-        mock_upsert = MagicMock(return_value=stack_created)
-        monkeypatch.setattr(scheduling, 'upsert_stack_and_stackframe', mock_upsert, raising=False)
-
-        header = self._make_fits_header()
-        body = {'fits_file': '/path/to/frame.fits', 'last_frame': False}
-        runtime_context = {'db_address': db_address, 'REDIS_URL': 'redis://localhost:6379/0'}
-
-        with patch('banzai.scheduling.fits_utils.get_primary_header', return_value=header):
-            process_stackframe(body, runtime_context)
-
-        created_tags = {
-            'smartstack_event': 'created',
-            'smartstack_moluid': 'mol-xyz',
-            'smartstack_camera': 'cam1',
-            'smartstack_frmtotal': 5,
-        }
-        frame_tags = {
-            'smartstack_event': 'frame_reduced',
-            'smartstack_moluid': 'mol-xyz',
-            'smartstack_camera': 'cam1',
-            'smartstack_stack_num': 1,
-            'smartstack_filepath': '/data/processed/frame-e09.fits',
-        }
-        if expect_created_log:
-            mock_logger.info.assert_any_call('Smartstack created', extra_tags=created_tags)
-        else:
-            assert not any(call.args == ('Smartstack created',) for call in mock_logger.info.call_args_list)
-        mock_logger.info.assert_any_call('Reduced stackframe', extra_tags=frame_tags)
-
     @patch('banzai.scheduling.stage_utils.run_pipeline_stages')
     def test_process_stackframe_upserts_only_after_reduction(self, mock_run_stages, db_address, monkeypatch):
         mock_upsert = MagicMock()
@@ -731,17 +693,14 @@ def _frame(stack_num, is_last=False, filepath=None):
 
 class TestFinalizeStack:
 
-    @pytest.mark.parametrize('status', ['complete', 'timeout'])
-    def test_finalize_claims_before_work_and_logs_terminal(self, status):
+    def test_finalize_claims_before_work(self):
         """The attempt is claimed first, then run_final -> publish -> mark_terminal, in that order."""
         rc = _runtime_context()
         stack = _stack(finalize_attempts=0, next_attempt_at=None)
         stackframes = [_frame(1), _frame(2, is_last=True)]
         with patch('banzai.stacking.dbs') as mock_dbs, \
              patch('banzai.stacking.smartstack_products') as mock_products, \
-             patch('banzai.stacking.post_to_shipper_queue') as mock_publish, \
-             patch('banzai.stacking.logger') as mock_logger:
-            mock_dbs.claim_finalize_attempt.return_value = 1
+             patch('banzai.stacking.post_to_shipper_queue') as mock_publish:
             mock_products.run_final.return_value = ('/o/e45.fits', '/o/small.jpg', '/o/large.jpg')
             manager = MagicMock()
             manager.attach_mock(mock_dbs.claim_finalize_attempt, 'claim')
@@ -749,7 +708,7 @@ class TestFinalizeStack:
             manager.attach_mock(mock_publish, 'publish')
             manager.attach_mock(mock_dbs.mark_stack_terminal, 'mark_terminal')
 
-            finalize_stack(rc, stack, stackframes, status)
+            finalize_stack(rc, stack, stackframes, 'complete')
 
         assert [call[0] for call in manager.mock_calls] == ['claim', 'run_final', 'publish', 'mark_terminal']
         mock_dbs.claim_finalize_attempt.assert_called_once_with(rc.db_address, stack.moluid, FINALIZE_BACKOFF_SECONDS)
@@ -757,17 +716,7 @@ class TestFinalizeStack:
             rc.broker_url, rc.SHIPPER_EXCHANGE, rc.SHIPPER_QUEUE_NAME,
             fits_path='/o/e45.fits', small_thumbnail='/o/small.jpg', large_thumbnail='/o/large.jpg',
         )
-        mock_dbs.mark_stack_terminal.assert_called_once_with(rc.db_address, stack.moluid, status)
-        mock_logger.info.assert_called_once_with(
-            'Finalized smartstack',
-            extra_tags={
-                'smartstack_event': 'terminal',
-                'smartstack_status': status,
-                'smartstack_moluid': stack.moluid,
-                'smartstack_camera': stack.camera,
-                'smartstack_finalize_attempt': 1,
-            },
-        )
+        mock_dbs.mark_stack_terminal.assert_called_once_with(rc.db_address, stack.moluid, 'complete')
 
     def test_finalize_failure_leaves_stack_active(self):
         """A run_final error leaves the claimed stack active for retry."""
@@ -776,9 +725,7 @@ class TestFinalizeStack:
         stackframes = [_frame(1)]
         with patch('banzai.stacking.dbs') as mock_dbs, \
              patch('banzai.stacking.smartstack_products') as mock_products, \
-             patch('banzai.stacking.post_to_shipper_queue') as mock_publish, \
-             patch('banzai.stacking.logger') as mock_logger:
-            mock_dbs.claim_finalize_attempt.return_value = 2
+             patch('banzai.stacking.post_to_shipper_queue') as mock_publish:
             mock_products.run_final.side_effect = RuntimeError('stack blew up')
 
             finalize_stack(rc, stack, stackframes, 'complete')
@@ -786,17 +733,6 @@ class TestFinalizeStack:
         mock_dbs.claim_finalize_attempt.assert_called_once()
         mock_publish.assert_not_called()
         mock_dbs.mark_stack_terminal.assert_not_called()
-        mock_logger.error.assert_called_once_with(
-            'Failed to finalize smartstack',
-            exc_info=True,
-            extra_tags={
-                'smartstack_event': 'finalize_failed',
-                'smartstack_target_status': 'complete',
-                'smartstack_moluid': stack.moluid,
-                'smartstack_camera': stack.camera,
-                'smartstack_finalize_attempt': 2,
-            },
-        )
 
     def test_publish_failure_leaves_stack_active(self):
         """A publishing error leaves the stack active for retry."""
@@ -822,8 +758,7 @@ class TestFinalizeStack:
         stackframes = [_frame(1)]
         with patch('banzai.stacking.dbs') as mock_dbs, \
              patch('banzai.stacking.smartstack_products') as mock_products, \
-             patch('banzai.stacking.post_to_shipper_queue') as mock_publish, \
-             patch('banzai.stacking.logger') as mock_logger:
+             patch('banzai.stacking.post_to_shipper_queue') as mock_publish:
 
             finalize_stack(rc, stack, stackframes, 'complete')
 
@@ -831,16 +766,6 @@ class TestFinalizeStack:
         mock_dbs.claim_finalize_attempt.assert_not_called()
         mock_products.run_final.assert_not_called()
         mock_publish.assert_not_called()
-        mock_logger.error.assert_called_once_with(
-            'Smartstack exhausted finalize attempts; marking error',
-            extra_tags={
-                'smartstack_event': 'terminal',
-                'smartstack_status': 'error',
-                'smartstack_moluid': stack.moluid,
-                'smartstack_camera': stack.camera,
-                'smartstack_finalize_attempt': MAX_FINALIZE_ATTEMPTS,
-            },
-        )
 
 
 class TestStackTimedOut:

--- a/banzai/tests/test_smart_stacking.py
+++ b/banzai/tests/test_smart_stacking.py
@@ -590,6 +590,30 @@ class TestProcessStackframe:
         )
         redis_module.Redis.from_url.assert_not_called()
 
+    @pytest.mark.parametrize('stack_created, expect_created_log', [
+        (True, True),
+        (False, False),
+    ])
+    @patch('banzai.scheduling.logger')
+    @patch('banzai.scheduling.stage_utils.run_pipeline_stages')
+    def test_process_stackframe_logs_lifecycle_events(self, mock_run_stages, mock_logger, stack_created,
+                                                      expect_created_log, db_address, monkeypatch):
+        mock_run_stages.return_value = [self._make_mock_image()]
+        mock_upsert = MagicMock(return_value=stack_created)
+        monkeypatch.setattr(scheduling, 'upsert_stack_and_stackframe', mock_upsert, raising=False)
+
+        header = self._make_fits_header()
+        body = {'fits_file': '/path/to/frame.fits', 'last_frame': False}
+        runtime_context = {'db_address': db_address, 'REDIS_URL': 'redis://localhost:6379/0'}
+
+        with patch('banzai.scheduling.fits_utils.get_primary_header', return_value=header):
+            process_stackframe(body, runtime_context)
+
+        events = [call.kwargs.get('extra_tags', {}).get('smartstack_event')
+                  for call in mock_logger.info.call_args_list]
+        assert ('created' in events) is expect_created_log
+        assert 'frame_reduced' in events
+
     @patch('banzai.scheduling.stage_utils.run_pipeline_stages')
     def test_process_stackframe_upserts_only_after_reduction(self, mock_run_stages, db_address, monkeypatch):
         mock_upsert = MagicMock()

--- a/docker-compose-site.yml
+++ b/docker-compose-site.yml
@@ -62,12 +62,15 @@ services:
   banzai-stackframe-listener:
     build: .
     container_name: ${CONTAINER_PREFIX:-banzai-}stackframe-listener
+    labels:
+      gtn.lco.logstash: "yes"
     extra_hosts:
       - "host.docker.internal:host-gateway"
     depends_on:
       banzai-cache-init:
         condition: service_completed_successfully
     environment:
+      - TZ=UTC
       - DB_ADDRESS=${DB_ADDRESS}
       - CAL_DB_ADDRESS=${CAL_DB_ADDRESS:-${DB_ADDRESS}}
       - STACKFRAME_TASK_QUEUE_NAME=${STACKFRAME_TASK_QUEUE_NAME:-stackframe_reduction_task_queue}
@@ -84,6 +87,8 @@ services:
   banzai-stackframe-worker:
     build: .
     container_name: ${CONTAINER_PREFIX:-banzai-}stackframe-worker
+    labels:
+      gtn.lco.logstash: "yes"
     extra_hosts:
       - "host.docker.internal:host-gateway"
     depends_on:
@@ -94,6 +99,7 @@ services:
       - ${HOST_CALS_DIR}:${HOST_CALS_DIR}
       - ${HOST_REDUCED_DIR}:${HOST_REDUCED_DIR}
     environment:
+      - TZ=UTC
       - DB_ADDRESS=${DB_ADDRESS}
       - CAL_DB_ADDRESS=${CAL_DB_ADDRESS:-${DB_ADDRESS}}
       - TASK_HOST=${REDIS_URL}
@@ -115,6 +121,8 @@ services:
   banzai-stacking-supervisor:
     build: .
     container_name: ${CONTAINER_PREFIX:-banzai-}stacking-supervisor
+    labels:
+      gtn.lco.logstash: "yes"
     extra_hosts:
       - "host.docker.internal:host-gateway"
     depends_on:
@@ -123,6 +131,7 @@ services:
     volumes:
       - ${HOST_REDUCED_DIR}:${HOST_REDUCED_DIR}
     environment:
+      - TZ=UTC
       - DB_ADDRESS=${DB_ADDRESS}
       - STACK_QUEUE_NAME=${STACK_QUEUE_NAME:-banzai_stack_queue}
       - SHIPPER_EXCHANGE=${SHIPPER_EXCHANGE:-ship_files}


### PR DESCRIPTION
## Summary

This is PR 8 of 8 completing the v1 banzai implementation of Smartstacking at site.

PR1 (#469): combine math
PR2 (#470): JPEG utilities
PR3 (#471): DB updates   
PR4 (#473): shipper contract                     
PR5 (#474): smartstack data products
PR6 (#475): stack worker polling
PR7 (#476): e2e tests, compose cleanup   
PR8 (#477): logging  &emsp;&emsp;&emsp;&emsp;    <-- you are here

```text
PR1 combine math ───────┐
PR2 JPEG utilities ─────┤
PR3 DB updates ─────────┼──> PR5 data products --> PR6 stack workers --> PR7 E2E --> PR8 logs/docs
PR4 shipper contract ───┘
```
PRs 1–4 provide the independent foundations for combining images, rendering JPEGs, storing stack state, and shipper integration (this PR). PR5 builds the data products, this PR adds the polling worker, crash-only supervisor, and site deployment configuration. PR7 adds E2E and recovery proof; PR8 (this one) adds structured lifecycle telemetry.

## Structured lifecycle events

Smartstack logs now use a consistent `smartstack_*` namespace and can be grouped by `smartstack_moluid`:

| Event | Emitted when |
|---|---|
| `created` | The first accepted member creates the parent stack |
| `frame_reduced` | A reduced member is accepted |
| `finalize_failed` | Product generation or publication fails after an attempt is claimed |
| `terminal` | A stack reaches `complete`, `timeout`, or exhausted-attempt `error` |
| `frame_ignored` | A late member is rejected by a timeout tombstone |

Events include the relevant camera, stack number or filepath, lifecycle status, target status, and claimed attempt number. Successful previews remain debug-level messages rather than lifecycle events.

Unit tests pin the complete structured tag dictionaries for creation, accepted and ignored members, successful terminal transitions, failed attempts, and exhausted-attempt errors.

## Site log shipping

The three Smartstack services opt into the existing site log pipeline:

- `banzai-stackframe-listener`
- `banzai-stackframe-worker`
- `banzai-stacking-supervisor`

Each receives the `gtn.lco.logstash: "yes"` label and `TZ=UTC`. 
