### PR TITLE
Process smartstack frames in AWS banzai (e45 --> e91)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,11 @@
 Versions
 ========
 
+1.38.2 (2026-09-02)
+-------------------
+
+- Support reduction of smartstacks (e45 -> e91) in AWS banzai
+
 1.38.1 (2026-08-25)
 -------------------
 

--- a/banzai/lco.py
+++ b/banzai/lco.py
@@ -1,5 +1,6 @@
 import datetime
 import os
+import re
 from fnmatch import fnmatch
 from typing import Optional
 
@@ -215,7 +216,9 @@ class LCOObservationFrame(ObservationFrame):
                 self.public_date = next_year
 
     def get_output_filename(self, runtime_context):
-        output_filename = self.filename.replace('00.fits', '{:02d}.fits'.format(int(runtime_context.reduction_level)))
+        reduction_level = f'{int(runtime_context.reduction_level):02d}'
+        # Regex: replace two digits only when they appear immediately before .fits or .fits.fz.
+        output_filename = re.sub(r'\d{2}(?=\.fits(?:\.fz)?$)', reduction_level, self.filename)
         if runtime_context.fpack and not output_filename.endswith('.fz'):
             output_filename += '.fz'
         if not runtime_context.fpack and output_filename.endswith('.fz'):

--- a/banzai/settings.py
+++ b/banzai/settings.py
@@ -38,6 +38,8 @@ ORDERED_STAGES = ['banzai.bpm.BadPixelMaskLoader',
                   'banzai.qc.pointing.PointingTest',
                   'banzai.photometry.PhotometricCalibrator']
 
+START_STAGE_BY_REDUCTION_LEVEL = {'45': 'banzai.photometry.SourceDetector'}
+
 CALIBRATION_MIN_FRAMES = {'BIAS': 5,
                           'DARK': 5,
                           'SKYFLAT': 5}

--- a/banzai/tests/test_frames.py
+++ b/banzai/tests/test_frames.py
@@ -202,12 +202,18 @@ def test_init_poisson_uncertainties():
     assert (test_data.uncertainty == 5 * np.ones(test_data.data.shape)).all()
 
 
-def test_get_output_filename():
-    test_frame = FakeLCOObservationFrame(file_path='test_image_n00.fits')
-    test_context = FakeContext(frame_class=FakeLCOObservationFrame, reduction_level='9')
+@pytest.mark.parametrize(('input_filename', 'fpack', 'reduction_level', 'expected_filename'), [
+    ('test_image_n00.fits', True, '9', 'test_image_n09.fits.fz'),
+    ('test_image_00.fits', True, '91', 'test_image_91.fits.fz'),
+    ('test_image-e45.fits', True, '91', 'test_image-e91.fits.fz'),
+    ('test_image-e45.fits.fz', False, '91', 'test_image-e91.fits'),
+])
+def test_get_output_filename(input_filename, fpack, reduction_level, expected_filename):
+    test_frame = FakeLCOObservationFrame(file_path=input_filename)
+    test_context = FakeContext(frame_class=FakeLCOObservationFrame, fpack=fpack, reduction_level=reduction_level)
     filename = test_frame.get_output_filename(test_context)
 
-    assert filename == 'test_image_n09.fits.fz'
+    assert filename == expected_filename
 
 
 def test_section_transformation():

--- a/banzai/tests/test_need_to_process_image.py
+++ b/banzai/tests/test_need_to_process_image.py
@@ -18,6 +18,46 @@ class FakeRealtimeImage(object):
         self.tries = tries
 
 
+@pytest.mark.parametrize('reduction_level, success, expected', [
+    pytest.param(0, False, True, id='raw'),
+    pytest.param(45, False, True, id='configured-nonzero'),
+    pytest.param(45, True, False, id='configured-successful-duplicate'),
+    pytest.param(91, False, False, id='unsupported-nonzero'),
+])
+@mock.patch('banzai.utils.realtime_utils.logger')
+@mock.patch('banzai.utils.image_utils.image_can_be_processed', return_value=True)
+@mock.patch('banzai.utils.realtime_utils.import_utils.import_attribute')
+@mock.patch('banzai.dbs.commit_processed_image')
+@mock.patch('banzai.dbs.get_processed_image')
+def test_archive_reduction_level_routing(mock_processed, mock_commit, mock_import, mock_can_process, mock_logger,
+                                         reduction_level, success, expected):
+    image = FakeRealtimeImage(success=success, checksum=md5_hash1)
+    mock_processed.return_value = image
+    test_image = mock.MagicMock(meta={'RLEVEL': reduction_level}, obstype='EXPOSE')
+    factory = mock.MagicMock()
+    factory.observation_frame_class.return_value = test_image
+    factory.get_instrument_from_header.return_value = mock.sentinel.instrument
+    mock_import.return_value.return_value = factory
+    context = FakeContext(
+        START_STAGE_BY_REDUCTION_LEVEL={'45': 'banzai.photometry.SourceDetector'},
+        delay_to_block_end=False,
+    )
+    file_info = {
+        'frameid': 42,
+        'filename': 'test.fits',
+        'version_set': [{'md5': md5_hash1}],
+        'RLEVEL': reduction_level,
+        'OBSTYPE': 'EXPOSE',
+    }
+
+    assert need_to_process_image(file_info, context, mock.MagicMock()) is expected
+    if reduction_level == 91:
+        mock_logger.error.assert_called_once_with(
+            'Image has unsupported reduction level. Aborting.',
+            extra_tags={'filename': 'test.fits', 'reduction_level': '91'},
+        )
+
+
 @mock.patch('banzai.utils.file_utils.get_md5')
 @mock.patch('banzai.dbs.get_processed_image')
 @mock.patch('banzai.utils.fits_utils.get_primary_header')

