### PR TITLE
Smartstack changelog and version bump

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,16 @@
 Versions
 ========
 
+1.38.0 (2026-08-25)
+-------------------
+
+- Initial complete site-side smartstacking capabilities to build and ship e45
+  preview jpgs, and final jpg/fits data products
+- Reworked smartstack database state and workers to support timeout
+  finalization, bounded retries, and restart recovery
+- Made the site deployment smartstack-only and added structured lifecycle
+  logging
+
 1.37.1 (2026-07-22)
 -------------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "lco-banzai"
 requires-python = ">=3.11,<4"
-version = "1.37.1"
+version = "1.38.0"
 description = "Python data reduction package for LCOGT data"
 
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.11, <4"
 resolution-markers = [
     "python_full_version >= '3.14' and sys_platform == 'win32'",
@@ -1176,7 +1176,7 @@ wheels = [
 
 [[package]]
 name = "lco-banzai"
-version = "1.37.1"
+version = "1.38.0"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
Banzai version bumped to 1.38.0 and added some notes in the changelog. I forgot to add these to the recent smartstack PRs that were just merged.