--- a/banzai/tests/test_stage_utils.py
+++ b/banzai/tests/test_stage_utils.py
@@ -1,0 +1,57 @@
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from banzai.utils import stage_utils
+
+
+@pytest.mark.parametrize('start_stage, last_stage, extra_stages, expected', [
+    (None, None, None, ['first', 'second', 'third']),
+    ('second', None, None, ['second', 'third']),
+    ('second', 'second', ['extra'], ['second', 'extra']),
+])
+def test_get_stages_for_individual_frame(start_stage, last_stage, extra_stages, expected):
+    assert stage_utils.get_stages_for_individual_frame(
+        ['first', 'second', 'third'],
+        start_stage=start_stage,
+        last_stage=last_stage,
+        extra_stages=extra_stages,
+    ) == expected
+
+
+@pytest.mark.parametrize('reduction_level, expected_stages', [
+    (0, ['first', 'source-detector', 'last']),
+    (45, ['source-detector', 'last']),
+])
+def test_run_pipeline_stages_uses_start_stage_for_reduction_level(monkeypatch, reduction_level, expected_stages):
+    image = MagicMock(meta={'RLEVEL': reduction_level}, obstype='EXPOSE')
+    frame_factory = MagicMock()
+    frame_factory.open.return_value = image
+    stages_run = []
+
+    def import_attribute(attribute):
+        if attribute == 'frame-factory':
+            return MagicMock(return_value=frame_factory)
+
+        def stage_constructor(runtime_context):
+            stage = MagicMock()
+            stage.run.side_effect = lambda images: images
+            stages_run.append(attribute)
+            return stage
+
+        return stage_constructor
+
+    monkeypatch.setattr(stage_utils.import_utils, 'import_attribute', import_attribute)
+    runtime_context = SimpleNamespace(
+        FRAME_FACTORY='frame-factory',
+        ORDERED_STAGES=['first', 'source-detector', 'last'],
+        START_STAGE_BY_REDUCTION_LEVEL={'45': 'source-detector'},
+        LAST_STAGE={'EXPOSE': None},
+        EXTRA_STAGES={'EXPOSE': None},
+    )
+
+    stage_utils.run_pipeline_stages([{'path': 'test.fits'}], runtime_context)
+
+    assert stages_run == expected_stages
+    image.write.assert_called_once_with(runtime_context)

--- a/banzai/utils/realtime_utils.py
+++ b/banzai/utils/realtime_utils.py
@@ -99,8 +99,14 @@ def need_to_process_image(file_info, context, task):
             except Exception:
                 logger.error(f'Issue getting instrument from header. {logs.format_exception()}', extra_tags={'filename': filename})
                 need_to_process = False
-            if image_utils.get_reduction_level(test_image.meta) != '00':
-                logger.error('Image has nonzero reduction level. Aborting.', extra_tags={'filename': filename})
+            reduction_level = image_utils.get_reduction_level(test_image.meta)
+            is_supported_reduction_level = (
+                reduction_level == '00'
+                or reduction_level in context.START_STAGE_BY_REDUCTION_LEVEL
+            )
+            if not is_supported_reduction_level:
+                logger.error('Image has unsupported reduction level. Aborting.',
+                             extra_tags={'filename': filename, 'reduction_level': reduction_level})
                 need_to_process = False
             elif test_image.instrument is None:
                 logger.error('This queue message has an instrument that is not currently in the DB. Aborting:',

--- a/banzai/utils/stage_utils.py
+++ b/banzai/utils/stage_utils.py
@@ -1,4 +1,4 @@
-from banzai.utils import import_utils
+from banzai.utils import image_utils, import_utils
 from banzai.context import Context
 from banzai.logs import get_logger
 from banzai.metrics import trace_function
@@ -6,12 +6,14 @@ from banzai.metrics import trace_function
 logger = get_logger()
 
 
-def get_stages_for_individual_frame(ordered_stages, last_stage=None, extra_stages=None):
+def get_stages_for_individual_frame(ordered_stages, start_stage=None, last_stage=None, extra_stages=None):
     """
 
     Parameters
     ----------
     ordered_stages: list of banzai.stages.Stage objects
+    start_stage: banzai.stages.Stage
+                 First stage to do
     last_stage: banzai.stages.Stage
                 Last stage to do
     extra_stages: Stages to do after the last stage
@@ -28,12 +30,17 @@ def get_stages_for_individual_frame(ordered_stages, last_stage=None, extra_stage
     if extra_stages is None:
         extra_stages = []
 
+    if start_stage is None:
+        start_index = 0
+    else:
+        start_index = ordered_stages.index(start_stage)
+
     if last_stage is None:
         last_index = None
     else:
         last_index = ordered_stages.index(last_stage) + 1
 
-    stages_todo = [stage for stage in ordered_stages[:last_index]]
+    stages_todo = [stage for stage in ordered_stages[start_index:last_index]]
     stages_todo += [stage for stage in extra_stages]
 
     return stages_todo
@@ -49,7 +56,10 @@ def run_pipeline_stages(image_paths: list, runtime_context: Context, calibration
     if calibration_maker:
         stages_to_do = runtime_context.CALIBRATION_STACKER_STAGES[images[0].obstype.upper()]
     else:
+        reduction_level = image_utils.get_reduction_level(images[0].meta)
+        start_stage = runtime_context.START_STAGE_BY_REDUCTION_LEVEL.get(reduction_level)
         stages_to_do = get_stages_for_individual_frame(runtime_context.ORDERED_STAGES,
+                                                       start_stage=start_stage,
                                                        last_stage=runtime_context.LAST_STAGE[images[0].obstype.upper()],
                                                        extra_stages=runtime_context.EXTRA_STAGES[images[0].obstype.upper()])
 

--- a/docs/smartstacking_architecture.md
+++ b/docs/smartstacking_architecture.md
@@ -19,13 +19,14 @@ Also worth noting: the preview frames are visually stretched, lower-resolution j
 
 _____
 
-This page describes the Smartstack path in `docker-compose-site.yml`. The program that sends raw frames, the shipper, and the archive are outside this repository. The site deployment does not run the normal realtime `e91` path.
+This page describes the Smartstack path in `docker-compose-site.yml`. The program that sends raw frames, the shipper, and the archive are outside this repository. The site deployment does not run the normal realtime `e91` path; central BANZAI performs that tail reduction after the final `e45` reaches the archive.
 
 The reduction level suffixes used:
 
 - `n00` is a raw stackframe with obstype=SUB_EXP.
 - `n09` is a reduced stackframe, following BANZAI's default ordered reduction steps.
 - `e45` is the combined Smartstack product, with obstype=EXPOSE.
+- `e91` is the archive-facing product after central BANZAI runs the configured tail stages on the `e45`.
 
 ## Full smartstack process:
 
@@ -37,6 +38,8 @@ flowchart LR
     DB[("PostgreSQL<br/>n09 paths and stack progress")]
     Stacker["Stack worker<br/>rebuild preview or final"]
     Shipper["Shipper<br/>(outside this repository)"]
+    Archive["Science Archive<br/>(outside this repository)"]
+    Central["Central BANZAI<br/>tail reduction"]
     Files[("Shared files<br/>n00, n09, e45, and JPEGs")]
 
     Site -->|"raw path over RabbitMQ"| Listener
@@ -49,6 +52,9 @@ flowchart LR
     Reducer <-->|"read n00 and write n09"| Files
     Stacker <-->|"read n09 and write products"| Files
     Shipper -->|"open products"| Files
+    Shipper -->|"upload final e45"| Archive
+    Archive -->|"archived e45 event"| Central
+    Central -->|"write e91"| Archive
 ```
 
 1. Site software writes a raw `n00` FITS file and sends its absolute path to RabbitMQ `banzai_stack_queue`.
@@ -57,6 +63,8 @@ flowchart LR
 4. After that succeeds, the worker saves the `n09` path and stack information in PostgreSQL.
 5. A stacking process checks PostgreSQL about every five seconds. It opens the `n09` files and makes a preview or final product when needed.
 6. BANZAI sends the product paths through RabbitMQ to the shipper.
+7. The shipper uploads the final site-produced `e45` to the archive.
+8. Central BANZAI receives the archived `e45`, runs the configured tail stages, and writes a distinct `e91` product.
 
 ### Local calibration cache
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "lco-banzai"
 requires-python = ">=3.11,<4"
-version = "1.38.1"
+version = "1.38.2"
 description = "Python data reduction package for LCOGT data"
 
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -1176,7 +1176,7 @@ wheels = [
 
 [[package]]
 name = "lco-banzai"
-version = "1.38.1"
+version = "1.38.2"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
This change configures banzai to process the smartstack fits files (e45) that are sent to the archive, producing a final e91 as output. 

To recap the current smartstack process:
- site banzai: receives n00 (raw stackframes)
- site banzai: reduce the n00 frames to produce n09 stackframes (using the same complete reduction stages as EXPOSE frames)
- site banzai: stack the n09 frames into one e45, and send to the archive
- AWS banzai: receives the e45 and do another reduction pass to create an e91 frame

The stages run on the e45 frame are:
- SourceDetector
- WCSSolver
- PointingTest
- PhotometricCalibrator

This PR also includes a version bump from 1.38.1 to 1.38.2.